### PR TITLE
Add additional validition for action return types

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.0.8-pre",
+  "version": "2.0.9-pre",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.0.7-pre",
+    "@prismatic-io/spectral": "7.0.8-pre",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.0.7-pre",
+  "version": "7.0.8-pre",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -512,6 +512,16 @@ describe("util", () => {
   });
 
   describe("string", () => {
+    it("detects a string value", () => {
+      expect(util.types.isString("value")).toStrictEqual(true);
+      expect(util.types.isString(new String("value"))).toStrictEqual(true);
+    });
+
+    it("detects a non-string value", () => {
+      expect(util.types.isString(["value"])).toStrictEqual(false);
+      expect(util.types.isString(4)).toStrictEqual(false);
+    });
+
     it("coerces plain text buffer to string", () => {
       fc.assert(
         fc.property(bufferArbitrary, (v) => {
@@ -677,27 +687,27 @@ describe("util", () => {
       expect(util.types.isObjectFieldMap(v2)).toStrictEqual(false);
       expect(util.types.isObjectFieldMap(v3)).toStrictEqual(false);
     });
-  });
 
-  it("coerces valid values", () => {
-    const v = [{ key: "foo", value: { objectKey: "bar", fieldKey: "biz" } }];
-    expect(util.types.toObjectFieldMap(v)).toStrictEqual(v);
-  });
+    it("coerces valid values", () => {
+      const v = [{ key: "foo", value: { objectKey: "bar", fieldKey: "biz" } }];
+      expect(util.types.toObjectFieldMap(v)).toStrictEqual(v);
+    });
 
-  it("throws on invalid values", () => {
-    const v1 = [
-      { missingKey: "foo", value: { objectKey: "bar", fieldKey: "biz" } },
-    ];
-    const v2 = [
-      { key: "foo", value: { missingObjectKey: "bar", fieldKey: "biz" } },
-    ];
-    const v3 = [
-      { key: "foo", value: { objectKey: "bar", missingFieldKey: "biz" } },
-    ];
-    const error = "cannot be coerced to ObjectFieldMap";
-    expect(() => util.types.toObjectFieldMap(v1)).toThrow(error);
-    expect(() => util.types.toObjectFieldMap(v2)).toThrow(error);
-    expect(() => util.types.toObjectFieldMap(v3)).toThrow(error);
+    it("throws on invalid values", () => {
+      const v1 = [
+        { missingKey: "foo", value: { objectKey: "bar", fieldKey: "biz" } },
+      ];
+      const v2 = [
+        { key: "foo", value: { missingObjectKey: "bar", fieldKey: "biz" } },
+      ];
+      const v3 = [
+        { key: "foo", value: { objectKey: "bar", missingFieldKey: "biz" } },
+      ];
+      const error = "cannot be coerced to ObjectFieldMap";
+      expect(() => util.types.toObjectFieldMap(v1)).toThrow(error);
+      expect(() => util.types.toObjectFieldMap(v2)).toThrow(error);
+      expect(() => util.types.toObjectFieldMap(v3)).toThrow(error);
+    });
   });
 
   describe("jsonForm", () => {
@@ -707,27 +717,65 @@ describe("util", () => {
     });
 
     it("detects invalid values", () => {
-      const v1 = { missindSchema: {}, uiSchema: {}, data: {} };
+      const v1 = { missingSchema: {}, uiSchema: {}, data: {} };
       const v2 = { schema: {}, missingUiSchema: {}, data: {} };
       const v3 = { schema: {}, uiSchema: {}, missingData: {} };
-      expect(util.types.isObjectFieldMap(v1)).toStrictEqual(false);
-      expect(util.types.isObjectFieldMap(v2)).toStrictEqual(false);
-      expect(util.types.isObjectFieldMap(v3)).toStrictEqual(false);
+      expect(util.types.isJSONForm(v1)).toStrictEqual(false);
+      expect(util.types.isJSONForm(v2)).toStrictEqual(false);
+      expect(util.types.isJSONForm(v3)).toStrictEqual(false);
+    });
+
+    it("coerces valid values", () => {
+      const v = { schema: {}, uiSchema: {}, data: {} };
+      expect(util.types.toJSONForm(v)).toStrictEqual(v);
+    });
+
+    it("throws on invalid values", () => {
+      const v1 = { missingSchema: {}, uiSchema: {}, data: {} };
+      const v2 = { schema: {}, missingUiSchema: {}, data: {} };
+      const v3 = { schema: {}, uiSchema: {}, missingData: {} };
+      const error = "cannot be coerced to JSONForm";
+      expect(() => util.types.toJSONForm(v1)).toThrow(error);
+      expect(() => util.types.toJSONForm(v2)).toThrow(error);
+      expect(() => util.types.toJSONForm(v3)).toThrow(error);
     });
   });
 
-  it("coerces valid values", () => {
-    const v = { schema: {}, uiSchema: {}, data: {} };
-    expect(util.types.toJSONForm(v)).toStrictEqual(v);
+  describe("picklist", () => {
+    it("detects picklist value", () => {
+      const v1 = ["value", new String("value")];
+      const v2: unknown = [];
+      expect(util.types.isPicklist(v1)).toStrictEqual(true);
+      expect(util.types.isPicklist(v2)).toStrictEqual(true);
+    });
+
+    it("detects non-picklist value", () => {
+      const v1 = "value";
+      const v2 = ["value", 4];
+      expect(util.types.isPicklist(v1)).toStrictEqual(false);
+      expect(util.types.isPicklist(v2)).toStrictEqual(false);
+    });
   });
 
-  it("throws on invalid values", () => {
-    const v1 = { missindSchema: {}, uiSchema: {}, data: {} };
-    const v2 = { schema: {}, missingUiSchema: {}, data: {} };
-    const v3 = { schema: {}, uiSchema: {}, missingData: {} };
-    const error = "cannot be coerced to JSONForm";
-    expect(() => util.types.toJSONForm(v1)).toThrow(error);
-    expect(() => util.types.toJSONForm(v2)).toThrow(error);
-    expect(() => util.types.toJSONForm(v3)).toThrow(error);
+  describe("schedule", () => {
+    it("detects schedule value", () => {
+      const v1 = { value: "00 00 * * 2,3" };
+      const v2 = {
+        value: "00 00 * * 2,3",
+        timeZone: "America/Chicago",
+        scheduleType: "week",
+      };
+      expect(util.types.isSchedule(v1)).toStrictEqual(true);
+      expect(util.types.isSchedule(v2)).toStrictEqual(true);
+    });
+
+    it("detects non-schedule value", () => {
+      const v = {
+        missingValue: "00 00 * * 2,3",
+        timeZone: "America/Chicago",
+        scheduleType: "week",
+      };
+      expect(util.types.isSchedule(v)).toStrictEqual(false);
+    });
   });
 });

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -320,6 +320,29 @@ const toDate = (value: unknown): Date => {
 const isUrl = (value: string): boolean => isWebUri(value) !== undefined;
 
 /**
+ * This function checks if value is a valid picklist.
+ *
+ * - `util.types.isPicklist(["value", new String("value")])` will return `true`.
+ *
+ * @param value The variable to test.
+ * @returns This function returns true if `value` is a valid picklist.
+ */
+const isPicklist = (value: unknown): boolean =>
+  Array.isArray(value) && value.every(isString);
+
+/**
+ * This function checks if value is a valid schedule.
+ *
+ * - `util.types.isSchedule({value: "00 00 * * 2,3"})` will return `true`.
+ * - `util.types.isSchedule({value: "00 00 * * 2,3", scheduleType: "week", timeZone: "America/Chicago"})` will return `true`.
+ *
+ * @param value The variable to test.
+ * @returns This function returns true if `value` is a valid schedule.
+ */
+const isSchedule = (value: unknown): boolean =>
+  isObjectWithTruthyKeys(value, ["value"]);
+
+/**
  * This function helps to transform key-value lists to objects.
  * This is useful for transforming inputs that are key-value collections into objects.
  *
@@ -434,6 +457,15 @@ const formatJsonExample = (input: unknown): string =>
   ["```json", JSON.stringify(input, undefined, 2), "```"].join("\n");
 
 /**
+ * This function checks if value is a string.
+ * `util.types.isString("value")` and `util.types.isString(new String("value"))` return true.
+ * @param value The variable to test.
+ * @returns This function returns true or false, depending on if `value` is a string.
+ */
+const isString = (value: unknown): value is string =>
+  typeof value === "string" || value instanceof String;
+
+/**
  * This function converts a `value` to a string.
  * If `value` is undefined or an empty string, an optional `defaultValue` can be returned.
  *
@@ -511,6 +543,7 @@ export default {
     toBufferDataPayload,
     isData,
     toData,
+    isString,
     toString,
     keyValPairListToObject,
     isJSON,
@@ -522,6 +555,8 @@ export default {
     toObjectFieldMap,
     isJSONForm,
     toJSONForm,
+    isPicklist,
+    isSchedule,
   },
   docs: {
     formatJsonExample,


### PR DESCRIPTION
Adds validation for `string`, `schedule` and `picklist` action return types.