### PR TITLE
OpenAPI generator enhancements

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/formats/index.ts
+++ b/packages/generator-spectral/src/generators/formats/index.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path, { extname } from "path";
 import { camelCase } from "lodash";
 import Generator from "yeoman-generator";
 import { read } from "./readers/openapi";
@@ -62,6 +62,7 @@ class FormatsGenerator extends Generator {
   async writing() {
     this.renderTemplate("tsconfig.json");
     this.renderTemplate("webpack.config.js");
+    this.renderTemplate("jest.config.js");
     this.renderTemplate(["assets", "icon.png"]);
 
     this.packageJson.merge({
@@ -72,7 +73,7 @@ class FormatsGenerator extends Generator {
       version: "0.0.1",
       scripts: {
         build: "webpack",
-        test: "jest",
+        test: "jest --runInBand",
         lint: "eslint --quiet --ext .ts .",
         "lint-fix": "eslint --quiet --ext .ts --fix .",
         format: "npm run lint-fix && prettier --loglevel error --write .",
@@ -100,6 +101,11 @@ class FormatsGenerator extends Generator {
 
     const result = await read(this.values.openapi);
     await write(this.values.key, this.values.public, result);
+
+    this.fs.copy(
+      this.values.openapi,
+      `${this.values.key}-openapi-spec${extname(this.values.openapi)}`
+    );
 
     if (this.values.icon) {
       this.fs.copy(this.values.icon, path.join("assets", "icon.png"));

--- a/packages/generator-spectral/src/generators/formats/readers/openapi/actions.ts
+++ b/packages/generator-spectral/src/generators/formats/readers/openapi/actions.ts
@@ -42,8 +42,7 @@ const buildPerformFunction = (
     writer
       .writeLine(`async (context, { connection, ${destructureNames} }) => {`)
       .blankLineIfLastNot()
-      // FIXME: Apparently type inference doesn't work with inlined inputs!?
-      .writeLine("const client = createClient(connection as Connection);")
+      .writeLine("const client = createClient(connection);")
       .write("const {data} = await client.")
       .write(verb)
       .write("(`")

--- a/packages/generator-spectral/src/generators/formats/utils.ts
+++ b/packages/generator-spectral/src/generators/formats/utils.ts
@@ -25,7 +25,14 @@ export const createDescription = (text?: string): string => {
   const strippedText = stripTags(text);
   const [nonEmptyLine] = strippedText.split("\n").filter((t) => t.trim() != "");
   const [fragment] = nonEmptyLine.split(/[.!?]/g);
-  return fragment;
+  return escapeText(fragment);
+};
+
+export const escapeText = (text?: string): string => {
+  if (!text) {
+    return "";
+  }
+  return text.replace(/"/g, '\\"');
 };
 
 export type GeneratedFunction = string | WriterFunction;

--- a/packages/generator-spectral/src/generators/formats/writer/actions.ts
+++ b/packages/generator-spectral/src/generators/formats/writer/actions.ts
@@ -28,7 +28,7 @@ const writeInput = (
   }: Input
 ): CodeBlockWriter =>
   writer
-    .writeLine(`${key}: {`)
+    .writeLine(`${key}: input({`)
     .writeLine(`label: "${label}",`)
     .writeLine(`type: "${type}",`)
     .conditionalWriteLine(required !== undefined, `required: ${required},`)
@@ -55,7 +55,7 @@ const writeInput = (
       comments !== undefined,
       () => `comments: "${createDescription(`${comments}`)}",`
     )
-    .writeLine("},");
+    .writeLine("}),");
 
 const buildActionDeclaration = ({
   key: rawKey,
@@ -125,8 +125,7 @@ const writeActionGroup = (
   file.addImportDeclarations([
     {
       moduleSpecifier: "@prismatic-io/spectral",
-      // FIXME: Connection should _not_ be required. See openapi.ts reader for details :(
-      namedImports: ["action", "util", "Connection"],
+      namedImports: ["action", "input", "util"],
     },
     {
       moduleSpecifier: "../client",

--- a/packages/generator-spectral/src/generators/formats/writer/connections.ts
+++ b/packages/generator-spectral/src/generators/formats/writer/connections.ts
@@ -9,7 +9,7 @@ import {
   VariableDeclarationKind,
   VariableDeclarationStructure,
 } from "ts-morph";
-import { Connection, ConnectionInput } from "../utils";
+import { Connection, ConnectionInput, escapeText } from "../utils";
 import path from "path";
 
 const writeInput = (
@@ -41,7 +41,10 @@ const writeInput = (
       `default: "${defaultValue}",`
     )
     .conditionalWriteLine(example !== undefined, `example: "${example}",`)
-    .conditionalWriteLine(comments !== undefined, `comments: "${comments}",`)
+    .conditionalWriteLine(
+      comments !== undefined,
+      `comments: "${escapeText(comments)}",`
+    )
     .writeLine("},");
 
 const buildConnectionDeclaration = ({
@@ -67,7 +70,7 @@ const buildConnectionDeclaration = ({
         .writeLine(`label: "${label}",`)
         .conditionalWriteLine(
           comments !== undefined,
-          `comments: "${comments}",`
+          `comments: "${escapeText(comments)}",`
         )
         .conditionalWriteLine(
           iconPath !== undefined,


### PR DESCRIPTION
- Wrap all input data objects in the `input` function to aid in perform fn typing
- Copy in the OpenAPI spec used for component generation
- Fix number/boolean inputs incorrectly using undefined for falsey values
- Escape double quotes in input comments
- Generated components now have a proper jest config
- Generated components also have a minimal start of a harness-based testing file templated out