### PR TITLE
Add component testing harness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,3 +23,7 @@ jobs:
         uses: borales/actions-yarn@v2.3.0
         with:
           cmd: turbo run test
+      - name: Run Type Tests
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: turbo run tsd

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/serverTypes/convert.ts
+++ b/packages/spectral/src/serverTypes/convert.ts
@@ -89,7 +89,7 @@ const convertConnection = (
   ),
 });
 
-export const convertComponent = <TPublic extends boolean = false>({
+export const convertComponent = <TPublic extends boolean>({
   connections = [],
   actions = {},
   triggers = {},

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -3,7 +3,7 @@ interface DisplayDefinition {
   description: string;
 }
 
-interface Component {
+export interface Component {
   key: string;
   public?: boolean;
   documentationUrl?: string;
@@ -13,7 +13,7 @@ interface Component {
   connections: Connection[];
 }
 
-interface Action {
+export interface Action {
   key: string;
   display: DisplayDefinition & { directions?: string; important?: boolean };
   inputs: Input[];
@@ -26,9 +26,9 @@ interface Action {
   examplePayload?: unknown;
 }
 
-type ActionLoggerFunction = (...args: unknown[]) => void;
+export type ActionLoggerFunction = (...args: unknown[]) => void;
 
-interface ActionLogger {
+export interface ActionLogger {
   metric: ActionLoggerFunction;
   trace: ActionLoggerFunction;
   debug: ActionLoggerFunction;
@@ -38,7 +38,7 @@ interface ActionLogger {
   error: ActionLoggerFunction;
 }
 
-interface ActionContext {
+export interface ActionContext {
   logger: ActionLogger;
   instanceState: Record<string, unknown>;
   crossFlowState: Record<string, unknown>;
@@ -49,7 +49,7 @@ interface ActionContext {
 
 type TriggerOptionChoice = "invalid" | "valid" | "required";
 
-interface TriggerPayload {
+export interface TriggerPayload {
   headers: Record<string, string>;
   queryParameters: Record<string, string>;
   rawBody: {
@@ -94,15 +94,18 @@ interface TriggerBranchingResult extends TriggerBaseResult {
   branch: string;
 }
 
-type TriggerResult = TriggerBranchingResult | TriggerBaseResult | undefined;
+export type TriggerResult =
+  | TriggerBranchingResult
+  | TriggerBaseResult
+  | undefined;
 
-type TriggerPerformFunction = (
+export type TriggerPerformFunction = (
   context: ActionContext,
   payload: TriggerPayload,
   params: Record<string, unknown>
 ) => Promise<TriggerResult>;
 
-interface Trigger {
+export interface Trigger {
   key: string;
   display: DisplayDefinition & { directions?: string; important?: boolean };
   inputs: Input[];
@@ -118,18 +121,26 @@ interface Trigger {
   isCommonTrigger?: boolean;
 }
 
-enum OAuth2Type {
+export enum OAuth2Type {
   ClientCredentials = "client_credentials",
   AuthorizationCode = "authorization_code",
 }
 
-interface Connection {
+export interface Connection {
   key: string;
   label: string;
   comments?: string;
   oauth2Type?: OAuth2Type;
   iconPath?: string;
   inputs: (Input & { shown?: boolean })[];
+}
+
+export interface ConnectionValue {
+  key: string;
+  configVarKey: string;
+  fields: { [key: string]: unknown };
+  token?: Record<string, unknown>;
+  context?: Record<string, unknown>;
 }
 
 interface ServerPerformDataStructureReturn {
@@ -165,14 +176,14 @@ interface ServerPerformBranchingDataReturn extends ServerPerformDataReturn {
   branch: string;
 }
 
-type ActionPerformReturn =
+export type ActionPerformReturn =
   | ServerPerformDataStructureReturn
   | ServerPerformBranchingDataStructureReturn
   | ServerPerformDataReturn
   | ServerPerformBranchingDataReturn
   | undefined; // Allow an action to return nothing to reduce component implementation boilerplate
 
-type ActionPerformFunction = (
+export type ActionPerformFunction = (
   context: ActionContext,
   params: Record<string, unknown>
 ) => Promise<ActionPerformReturn>;
@@ -182,7 +193,7 @@ interface InputFieldChoice {
   value: string;
 }
 
-interface Input {
+export interface Input {
   key: string;
   label: string;
   keyLabel?: string;
@@ -196,5 +207,3 @@ interface Input {
   model?: InputFieldChoice[];
   language?: string;
 }
-
-export type { Component, Trigger, Action, Connection, Input };

--- a/packages/spectral/src/testing.test.ts
+++ b/packages/spectral/src/testing.test.ts
@@ -1,0 +1,149 @@
+import { createHarness, ComponentTestHarness } from "./testing";
+import { component, connection, input, action, trigger } from ".";
+import { ConnectionValue } from "./serverTypes";
+import { OAuth2Type } from "./types";
+
+const testConnection = connection({
+  key: "connection",
+  label: "Test Connection",
+  oauth2Type: OAuth2Type.AuthorizationCode,
+  inputs: {
+    authorizeUrl: {
+      label: "Authorize URL",
+      placeholder: "Authorize URL",
+      type: "string",
+      required: true,
+      shown: false,
+      default: "https://example.com/auth",
+      comments: "The OAuth 2.0 Authorization URL for the API",
+    },
+    tokenUrl: {
+      label: "Token URL",
+      placeholder: "Token URL",
+      type: "string",
+      required: true,
+      shown: false,
+      default: "https://example.com/token",
+      comments: "The OAuth 2.0 Token URL for the API",
+    },
+    scopes: {
+      label: "Scopes",
+      placeholder: "Scopes",
+      type: "string",
+      required: true,
+      shown: true,
+      comments: "Space separated OAuth 2.0 permission scopes for the API",
+      default: "offline_access",
+    },
+    clientId: {
+      label: "Client ID",
+      placeholder: "Client ID",
+      type: "string",
+      required: true,
+      shown: true,
+      default: "client-id",
+      comments: "Client Identifier of your app for the API",
+    },
+    clientSecret: {
+      label: "Client Secret",
+      placeholder: "Client Secret",
+      type: "password",
+      required: true,
+      shown: true,
+      default: "client-secret",
+      comments: "Client Secret of your app for the API",
+    },
+  },
+});
+
+const connectionValue: ConnectionValue = {
+  key: testConnection.key,
+  configVarKey: "testConnection",
+  fields: Object.entries(testConnection.inputs).reduce<Record<string, unknown>>(
+    (result, [key, { default: value }]) => ({ ...result, [key]: value }),
+    {}
+  ),
+  token: {
+    access_token: "access",
+    refresh_token: "refresh",
+    expires_in: 100,
+    scope: "offline_access",
+    token_type: "Bearer",
+  },
+};
+process.env.PRISMATIC_CONNECTION_VALUE = JSON.stringify(connectionValue);
+
+const connectionInput = input({
+  label: "Connection",
+  type: "connection",
+});
+
+const fooInput = input({
+  label: "Foo",
+  type: "string",
+});
+
+const fooAction = action({
+  display: {
+    label: "Foo",
+    description: "Foo",
+  },
+  inputs: { connectionInput, fooInput },
+  perform: async (context, params) => {
+    return Promise.resolve({ data: params });
+  },
+});
+
+const fooTrigger = trigger({
+  display: {
+    label: "Foo",
+    description: "Foo",
+  },
+  inputs: { connectionInput },
+  perform: async (context, payload, params) => {
+    return Promise.resolve({ payload, params });
+  },
+  scheduleSupport: "invalid",
+  synchronousResponseSupport: "invalid",
+});
+
+const sample = component({
+  key: "sample",
+  display: {
+    label: "Sample",
+    description: "Sample",
+    iconPath: "icon.png",
+  },
+  triggers: { fooTrigger },
+  actions: { fooAction },
+  connections: [testConnection],
+});
+
+describe("harness", () => {
+  it("wraps a component", () => {
+    const harness = createHarness(sample);
+    expect(harness).toBeInstanceOf(ComponentTestHarness);
+  });
+});
+
+describe("invoking", () => {
+  const harness = createHarness(sample);
+
+  it("should allow invoking a trigger", async () => {
+    const result = await harness.trigger("fooTrigger", undefined, {
+      connectionInput: harness.connectionValue(testConnection),
+    });
+    expect(result?.payload).toBeDefined();
+    expect(result).toMatchObject({
+      params: { connectionInput: connectionValue },
+    });
+  });
+
+  it("should allow invoking an action", async () => {
+    const result = await harness.action("fooAction", {
+      connectionInput: harness.connectionValue(testConnection),
+      fooInput: "hello",
+    });
+    expect(result?.data).toMatchObject({ fooInput: "hello" });
+  });
+});

--- a/packages/spectral/src/types-tests/ComponentDefinition.test-d.ts
+++ b/packages/spectral/src/types-tests/ComponentDefinition.test-d.ts
@@ -1,0 +1,22 @@
+import { expectAssignable } from "tsd";
+import { Component } from "../serverTypes";
+import { component } from "..";
+
+const privateDefinition = component({
+  key: "private-definition",
+  display: { label: "Private", description: "Private", iconPath: "icon.png" },
+});
+expectAssignable<Component>(privateDefinition);
+
+const publicDefinition = component({
+  key: "public-definition",
+  public: true,
+  display: {
+    label: "Public",
+    description: "Public",
+    iconPath: "icon.png",
+    category: "a-category",
+  },
+  documentationUrl: "https://example.com/docs",
+});
+expectAssignable<Component>(publicDefinition);

--- a/packages/spectral/src/types/ComponentDefinition.ts
+++ b/packages/spectral/src/types/ComponentDefinition.ts
@@ -12,13 +12,12 @@ export interface ComponentHooks {
   error?: ErrorHandler;
 }
 
-interface BaseComponentDefinition<TPublic extends boolean = false> {
+/** Defines attributes of a Component. */
+export type ComponentDefinition<TPublic extends boolean> = {
   /** Specifies unique key for this Component. */
   key: string;
   /** Specifies if this Component is available for all Organizations or only your own @default false */
   public?: TPublic;
-  /** Specified the URL for the Component Documentation. */
-  documentationUrl?: string;
   /** Defines how the Component is displayed in the Prismatic interface. */
   display: ComponentDisplayDefinition<TPublic>;
   /** Specifies the supported Actions of this Component. */
@@ -29,9 +28,9 @@ interface BaseComponentDefinition<TPublic extends boolean = false> {
   connections?: ConnectionDefinition[];
   /** Hooks */
   hooks?: ComponentHooks;
-}
-
-/** Defines attributes of a Component. */
-export type ComponentDefinition<TPublic extends boolean = false> =
-  BaseComponentDefinition<TPublic> &
-    (TPublic extends true ? { documentationUrl: string } : unknown);
+} & (TPublic extends true
+  ? {
+      /** Specified the URL for the Component Documentation. */
+      documentationUrl: string;
+    }
+  : unknown);

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "tsd": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "check": {
       "outputs": []
     },


### PR DESCRIPTION
This wraps a Component definition and allows testing a Component by executing
its actions and triggers in a more realistic fashion compared to the old
more direct `invoke` and `invokeTrigger` testing functions.