### PR TITLE
Add params to HTTP createClient

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -36,7 +36,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "6.6.0",
+    "@prismatic-io/spectral": "6.6.1",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -57,6 +57,7 @@ export interface ClientProps {
   baseUrl?: string;
   responseType?: AxiosRequestConfig["responseType"];
   headers?: AxiosRequestConfig["headers"];
+  params?: Record<string, any>;
   timeout?: number;
   debug?: boolean;
   retryConfig?: RetryConfig;
@@ -89,6 +90,7 @@ export const createClient = ({
   responseType,
   headers,
   timeout,
+  params,
   debug = false,
   retryConfig,
 }: ClientProps): HttpClient => {
@@ -97,6 +99,7 @@ export const createClient = ({
     responseType,
     headers,
     timeout,
+    params,
     maxContentLength: Infinity,
     maxBodyLength: Infinity,
   });


### PR DESCRIPTION
Some APIs pass in things (like API key) via `params`, so it's useful to be able to set a generic `params` value for all HTTP requests. This change lets you pass in a `params` object into Spectral's HTTP client's `createClient` function, and those params will be used for all HTTP requests.