### PR TITLE
Remove key property from action()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from "./server-types";
 
 const convertAction = (
+  actionKey: string,
   action: ActionDefinition<
     Inputs,
     boolean,
@@ -29,6 +30,7 @@ const convertAction = (
 
   return {
     ...action,
+    key: actionKey,
     inputs: inputDefinitions,
     perform: action.perform as ActionDefinitionV1["perform"],
     examplePayload: action.examplePayload as
@@ -49,7 +51,7 @@ export const component = (
   actions: Object.fromEntries(
     Object.entries(definition.actions).map(([actionKey, action]) => [
       actionKey,
-      convertAction(action),
+      convertAction(actionKey, action),
     ])
   ),
 });

--- a/src/types/ActionDefinition.ts
+++ b/src/types/ActionDefinition.ts
@@ -11,8 +11,6 @@ export interface ActionDefinition<
   AllowsBranching extends boolean,
   ReturnData extends PerformReturn<AllowsBranching, unknown>
 > {
-  /** Key used for the Actions map and to uniquely identify this Component in your tenant. */
-  key: string;
   /** Defines how the Action is displayed in the Prismatic interface. */
   display: ActionDisplayDefinition;
   /** Function to perform when this Action is used and invoked. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,11 +3,7 @@ import dateIsValid from "date-fns/isValid";
 import dateIsDate from "date-fns/isDate";
 import { isWebUri } from "valid-url";
 import { DataPayload } from "./server-types";
-import {
-  ConditionalExpression,
-  TermOperatorPhrase,
-  KeyValuePair,
-} from "./types";
+import { KeyValuePair } from "./types";
 
 const isBool = (value: unknown): value is boolean =>
   value === true || value === false;


### PR DESCRIPTION
Define an action key once: in the `actions:` parameter of `component()`.

This removes the need to include the action key as a parameter of `action()`, which could cause problems as the key in `component({actions: {}})` might not match the key defined in `action({key: ""})`. Remove redundancy and make things less error-prone.

I tested this with a component that had a few actions; the component compiles the way it used to without the `key` property of `action()`.