### PR TITLE
Add toObject util function to easily turn JSON into a parsed object

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.2.0",
+    "@prismatic-io/spectral": "7.2.1",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -871,4 +871,16 @@ describe("util", () => {
       expect(util.types.isConnection(v3)).toStrictEqual(false);
     });
   });
+
+  describe("toObject", () => {
+    it("parses JSON correctly", () => {
+      const value = '{"foo":"bar","baz":123,"buz":false}';
+      const expectedResult = { foo: "bar", baz: 123, buz: false };
+      expect(util.types.toObject(value)).toStrictEqual(expectedResult);
+    });
+    it("objects remain objects", () => {
+      const value = { foo: "bar", baz: 123, buz: false };
+      expect(util.types.toObject(value)).toStrictEqual(value);
+    });
+  });
 });

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -554,7 +554,8 @@ const isJSON = (value: string): boolean => {
   }
 };
 
-/** This function accepts an arbitrary object/value and safely serializes it (handles cyclic references).
+/**
+ * This function accepts an arbitrary object/value and safely serializes it (handles cyclic references).
  *
  * @param value Arbitrary object/value to serialize.
  * @returns JSON serialized text that can be safely logged.
@@ -567,9 +568,9 @@ const toJSON = (value: unknown): string => {
 /**
  * This function returns a lower cased version of the headers passed to it.
  *
- * - `lowerCaseHeaders({"Content-Type": "Application/JSON"}) will return {"content-type": "Application/JSON"}`
- * - `lowerCaseHeaders({"Cache-Control": "max-age=604800"}) will return {"cache-control": "max-age=604800"}`
- * - `lowerCaseHeaders({"Accept-Language": "en-us"}) will return {"accept-language": "en-us"}`
+ * - `lowerCaseHeaders({"Content-Type": "Application/JSON"})` will return `{"content-type": "Application/JSON"}`
+ * - `lowerCaseHeaders({"Cache-Control": "max-age=604800"})` will return `{"cache-control": "max-age=604800"}`
+ * - `lowerCaseHeaders({"Accept-Language": "en-us"})` will return `{"accept-language": "en-us"}`
  * @param headers The headers to convert to lower case
  * @returns This function returns a header object
  * */
@@ -579,6 +580,23 @@ export const lowerCaseHeaders = (
   Object.entries(headers).reduce((result, [key, val]) => {
     return { ...result, [key.toLowerCase()]: val };
   }, {});
+
+/**
+ * This function parses a JSON string (if JSON) and returns an object, or returns the object.
+ *
+ * - `toObject('{"foo":"bar","baz":123}')` will return object `{foo: "bar", baz: 123}`
+ * - `toObject({foo:"bar",baz:123})` will return object `{foo: "bar", baz: 123}`
+ *
+ * @param value The JSON string or object to convert
+ * @returns This function returns an object, parsing JSON as necessary
+ */
+export const toObject = (value: unknown): object => {
+  if (typeof value === "string" && isJSON(value)) {
+    return JSON.parse(value);
+  } else {
+    return value as object;
+  }
+};
 
 export default {
   types: {
@@ -613,5 +631,6 @@ export default {
     isSchedule,
     isConnection,
     isElement,
+    toObject,
   },
 };


### PR DESCRIPTION
When an input is a complex data structure, sometimes you don't know if the input you receive will be JSON-serialized or not.

This new utility function, `util.types.toObject()`, detects and parses JSON if it is passed JSON. Else, it returns the object that it received. That way, component users can input static JSON-serialized objects, or they can reference JavaScript objects from previous steps.