### PR TITLE
Add additional parameters to context

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,22 +8,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Dependencies
-        uses: borales/actions-yarn@v2.3.0
+        uses: borales/actions-yarn@v3.0.0
         with:
           cmd: install
       - name: Check Formatting
-        uses: borales/actions-yarn@v2.3.0
+        uses: borales/actions-yarn@v3.0.0
         with:
           cmd: run check
       - name: Build
-        uses: borales/actions-yarn@v2.3.0
+        uses: borales/actions-yarn@v3.0.0
         with:
           cmd: run build
       - name: Run Tests
-        uses: borales/actions-yarn@v2.3.0
+        uses: borales/actions-yarn@v3.0.0
         with:
           cmd: run test
       - name: Run Type Tests
-        uses: borales/actions-yarn@v2.3.0
+        uses: borales/actions-yarn@v3.0.0
         with:
           cmd: run tsd

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "6.5.2",
+  "version": "6.6.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -45,6 +45,18 @@ export interface ActionContext {
   executionState: Record<string, unknown>;
   stepId: string;
   executionId: string;
+  webhookUrls: Record<string, string>;
+  webhookApiKeys: Record<string, string[]>;
+  invokeUrl: string;
+  customer: {
+    id: string | null;
+    externalId: string | null;
+    name: string | null;
+  };
+  instance: {
+    id: string | null;
+    name: string | null;
+  };
 }
 
 type TriggerOptionChoice = "invalid" | "valid" | "required";

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -79,6 +79,22 @@ export const invoke = async <
     executionState: {},
     stepId: "mockStepId",
     executionId: "mockExecutionId",
+    webhookUrls: {
+      "Flow 1": "https://example.com",
+    },
+    webhookApiKeys: {
+      "Flow 1": ["example-123", "example-456"],
+    },
+    invokeUrl: "https://example.com",
+    customer: {
+      id: "customerId",
+      name: "Customer 1",
+      externalId: "1234",
+    },
+    instance: {
+      id: "instanceId",
+      name: "Instance 1",
+    },
     ...context,
   };
 
@@ -151,6 +167,22 @@ export const invokeTrigger = async <
     executionState: {},
     stepId: "mockStepId",
     executionId: "mockExecutionId",
+    webhookUrls: {
+      "Flow 1": "https://example.com",
+    },
+    webhookApiKeys: {
+      "Flow 1": ["example-123", "example-456"],
+    },
+    invokeUrl: "https://example.com",
+    customer: {
+      id: "customerId",
+      name: "Customer 1",
+      externalId: "1234",
+    },
+    instance: {
+      id: "instanceId",
+      name: "Instance 1",
+    },
     ...context,
   };
 
@@ -205,6 +237,22 @@ export class ComponentTestHarness<TComponent extends Component> {
       executionState: {},
       stepId: "mockStepId",
       executionId: "mockExecutionId",
+      webhookUrls: {
+        "Flow 1": "https://example.com",
+      },
+      webhookApiKeys: {
+        "Flow 1": ["example-123", "example-456"],
+      },
+      invokeUrl: "https://example.com",
+      customer: {
+        id: "customerId",
+        name: "Customer 1",
+        externalId: "1234",
+      },
+      instance: {
+        id: "instanceId",
+        name: "Instance 1",
+      },
       ...context,
     };
 
@@ -228,6 +276,22 @@ export class ComponentTestHarness<TComponent extends Component> {
       executionState: {},
       stepId: "mockStepId",
       executionId: "mockExecutionId",
+      webhookUrls: {
+        "Flow 1": "https://example.com",
+      },
+      webhookApiKeys: {
+        "Flow 1": ["example-123", "example-456"],
+      },
+      invokeUrl: "https://example.com",
+      customer: {
+        id: "customerId",
+        name: "Customer 1",
+        externalId: "1234",
+      },
+      instance: {
+        id: "instanceId",
+        name: "Instance 1",
+      },
       ...context,
     };
 

--- a/packages/spectral/src/types/ActionPerformFunction.ts
+++ b/packages/spectral/src/types/ActionPerformFunction.ts
@@ -29,4 +29,21 @@ export interface ActionContext {
   stepId: string;
   /** A unique id that corresponds to the specific execution of the Integration */
   executionId: string;
+  /** An object containing webhook URLs for all flows of the currently running instance */
+  webhookUrls: Record<string, string>;
+  /** An object containing webhook API keys for all flows of the currently running instance */
+  webhookApiKeys: Record<string, string[]>;
+  /** The URL used to invoke the current execution */
+  invokeUrl: string;
+  /** An object containing the ID, External ID and name of the customer the instance is deployed to */
+  customer: {
+    id: string | null;
+    externalId: string | null;
+    name: string | null;
+  };
+  /** An object containing the ID ad name of the currently running instance */
+  instance: {
+    id: string | null;
+    name: string | null;
+  };
 }


### PR DESCRIPTION
This PR adds additional metadata about an instance execution to the `context` paramater, for use by an action or trigger's `perform` function, and will be especially handy for developing actions that configure and remove webhooks in third-party apps.

- `webhookUrls` contains the URLs of the running instance's sibling flows.
- `webhookApiKeys` contains the API keys of the running instance's sibling flows.
- `invokeUrl` was the URL used to invoke the integration.
- `customer` is an object containing an `id`, `name`, and `externalId` of the customer the instance is assigned to.
- `instance` is an object containing an `id` and `name` of the running instance.
