### PR TITLE
Handle binary files better in raw request actions

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -42,7 +42,9 @@ const toFormData = (
   const form = new FormData();
   (formData || []).map(({ key, value }) => form.append(key, value));
   (fileData || []).map(({ key, value }) =>
-    form.append(key, value, { filename: key })
+    form.append(key, util.types.toBufferDataPayload(value).data, {
+      filename: key,
+    })
   );
   return form;
 };

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -401,7 +401,7 @@ const keyValPairListToObject = <TValue = unknown>(
  * @param value The value to test
  * @returns This function returns true if `value` is a DataPayload object, and false otherwise.
  */
-const isBufferDataPayload = (value: unknown): boolean => {
+const isBufferDataPayload = (value: unknown): value is DataPayload => {
   return value instanceof Object && "data" in value;
 };
 
@@ -419,7 +419,7 @@ const isBufferDataPayload = (value: unknown): boolean => {
  */
 const toBufferDataPayload = (value: unknown): DataPayload => {
   if (isBufferDataPayload(value)) {
-    return value as DataPayload;
+    return value;
   }
 
   if (typeof value === "string") {


### PR DESCRIPTION
Spectral's HTTP client is used to generate "Raw Request" actions for many components. It includes a "File Data" input, where users can provide file names and contents to upload as part of a multi-part form POST.

The HTTP client does _not_ currently handle binary files https://prismatic.io/docs/custom-components/writing-custom-components/#handling-binary-files-in-custom-components . Binary files (images, PDFs, mp3s, etc) are passed between steps as objects of the form `{data: Buffer, contentType: string}`. Currently, if you reference one of these objects in a Raw Request action, you get a cryptic error because axios doesn't understand the object format. 

This change will take an input, and if it is already `{data: Buffer, contentType: string}`, will keep it in that form, and if it is a string, etc., will turn it into `{data: Buffer, contentType: string}`. Then, it references the object's `.data`, and feeds that buffer to Axios.

I've tested this change with our Pipedrive component and verified that I can upload both files that are references to images, and files whose contents I specify as a string.