### PR TITLE
Expand type coercion and allow for default values to be specified for util functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -6,6 +6,7 @@ describe("util", () => {
     .base64String()
     .map((v) => Buffer.from(v, "base64"));
   const uint8ArrayArbitrary = bufferArbitrary.map((b) => new Uint8Array(b));
+  const unknowns = (): fc.Arbitrary<unknown> => fc.constantFrom(undefined);
 
   describe("boolean", () => {
     type TruthyValue = true | "true" | "t" | "T" | "yes" | "y" | "Y";
@@ -81,6 +82,30 @@ describe("util", () => {
         )
       );
     });
+
+    it("allows for boolean default to true for undefined inputs and undefined default", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toBool(v)).toStrictEqual(true)
+        )
+      );
+    });
+
+    it("allows for boolean default of false for undefined inputs", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toBool(v, false)).toStrictEqual(false)
+        )
+      );
+    });
+
+    it("allows for boolean default of true for undefined inputs", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toBool(v, true)).toStrictEqual(true)
+        )
+      );
+    });
   });
 
   describe("integer", () => {
@@ -116,6 +141,22 @@ describe("util", () => {
       fc.assert(
         fc.property(invalidValues, (v) =>
           expect(() => util.types.toInt(v)).toThrow("cannot be coerced to int")
+        )
+      );
+    });
+
+    it("Allows for default value of 0 when value is undefined", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toInt(v)).toStrictEqual(0)
+        )
+      );
+    });
+
+    it("Allows for default values when value is undefined", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toInt(v, 20)).toStrictEqual(20)
         )
       );
     });
@@ -288,6 +329,34 @@ describe("util", () => {
             contentType: "application/octet-stream",
           })
         )
+      );
+    });
+  });
+
+  describe("string", () => {
+    it("coerces plain text buffer to string", () => {
+      fc.assert(
+        fc.property(bufferArbitrary, (v) => {
+          expect(util.types.toString(v)).toStrictEqual(v.toString());
+        })
+      );
+    });
+
+    it("coerces unknown value to empty string", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) => {
+          expect(util.types.toString(v)).toStrictEqual("");
+        })
+      );
+    });
+
+    it("coerces unknown value to given default string", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) => {
+          expect(util.types.toString(v, "hello, world")).toStrictEqual(
+            "hello, world"
+          );
+        })
       );
     });
   });

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -83,10 +83,10 @@ describe("util", () => {
       );
     });
 
-    it("allows for boolean default to true for undefined inputs and undefined default", () => {
+    it("allows for boolean default to false for undefined inputs and undefined default", () => {
       fc.assert(
         fc.property(unknowns(), (v) =>
-          expect(util.types.toBool(v)).toStrictEqual(true)
+          expect(util.types.toBool(v)).toStrictEqual(false)
         )
       );
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,10 +23,7 @@ const toBool = (value: unknown, defaultValue?: boolean) => {
   }
 
   if (typeof value === "undefined") {
-    if (typeof defaultValue === "undefined") {
-      return true;
-    }
-    return defaultValue;
+    return Boolean(defaultValue);
   }
 
   throw new Error(`Value '${value}' cannot be coerced to bool.`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ import { ConditionalExpression, TermOperatorPhrase } from "./types";
 const isBool = (value: unknown): value is boolean =>
   value === true || value === false;
 
-const toBool = (value: unknown) => {
+const toBool = (value: unknown, defaultValue?: boolean) => {
   if (isBool(value)) {
     return value;
   }
@@ -22,12 +22,19 @@ const toBool = (value: unknown) => {
     }
   }
 
+  if (typeof value === "undefined") {
+    if (typeof defaultValue === "undefined") {
+      return true;
+    }
+    return defaultValue;
+  }
+
   throw new Error(`Value '${value}' cannot be coerced to bool.`);
 };
 
 const isInt = (value: unknown): value is number => Number.isInteger(value);
 
-const toInt = (value: unknown) => {
+const toInt = (value: unknown, defaultValue?: number) => {
   if (isInt(value)) return value;
 
   if (typeof value === "string") {
@@ -35,6 +42,10 @@ const toInt = (value: unknown) => {
     if (!Number.isNaN(intValue)) {
       return intValue;
     }
+  }
+
+  if (typeof value === "undefined") {
+    return defaultValue || 0;
   }
 
   throw new Error(`Value '${value}' cannot be coerced to int.`);
@@ -143,6 +154,22 @@ const toData = (value: unknown): DataPayload => {
 const formatJsonExample = (input: unknown) =>
   ["```json", JSON.stringify(input, undefined, 2), "```"].join("\n");
 
+const toString = (value: unknown, defaultValue?: string): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "undefined" || value === null) {
+    return defaultValue || "";
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return value.toString();
+  }
+
+  throw new Error(`Value '${value}' cannot be converted to a String.`);
+};
+
 export default {
   types: {
     isBool,
@@ -156,6 +183,7 @@ export default {
     isConditionalExpression,
     isUrl,
     toData,
+    toString,
   },
   docs: {
     formatJsonExample,


### PR DESCRIPTION
Would this do the trick to allow component authors to handle `unknown` inputs better?