### PR TITLE
Bump the version of webpack that is templated for new components

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/component/index.ts
+++ b/packages/generator-spectral/src/generators/component/index.ts
@@ -118,7 +118,7 @@ class ComponentGenerator extends Generator {
       "ts-jest": "27.0.3",
       "ts-loader": "9.2.3",
       typescript: "4.3.5",
-      webpack: "5.75.0",
+      webpack: "5.76.3",
       "webpack-cli": "5.0.1",
       eslint: "6.8.0",
     });


### PR DESCRIPTION
When initializing a new component, NPM throws a warning that webpack version 5.75.0 and below has an active CVE. This bumps webpack to current latest.