### PR TITLE
A flow can have multiple API keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -200,7 +200,7 @@ export const defaultTriggerPayload = (): TriggerPayload => {
       "Flow 1": "https://example.com",
     },
     webhookApiKeys: {
-      "Flow 1": "example-123",
+      "Flow 1": ["example-123", "example-456"],
     },
     customer: {
       name: "Customer 1",

--- a/src/types/TriggerPayload.ts
+++ b/src/types/TriggerPayload.ts
@@ -20,7 +20,7 @@ export interface TriggerPayload {
   };
   /** The optional API keys assigned to the flows of this integration. These may be unique per integration instance and per flow. */
   webhookApiKeys: {
-    [key: string]: string;
+    [key: string]: string[];
   };
   customer: {
     externalId: string | null;


### PR DESCRIPTION
webhookApiKeys should allow for `string[]` instead of just `string`.