### PR TITLE
Bump webpack to latest to address compat issue with NodeJS 18+

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/component/index.ts
+++ b/packages/generator-spectral/src/generators/component/index.ts
@@ -113,13 +113,13 @@ class ComponentGenerator extends Generator {
     await this.addDevDependencies("@prismatic-io/eslint-config-spectral");
     await this.addDevDependencies({
       "@types/jest": "26.0.24",
-      "copy-webpack-plugin": "9.0.1",
+      "copy-webpack-plugin": "11.0.0",
       jest: "27.0.6",
       "ts-jest": "27.0.3",
       "ts-loader": "9.2.3",
       typescript: "4.3.5",
-      webpack: "5.43.0",
-      "webpack-cli": "4.7.2",
+      webpack: "5.75.0",
+      "webpack-cli": "5.0.1",
       eslint: "6.8.0",
     });
   }


### PR DESCRIPTION
Some users report errors when building custom components on Windows machines running NodeJS version 18+ (the latest LTS). 

```
PS C:\Users\Administrator\my-component> npm run build

> my-component@0.0.1 build
> webpack

C:\Users\Administrator\my-component\node_modules\loader-runner\lib\LoaderRunner.js:146
                if(isError) throw e;
                            ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at BulkUpdateDecorator.hashFactory (C:\Users\Administrator\my-component\node_modules\webpack\lib\util\createHash.js:145:18)
    at BulkUpdateDecorator.update (C:\Users\Administrator\my-component\node_modules\webpack\lib\util\createHash.js:46:50)
    at RawSource.updateHash (C:\Users\Administrator\my-component\node_modules\webpack-sources\lib\RawSource.js:64:8)
    at NormalModule._initBuildHash (C:\Users\Administrator\my-component\node_modules\webpack\lib\NormalModule.js:868:17)
    at handleParseResult (C:\Users\Administrator\my-component\node_modules\webpack\lib\NormalModule.js:934:10)
    at C:\Users\Administrator\my-component\node_modules\webpack\lib\NormalModule.js:1026:4
    at processResult (C:\Users\Administrator\my-component\node_modules\webpack\lib\NormalModule.js:743:11)
    at C:\Users\Administrator\my-component\node_modules\webpack\lib\NormalModule.js:807:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.1
```

NodeJS 18+ runs a more recent version of OpenSSL that is incompatible with webpack 5.43.0.

This bumps webpack to current latest (5.75.0), along with other webpack-related dependencies. Bumping these dependencies results in Windows users with NodeJS 18+ being able to build components. 

I verified that this change is compatible with older versions of NodeJS running on other OS's (like MacOS).