### PR TITLE
Add an input for form data file names

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -37,13 +37,14 @@ const toAuthorizationHeaders = (
 
 const toFormData = (
   formData: KeyValuePair<unknown>[],
-  fileData: KeyValuePair<unknown>[]
+  fileData: KeyValuePair<unknown>[],
+  fileDataFileNames: Record<string, string> = {}
 ): FormData => {
   const form = new FormData();
   (formData || []).map(({ key, value }) => form.append(key, value));
   (fileData || []).map(({ key, value }) =>
     form.append(key, util.types.toBufferDataPayload(value).data, {
-      filename: key,
+      filename: fileDataFileNames?.[key] || key,
     })
   );
   return form;
@@ -149,7 +150,7 @@ export const sendRawRequest = async (
 
   const payload =
     !isEmpty(values.formData) || !isEmpty(values.fileData)
-      ? toFormData(values.formData, values.fileData)
+      ? toFormData(values.formData, values.fileData, values.fileDataFileNames)
       : values.data;
 
   const client = createClient({

--- a/packages/spectral/src/clients/http/inputs.ts
+++ b/packages/spectral/src/clients/http/inputs.ts
@@ -153,6 +153,18 @@ export const fileData = input({
   example: `[{key: "example.txt", value: "My File Contents"}]`,
 });
 
+export const fileDataFileNames = input({
+  label: "File Data File Names",
+  placeholder: "The file name to apply to a file",
+  type: "string",
+  collection: "keyvaluelist",
+  required: false,
+  comments:
+    "File names to apply to the file data inputs. Keys must match the file data keys above.",
+  clean: (values: any) =>
+    values ? util.types.keyValPairListToObject<string>(values) : undefined,
+});
+
 export const debugRequest = input({
   label: "Debug Request",
   type: "boolean",
@@ -167,6 +179,7 @@ export const inputs = {
   data,
   formData,
   fileData,
+  fileDataFileNames,
   queryParams,
   headers,
   responseType,


### PR DESCRIPTION
When you include a file in a form-data POST or PUT request, that file can include a `filename`. That `filename` is often used by a third-party API to determine MIME type, present the file in their app, etc.

Up until now, the `filename` was always set to the file's `key`. That resulted, in many apps, in a file simply named `file`.

This allows you to optionally specify a name for a file that you're uploading.

<img width="601" alt="Screen Shot 2023-04-13 at 10 32 26 AM" src="https://user-images.githubusercontent.com/3622586/231832711-7f56294d-fb82-4e95-b3fb-3f7516290bca.png">
