### PR TITLE
Export some useful non-templated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,3 +19,4 @@ export * from "./TriggerPerformFunction";
 export * from "./TriggerDefinition";
 export * from "./HttpResponse";
 export * from "./TriggerPayload";
+export * as serverTypes from "./server-types";

--- a/src/types/server-types.ts
+++ b/src/types/server-types.ts
@@ -138,7 +138,7 @@ interface ServerPerformBranchingDataReturn extends ServerPerformDataReturn {
 }
 
 /** Required return type of all action perform functions */
-type ActionPerformReturn =
+export type ActionPerformReturn =
   | ServerPerformDataStructureReturn
   | ServerPerformBranchingDataStructureReturn
   | ServerPerformDataReturn
@@ -146,21 +146,21 @@ type ActionPerformReturn =
   | void; // Allow an action to return nothing to reduce component implementation boilerplate
 
 /** Definition of the function to perform when an Action is invoked. */
-type ActionPerformFunction = (
+export type ActionPerformFunction = (
   context: ActionContext,
   params: ActionInputParameters
 ) => Promise<ActionPerformReturn>;
 
-type TriggerResult = TriggerBranchingResult | TriggerBaseResult | void; // Allow a trigger to return nothing to reduce component implementation boilerplate
+export type TriggerResult = TriggerBranchingResult | TriggerBaseResult | void; // Allow a trigger to return nothing to reduce component implementation boilerplate
 
 /** Definition of the function to perform when a Trigger is invoked. */
-type TriggerPerformFunction = (
+export type TriggerPerformFunction = (
   context: ActionContext,
   payload: TriggerPayload,
   params: ActionInputParameters
 ) => Promise<TriggerResult>;
 
-type InputField = DefaultInputField | CodeInputField;
+export type InputField = DefaultInputField | CodeInputField;
 
 /** Defines attributes of a InputField. */
 interface DefaultInputField {
@@ -192,7 +192,7 @@ interface CodeInputField extends DefaultInputField {
 }
 
 /** InputField type enumeration. */
-type InputFieldType =
+export type InputFieldType =
   | "string"
   | "text"
   | "password"


### PR DESCRIPTION
Not sure if this is the best way to export these or not. We want to avoid collisions with existing templated types, which are named the same thing. So this ends up getting used like:
```
import { serverTypes } from "@prismatic-io/spectral";
...
const foo: serverTypes.InputFieldType = "string"; // contrived example
```

Is that what we want?