### PR TITLE
Fix blank data payloads for raw request actions

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -172,7 +172,7 @@ export const sendRawRequest = async (
       ...authorizationHeaders,
     },
     params: util.types.keyValPairListToObject(values.queryParams),
-    data: payload,
+    data: payload || undefined,
   });
 };
 


### PR DESCRIPTION
When a raw request action makes a request to an HTTP endpoint, but does not have a payload, `payload` is an empty string, `""`, which axios apparently serializes into `"\"\""`. That's usually fine -- you either specify a real payload, or you are doing a GET or DELETE request, and the HTTP body is ignored by the server. 

_However_, some APIs (looking at you, Shopify) will reject a GET or DELETE request if it contains any body in the request.

If the payload is an empty string, this causes the request to actually send nothing (and not the two-character `""` as the body).