### PR TITLE
Avoid falling back to FormData in HTTP client Raw Request

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -142,7 +142,10 @@ export const sendRawRequest = async (
     throw new Error("Cannot specify both Data and File/Form Data.");
   }
 
-  const payload = values.data || toFormData(values.formData, values.fileData);
+  const payload =
+    !isEmpty(values.formData) || !isEmpty(values.fileData)
+      ? toFormData(values.formData, values.fileData)
+      : values.data;
 
   const client = createClient({
     baseUrl,


### PR DESCRIPTION
This ends up having implications on the headers supplied to the raw request
client so we need to ensure we only have a FormData instance when we intend
to use form data serialization.