### PR TITLE
Support Element[] picklists

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.0.0",
+    "@prismatic-io/spectral": "7.2.0",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/types/DataSourceResult.ts
+++ b/packages/spectral/src/types/DataSourceResult.ts
@@ -1,12 +1,12 @@
 import { ConnectionDefinition } from "./ConnectionDefinition";
-import { ObjectSelection, ObjectFieldMap, JSONForm } from "./Inputs";
+import { ObjectSelection, ObjectFieldMap, JSONForm, Element } from "./Inputs";
 
 /** The type of field that is appropriate for rendering the data that is the result of the data source perform function. */
 type DataSourceTypeMap = {
   string: string;
   date: string;
   timestamp: string;
-  picklist: string[];
+  picklist: string[] | Element[];
   schedule: { value: string };
   code: string;
   credential: unknown; // DEPRECATED

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -761,15 +761,19 @@ describe("util", () => {
     it("detects picklist value", () => {
       const v1 = ["value", new String("value")];
       const v2: unknown = [];
+      const v3 = [{ key: "foo" }, { key: "foo", label: "Foo" }];
       expect(util.types.isPicklist(v1)).toStrictEqual(true);
       expect(util.types.isPicklist(v2)).toStrictEqual(true);
+      expect(util.types.isPicklist(v3)).toStrictEqual(true);
     });
 
     it("detects non-picklist value", () => {
       const v1 = "value";
       const v2 = ["value", 4];
+      const v3 = [{ missingKey: "foo" }];
       expect(util.types.isPicklist(v1)).toStrictEqual(false);
       expect(util.types.isPicklist(v2)).toStrictEqual(false);
+      expect(util.types.isPicklist(v3)).toStrictEqual(false);
     });
   });
 

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -17,6 +17,7 @@ import {
   ObjectFieldMap,
   JSONForm,
   ConnectionDefinition,
+  Element,
 } from "./types";
 
 const isObjectWithTruthyKeys = (value: unknown, keys: string[]): boolean => {
@@ -29,6 +30,15 @@ const isObjectWithTruthyKeys = (value: unknown, keys: string[]): boolean => {
     )
   );
 };
+
+/**
+ * This function checks if value is an Element.
+ * `util.types.isElement({key: "foo"})` and `util.types.isElement({key: "foo", label: "Foo"})` return true.
+ * @param value The variable to test.
+ * @returns This function returns true or false, depending on if `value` is an Element.
+ */
+const isElement = (value: unknown): value is Element =>
+  isObjectWithTruthyKeys(value, ["key"]);
 
 /**
  * @param value The value to test
@@ -82,9 +92,7 @@ const isObjectFieldMap = (value: unknown): value is ObjectFieldMap => {
       fields.every(
         (item) =>
           isObjectWithTruthyKeys(item, ["field"]) &&
-          isObjectWithTruthyKeys((item as Record<string, unknown>)?.field, [
-            "key",
-          ])
+          isElement((item as Record<string, unknown>)?.field)
       )
     );
   }
@@ -348,7 +356,7 @@ const isUrl = (value: string): boolean => isWebUri(value) !== undefined;
  * @returns This function returns true if `value` is a valid picklist.
  */
 const isPicklist = (value: unknown): boolean =>
-  Array.isArray(value) && value.every(isString);
+  Array.isArray(value) && (value.every(isString) || value.every(isElement));
 
 /**
  * This function checks if value is a valid schedule.
@@ -604,5 +612,6 @@ export default {
     isPicklist,
     isSchedule,
     isConnection,
+    isElement,
   },
 };


### PR DESCRIPTION
Adding support for picklist items to be Elements, which will facilitate a much nicer UX when dealing with dropdown choices that are more clearly expressed as key/value pairs.