### PR TITLE
Add reasonable defaults for primitive fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   TriggerBaseResult,
   TriggerBranchingResult,
   TriggerResult,
+  InputFieldDefaultMap,
 } from "./types";
 import {
   Action,
@@ -36,9 +37,11 @@ import {
 
 const convertInput = (
   key: string,
-  input: InputFieldDefinition
+  { default: defaultValue, type, ...rest }: InputFieldDefinition
 ): InputField => ({
-  ...input,
+  ...rest,
+  type,
+  default: defaultValue ?? InputFieldDefaultMap[type],
   key,
 });
 

--- a/src/types/InputFieldType.ts
+++ b/src/types/InputFieldType.ts
@@ -14,3 +14,15 @@ export type InputFieldTypeMap = {
   conditional: ConditionalExpression;
   connection: Connection;
 };
+
+export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> =
+  {
+    string: "",
+    data: "",
+    text: "",
+    password: "",
+    boolean: "false",
+    code: "",
+    conditional: undefined,
+    connection: undefined,
+  };

--- a/src/types/Inputs.ts
+++ b/src/types/Inputs.ts
@@ -1,4 +1,4 @@
-import { InputFieldType } from ".";
+import { InputFieldDefaultMap, InputFieldType } from ".";
 
 export type Inputs = Record<string, InputFieldDefinition>;
 export type ConnectionInput = DefaultInputFieldDefinition & { shown?: boolean };
@@ -10,6 +10,8 @@ export type InputFieldDefinition =
   | ConnectionInputField;
 
 interface BaseInputFieldDefinition {
+  /** Data type the InputField will collect. */
+  type: InputFieldType;
   /** Interface label of the InputField. */
   label: string;
   /** Collection type of the InputField */
@@ -17,7 +19,7 @@ interface BaseInputFieldDefinition {
   /** Text to show as the InputField placeholder. */
   placeholder?: string;
   /** Default value for this field. */
-  default?: string;
+  default?: typeof InputFieldDefaultMap[this["type"]];
   /** Additional text to give guidance to the user configuring the InputField. */
   comments?: string;
   /** Example valid input for this InputField. */

--- a/src/types/server-types.ts
+++ b/src/types/server-types.ts
@@ -6,7 +6,7 @@
  */
 
 /** Import shared types from types/ */
-import { OAuth2Type } from ".";
+import { OAuth2Type, InputFieldType, InputFieldDefaultMap } from ".";
 import { ActionContext } from "./ActionPerformFunction";
 import {
   ActionDisplayDefinition,
@@ -192,7 +192,7 @@ interface DefaultInputField {
   /** Text to show as the InputField placeholder. */
   placeholder?: string;
   /** Default value for this field. */
-  default?: string;
+  default?: typeof InputFieldDefaultMap[this["type"]];
   /** Additional text to give guidance to the user configuring the InputField. */
   comments?: string;
   /** Example valid input for this InputField. */
@@ -207,17 +207,6 @@ interface CodeInputField extends DefaultInputField {
   type: "code";
   language?: string;
 }
-
-/** InputField type enumeration. */
-export type InputFieldType =
-  | "string"
-  | "text"
-  | "password"
-  | "boolean"
-  | "code"
-  | "data"
-  | "conditional"
-  | "connection";
 
 /** Binary data payload */
 export interface DataPayload {


### PR DESCRIPTION
Conditional and Connection will require more elaborate defaulting - those
will work as before. The rest have reasonable defaults to be used in the
event the component author left it unspecified.