### PR TITLE
Add webhook API keys to trigger payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -199,6 +199,9 @@ export const defaultTriggerPayload = (): TriggerPayload => {
     webhookUrls: {
       "Flow 1": "https://example.com",
     },
+    webhookApiKeys: {
+      "Flow 1": "example-123",
+    },
     customer: {
       name: "Customer 1",
       externalId: "1234",

--- a/src/types/TriggerPayload.ts
+++ b/src/types/TriggerPayload.ts
@@ -14,7 +14,12 @@ export interface TriggerPayload {
     data: unknown;
     contentType?: string;
   };
+  /** The webhook URLs assigned to this integration's flows upon instance deploy */
   webhookUrls: {
+    [key: string]: string;
+  };
+  /** The optional API keys assigned to the flows of this integration. These may be unique per integration instance and per flow. */
+  webhookApiKeys: {
     [key: string]: string;
   };
   customer: {


### PR DESCRIPTION
This will allow integration builders to reference a flow's API key by referencing the output of a trigger (similar to how you can reference a webhookUrl).