### PR TITLE
Move authorization config from component to action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/types/ActionDefinition.ts
+++ b/src/types/ActionDefinition.ts
@@ -2,6 +2,7 @@ import {
   PerformReturn,
   ActionDisplayDefinition,
   ActionPerformFunction,
+  AuthorizationDefinition,
   Inputs,
 } from ".";
 
@@ -20,6 +21,8 @@ export interface ActionDefinition<
   perform: ActionPerformFunction<T, AllowsBranching, ReturnData>;
   /** InputFields to present in the Prismatic interface for configuration of this Action. */
   inputs: T;
+  /** Specifies Authorization settings, if applicable */
+  authorization?: AuthorizationDefinition;
   /** Optional attribute that specifies whether an Action will terminate execution.*/
   terminateExecution?: boolean;
   /** Determines whether an Action will allow Conditional Branching.*/

--- a/src/types/server-types.ts
+++ b/src/types/server-types.ts
@@ -29,8 +29,6 @@ interface ComponentBase<T extends boolean> {
   display: ComponentDisplayDefinition<T>;
   /** @deprecated Version of the Component. */
   version?: string;
-  /** Specifies Authorization settings, if applicable */
-  authorization?: AuthorizationDefinition;
   /** Specifies the supported Actions of this Component. */
   actions: Record<string, Action>;
 }
@@ -56,6 +54,8 @@ export interface Action {
   perform: ActionPerformFunction;
   /** InputFields to present in the Prismatic interface for configuration of this Action. */
   inputs: InputField[];
+  /** Specifies Authorization settings, if applicable */
+  authorization?: AuthorizationDefinition;
   /** Optional attribute that specifies whether an Action will terminate execution.*/
   terminateExecution?: boolean;
   /** Determines whether an Action will allow Conditional Branching.*/


### PR DESCRIPTION
This removes the component level authorization block in favor of adding it to each action to allow each to specify their own configuration. This includes a major version bump since this completely removes the component authorization block.