### PR TITLE
Allow createConnection to contain tokens, so you can test OAuth connections

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.3.7",
+  "version": "7.3.8",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -34,11 +34,13 @@ import { spyOn } from "jest-mock";
 
 export const createConnection = <T extends ConnectionDefinition>(
   { key }: T,
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
+  tokenValues?: Record<string, unknown>
 ): ConnectionValue => ({
   configVarKey: "",
   key,
   fields: values,
+  token: tokenValues,
 });
 
 /**


### PR DESCRIPTION
Most connections contain all of their data in `.fields`. OAuth connections have additional data in `.token`. This allows you to create a connection with `.token` populated. For example,

```
const sfConnection = createConnection(
  salesforceOAuth,
  {},
  {
    instance_url: "https://example.my.salesforce.com",
    access_token: "abc-123",
  }
);
```