### PR TITLE
Default inputs in test harness

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.0.13-pre",
+  "version": "2.0.14-pre",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.0.12-pre",
+    "@prismatic-io/spectral": "7.0.13-pre",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.0.12-pre",
+  "version": "7.0.13-pre",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"


### PR DESCRIPTION
Supports both defaulted values and running unspecified values through
clean functions, if defined. Mimics in-app defaulting behavior as
closely as possible.