### PR TITLE
Account for empty strings in toBool() and toInt()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -74,16 +74,6 @@ describe("util", () => {
       );
     });
 
-    it("throws when coercing non-boolean values", () => {
-      fc.assert(
-        fc.property(invalidValues, (v) =>
-          expect(() => util.types.toBool(v)).toThrow(
-            "cannot be coerced to bool"
-          )
-        )
-      );
-    });
-
     it("allows for boolean default to false for undefined inputs and undefined default", () => {
       fc.assert(
         fc.property(unknowns(), (v) =>

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -152,6 +152,14 @@ describe("util", () => {
       );
     });
 
+    it("coerces a float to an int", () => {
+      fc.assert(
+        fc.property(fc.float(), (v) =>
+          expect(util.types.toInt(v)).toStrictEqual(~~v)
+        )
+      );
+    });
+
     it("throws when coercing non-integer values", () => {
       fc.assert(
         fc.property(invalidValues, (v) =>
@@ -188,6 +196,61 @@ describe("util", () => {
       fc.assert(
         fc.property(emptyStrings(), (v) =>
           expect(util.types.toInt(v, 20)).toStrictEqual(20)
+        )
+      );
+    });
+  });
+
+  describe("number", () => {
+    const validValues = fc.string().filter((v) => !Number.isNaN(Number(v)));
+    const invalidValues = fc.string().filter((v) => Number.isNaN(Number(v)));
+
+    it("detects things that can be cast to a number", () => {
+      fc.assert(
+        fc.property(validValues, (v) =>
+          expect(util.types.isNumber(v)).toStrictEqual(true)
+        )
+      );
+    });
+
+    it("detects things that cannot be cast to a number", () => {
+      fc.assert(
+        fc.property(invalidValues, (v) =>
+          expect(util.types.isNumber(v)).toStrictEqual(false)
+        )
+      );
+    });
+
+    it("returns a number when given a number", () => {
+      fc.assert(
+        fc.property(fc.float(), (v) =>
+          expect(util.types.toNumber(v)).toStrictEqual(v)
+        )
+      );
+    });
+
+    it("returns a number when given something that can be cast to number", () => {
+      fc.assert(
+        fc.property(validValues, (v) =>
+          expect(util.types.toNumber(v)).toStrictEqual(Number(v))
+        )
+      );
+    });
+
+    it("throws when coercing non-number values", () => {
+      fc.assert(
+        fc.property(invalidValues, (v) =>
+          expect(() => util.types.toNumber(v)).toThrow(
+            "cannot be coerced to a number"
+          )
+        )
+      );
+    });
+
+    it("returns the default value when a value is missing", () => {
+      fc.assert(
+        fc.property(unknowns(), (v) =>
+          expect(util.types.toNumber(v, 5.5)).toStrictEqual(5.5)
         )
       );
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,11 +22,7 @@ const toBool = (value: unknown, defaultValue?: boolean) => {
     }
   }
 
-  if (typeof value === "undefined" || value === "") {
-    return Boolean(defaultValue);
-  }
-
-  throw new Error(`Value '${value}' cannot be coerced to bool.`);
+  return Boolean(value || defaultValue);
 };
 
 const isInt = (value: unknown): value is number => Number.isInteger(value);

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,7 @@ const toBool = (value: unknown, defaultValue?: boolean) => {
     }
   }
 
-  if (typeof value === "undefined") {
+  if (typeof value === "undefined" || value === "") {
     return Boolean(defaultValue);
   }
 
@@ -41,7 +41,7 @@ const toInt = (value: unknown, defaultValue?: number) => {
     }
   }
 
-  if (typeof value === "undefined") {
+  if (typeof value === "undefined" || value === "") {
     return defaultValue || 0;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,11 @@ const isInt = (value: unknown): value is number => Number.isInteger(value);
 const toInt = (value: unknown, defaultValue?: number) => {
   if (isInt(value)) return value;
 
+  // Turn a float into an int
+  if (typeof value === "number") {
+    return ~~value;
+  }
+
   if (typeof value === "string") {
     const intValue = Number.parseInt(value);
     if (!Number.isNaN(intValue)) {
@@ -42,6 +47,20 @@ const toInt = (value: unknown, defaultValue?: number) => {
   }
 
   throw new Error(`Value '${value}' cannot be coerced to int.`);
+};
+
+const isNumber = (value: unknown) => !Number.isNaN(Number(value));
+
+const toNumber = (value: unknown, defaultValue?: number) => {
+  if (isNumber(value)) {
+    return Number(value);
+  }
+
+  if (typeof value === "undefined" || value === "") {
+    return defaultValue || 0;
+  }
+
+  throw new Error(`Value '${value}' cannot be coerced to a number.`);
 };
 
 const isBigInt = (value: unknown): value is bigint => typeof value === "bigint";
@@ -135,6 +154,8 @@ export default {
     toBool,
     isInt,
     toInt,
+    isNumber,
+    toNumber,
     isBigInt,
     toBigInt,
     isDate,


### PR DESCRIPTION
Reasoning: `Boolean('') === false`, so `toBool('')` should probably also return `false` (rather than its current behavior of throwing an error.

For `toInt()`, I'd expect empty string to behave the same as `undefined`.