### PR TITLE
toNumber should use defaults when presented null or empty string.

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -8,6 +8,7 @@ describe("util", () => {
   const uint8ArrayArbitrary = bufferArbitrary.map((b) => new Uint8Array(b));
   const unknowns = (): fc.Arbitrary<unknown> => fc.constantFrom(undefined);
   const emptyStrings = (): fc.Arbitrary<string> => fc.constantFrom("");
+  const nulls = (): fc.Arbitrary<null> => fc.constantFrom(null);
 
   describe("boolean", () => {
     type TruthyValue = true | "true" | "t" | "T" | "yes" | "y" | "Y";
@@ -247,9 +248,25 @@ describe("util", () => {
       );
     });
 
-    it("returns the default value when a value is missing", () => {
+    it("returns the default value when a value is undefined", () => {
       fc.assert(
         fc.property(unknowns(), (v) =>
+          expect(util.types.toNumber(v, 5.5)).toStrictEqual(5.5)
+        )
+      );
+    });
+
+    it("returns the default value when a value is empty string", () => {
+      fc.assert(
+        fc.property(emptyStrings(), (v) =>
+          expect(util.types.toNumber(v, 5.5)).toStrictEqual(5.5)
+        )
+      );
+    });
+
+    it("returns the default value when a value is null", () => {
+      fc.assert(
+        fc.property(nulls(), (v) =>
           expect(util.types.toNumber(v, 5.5)).toStrictEqual(5.5)
         )
       );

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -260,6 +260,7 @@ const isNumber = (value: unknown): boolean => !Number.isNaN(Number(value));
  *
  * - `util.types.toNumber("3.22")` will return the number `3.22`.
  * - `util.types.toNumber("", 5.5)` will return the default value `5.5`, since `value` was an empty string.
+ * - `util.types.toNumber(null, 5.5)` will return the default value `5.5`, since `value` was `null`.
  * - `util.types.toNumber(undefined)` will return `0`, since `value` was undefined and no `defaultValue` was given.
  * - `util.types.toNumber("Hello")` will throw an error, since the string `"Hello"` cannot be coerced into a number.
  * @param value The value to turn into a number.
@@ -267,12 +268,12 @@ const isNumber = (value: unknown): boolean => !Number.isNaN(Number(value));
  * @returns This function returns the numerical version of `value` if possible, or the `defaultValue` if `value` is undefined or an empty string.
  */
 const toNumber = (value: unknown, defaultValue?: number): number => {
-  if (isNumber(value)) {
-    return Number(value);
+  if (typeof value === "undefined" || value === "" || value === null) {
+    return defaultValue || 0;
   }
 
-  if (typeof value === "undefined" || value === "") {
-    return defaultValue || 0;
+  if (isNumber(value)) {
+    return Number(value);
   }
 
   throw new Error(`Value '${value}' cannot be coerced to a number.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,23 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
+"@prismatic-io/spectral@7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@prismatic-io/spectral/-/spectral-7.3.2.tgz#38c891bc2225f8b33e7a1d0c3b97bcbdc45b94c8"
+  integrity sha512-/aQG4n8iX806S6PHl0fOowYi7jmVvC4yopUqYWiy/0nMwk+2kbqY+SNpoxudR9QzT8X4pcr3GQWmQEcyWVPvTg==
+  dependencies:
+    axios "0.27.2"
+    axios-retry "3.2.5"
+    date-fns "2.28.0"
+    form-data "4.0.0"
+    jest-mock "27.0.3"
+    safe-stable-stringify "2.3.1"
+    serialize-error "8.1.0"
+    soap "0.45.0"
+    url-join "5.0.0"
+    uuid "8.3.2"
+    valid-url "1.0.9"
+
 "@rushstack/eslint-patch@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.1.tgz#782fa5da44c4f38ae9fd38e9184b54e451936118"


### PR DESCRIPTION
`util.types.toNumber(null, 10)` currently returns `0` because in JavaScript `Number(null)` is `0`. The same is true for `""`, though weirdly not `undefined` (`Number(undefined)` is `NaN`).

This changes the behavior of `util.types.toNumber()` such that when presented `null` or `undefined`, it returns the default value when a default value is presented. Otherwise, it still returns `0`.