### PR TITLE
Re-add data property to JSON Form results

### DIFF
--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -39,6 +39,10 @@ export type JSONForm = {
    * and the layout. See https://jsonforms.io/docs/uischema/
    */
   uiSchema: UISchemaElement;
+  /**
+   * Optional default data to use in the inputs of your form
+   */
+  data?: Record<string, unknown>;
 };
 
 export type DynamicObjectSelection = string;


### PR DESCRIPTION
`data` will be used to supply default values to the inputs in a form.