### PR TITLE
Add explicit publishConfig package.json sections

### DIFF
--- a/packages/eslint-config-spectral/package.json
+++ b/packages/eslint-config-spectral/package.json
@@ -16,6 +16,10 @@
     "type": "git",
     "url": "https://github.com/prismatic-io/spectral.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf dist",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -15,6 +15,10 @@
     "type": "git",
     "url": "https://github.com/prismatic-io/spectral.git"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
`yarn publish` assumes scoped packages are private unless they already
exist. Adding this section explicitly states that they are indeed scoped and
intended to be public in the NPM registry.