### PR TITLE
Address CVE in qs package

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",
@@ -37,7 +37,7 @@
     "generators"
   ],
   "dependencies": {
-    "@prismatic-io/spectral": "7.3.2",
+    "@prismatic-io/spectral": "7.3.4",
     "yeoman-generator": "5.6.1",
     "lodash": "4.17.21",
     "@apidevtools/swagger-parser": "10.1.0",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.3.3",
+  "version": "7.3.4",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"
@@ -42,7 +42,7 @@
     "date-fns": "2.28.0",
     "form-data": "4.0.0",
     "jest-mock": "27.0.3",
-    "soap": "0.45.0",
+    "soap": "1.0.0",
     "uuid": "8.3.2",
     "valid-url": "1.0.9",
     "url-join": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,23 +1390,6 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@prismatic-io/spectral@7.3.2":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@prismatic-io/spectral/-/spectral-7.3.2.tgz#38c891bc2225f8b33e7a1d0c3b97bcbdc45b94c8"
-  integrity sha512-/aQG4n8iX806S6PHl0fOowYi7jmVvC4yopUqYWiy/0nMwk+2kbqY+SNpoxudR9QzT8X4pcr3GQWmQEcyWVPvTg==
-  dependencies:
-    axios "0.27.2"
-    axios-retry "3.2.5"
-    date-fns "2.28.0"
-    form-data "4.0.0"
-    jest-mock "27.0.3"
-    safe-stable-stringify "2.3.1"
-    serialize-error "8.1.0"
-    soap "0.45.0"
-    url-join "5.0.0"
-    uuid "8.3.2"
-    valid-url "1.0.9"
-
 "@rushstack/eslint-patch@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.1.tgz#782fa5da44c4f38ae9fd38e9184b54e451936118"
@@ -1941,10 +1924,10 @@
     "@typescript-eslint/types" "5.18.0"
     eslint-visitor-keys "^3.0.0"
 
-"@xmldom/xmldom@^0.7.0":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.8.tgz#a8d0a0067c9554c187b0d04e86ad1845053c0e06"
-  integrity sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==
+"@xmldom/xmldom@^0.8.5":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.6.tgz#8a1524eb5bd5e965c1e3735476f0262469f71440"
+  integrity sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
@@ -4293,15 +4276,14 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-formidable@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.0.1.tgz#4310bc7965d185536f9565184dee74fbb75557ff"
-  integrity sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==
+formidable@^3.2.4:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-3.2.5.tgz#95d6e0b0110c5e6f31ef5be4b0bd2d0791fd9232"
+  integrity sha512-GRGDJTWAZ3H+umZbF2bKcqjsTov25zgon1St05ziKdiSw3kxvI+meMJrXx3ylRmuSADOpviSakBuS4yvGCGnSg==
   dependencies:
     dezalgo "1.0.3"
     hexoid "1.0.0"
     once "1.4.0"
-    qs "6.9.3"
 
 from2@^2.1.1:
   version "2.3.0"
@@ -8013,11 +7995,6 @@ pure-rand@^4.1.1:
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-4.2.1.tgz#14c08ab1cebce0eb95b987638039742a1006a695"
   integrity sha512-ESI2eqHP9JlrnTb7H7fgczRUWB6VxMMJ2m9870WCIBhYkBzSGd6gml6WhQVXHK+ZM8k70TqsyI28ixaLPaNz5g==
 
-qs@6.9.3:
-  version "6.9.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
-  integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==
-
 qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
@@ -8612,21 +8589,21 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-soap@0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/soap/-/soap-0.45.0.tgz#6772e25da4b407bdba63b60fa615d94fd87cb988"
-  integrity sha512-t2wgZaWQCL8htPxpHzwW1Sw/Qy22Ls6my1X9ajMMXcmNYLlO4ogk10T0A+J8p4/6xHUQthfe2J3Ys1e9/sqS5w==
+soap@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/soap/-/soap-1.0.0.tgz#3273d8cb7bcbe99a69ad9a35fc6b087a9dc3a316"
+  integrity sha512-GB5GuKjWFtAPP0IaM4tKUvdF4dFlaz4iujLPg0DsCy9qAAgm5/g+SI+P9e6igWWwXZ74CC5Uo0VEEz8lte0CJA==
   dependencies:
     axios-ntlm "^1.2.0"
     debug "^4.3.2"
-    formidable "^2.0.1"
+    formidable "^3.2.4"
     get-stream "^6.0.1"
     lodash "^4.17.21"
     sax ">=0.6"
     strip-bom "^3.0.0"
     uuid "^8.3.2"
     whatwg-mimetype "3.0.0"
-    xml-crypto "^2.1.3"
+    xml-crypto "^3.0.0"
 
 socks-proxy-agent@^6.0.0, socks-proxy-agent@^6.1.1:
   version "6.1.1"
@@ -9978,12 +9955,12 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
 
-xml-crypto@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-2.1.3.tgz#6a7272b610ea3e4ea7f13e9e4876f1b20cbc32c8"
-  integrity sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==
+xml-crypto@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-3.0.1.tgz#1d4852b040e80413d8058e2917eddd9f17a00b8b"
+  integrity sha512-7XrwB3ujd95KCO6+u9fidb8ajvRJvIfGNWD0XLJoTWlBKz+tFpUzEYxsN+Il/6/gHtEs1RgRh2RH+TzhcWBZUw==
   dependencies:
-    "@xmldom/xmldom" "^0.7.0"
+    "@xmldom/xmldom" "^0.8.5"
     xpath "0.0.32"
 
 xml-name-validator@^3.0.0:


### PR DESCRIPTION
`qs` was a downstream dependency of `soap`, and had a [CVE](https://github.com/prismatic-io/spectral/security/dependabot/23). This bumps `soap` to latest, and latest `soap` does not have `qs` as a dependency.

I verified that components generated via `prism` with this change are identical to those generated by an older version.