### PR TITLE
Allow private components to have an optional documentationUrl

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.3.1",
+    "@prismatic-io/spectral": "7.3.2",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/types/ComponentDefinition.ts
+++ b/packages/spectral/src/types/ComponentDefinition.ts
@@ -36,4 +36,6 @@ export type ComponentDefinition<TPublic extends boolean> = {
       /** Specified the URL for the Component Documentation. */
       documentationUrl: string;
     }
-  : unknown);
+  : {
+      documentationUrl?: string;
+    });


### PR DESCRIPTION
Our current `component()` definition requires public components to contain a `documentationUrl`, mostly so we remember to include one internally. It omits `documentationUrl` from private components, though. But, it's handy as a private component developer to have a `documentationUrl`, so they can link to docs from the UI easily. This adds `documentationUrl` as an _optional_ property for private components.