### PR TITLE
Deprecate component version key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,9 @@ lib/
 docs/
 sidebars.js
 sidebars.jse
+
+# Build artifacts
+package/
+
+# Cache files
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export const component = (
     >;
   }
 ): Component => ({
+  version: "placeholder", // Placeholder until we deprecate version in component definitions
   ...definition,
   actions: Object.fromEntries(
     Object.entries(definition.actions).map(([actionKey, action]) => [

--- a/src/types/server-types.ts
+++ b/src/types/server-types.ts
@@ -26,8 +26,8 @@ export interface Component {
   public?: boolean;
   /** Defines how the Component is displayed in the Prismatic interface. */
   display: ComponentDisplayDefinition;
-  /** Version of the Component. */
-  version: string;
+  /** @deprecated Version of the Component. */
+  version?: string;
   /** Specifies Authorization settings, if applicable */
   authorization?: AuthorizationDefinition;
   /** Specifies the supported Actions of this Component. */


### PR DESCRIPTION
Component versioning is now handled by the platform, so the component `version:` key doesn't do anything.  This deprecates the key, and we can remove it entirely once the Prismatic backend schema validator stops expecting the `version` key.