### PR TITLE
Add PKCE support to OAuth 2.0 Authorization Code flow

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -5,6 +5,11 @@ export enum OAuth2Type {
   AuthorizationCode = "authorization_code",
 }
 
+export enum OAuth2PkceMethod {
+  Plain = "plain",
+  S256 = "S256",
+}
+
 interface BaseConnectionDefinition {
   key: string;
   label: string;
@@ -22,6 +27,8 @@ export interface DefaultConnectionDefinition extends BaseConnectionDefinition {
 interface OAuth2AuthorizationCodeConnectionDefinition
   extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.AuthorizationCode;
+  /** The PKCE method (S256 or plain) that this OAuth 2.0 connection uses (if any) */
+  oauth2PkceMethod?: OAuth2PkceMethod;
   inputs: {
     authorizeUrl: ConnectionInput;
     tokenUrl: ConnectionInput;


### PR DESCRIPTION
This will allow a component developer to enable the [PKCE extension](https://oauth.net/2/pkce/) for the OAuth 2.0 Authorization Code flow. When enabled, users who complete the OAuth 2.0 auth code flow will bring a `code_challenge` to the third-party when authenticating. When an authorization code is exchanged for an access token, the third-party will be presented a corresponding `code_verifier`.