### PR TITLE
Add Unix epoch support for util.types.toDate() and support string dates for comparison operators

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.5",
+  "version": "7.6.6",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"
@@ -40,7 +40,7 @@
     "@jsonforms/core": "3.0.0",
     "axios": "0.27.2",
     "axios-retry": "3.2.5",
-    "date-fns": "2.29.3",
+    "date-fns": "2.30.0",
     "form-data": "4.0.0",
     "jest-mock": "27.0.3",
     "soap": "1.0.0",

--- a/packages/spectral/src/conditionalLogic/index.ts
+++ b/packages/spectral/src/conditionalLogic/index.ts
@@ -6,8 +6,16 @@ import {
   UnaryOperator,
   BinaryOperator,
 } from "./types";
-import { isBefore, isAfter, parse, parseISO, isValid } from "date-fns";
+import {
+  isBefore,
+  isAfter,
+  parse,
+  parseISO,
+  isValid,
+  isEqual as isDateEqual,
+} from "date-fns";
 import _ from "lodash";
+import util from "../util";
 
 export type ValidationResult = [boolean] | [boolean, string];
 
@@ -244,11 +252,11 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case BinaryOperator.doesNotEndWith:
           return !`${right}`.endsWith(`${left}`);
         case BinaryOperator.dateTimeAfter:
-          return isAfter(left, right);
+          return isAfter(util.types.toDate(left), util.types.toDate(right));
         case BinaryOperator.dateTimeBefore:
-          return isBefore(left, right);
+          return isBefore(util.types.toDate(left), util.types.toDate(right));
         case BinaryOperator.dateTimeSame:
-          return left == right;
+          return isDateEqual(util.types.toDate(left), util.types.toDate(right));
         default:
           throw new Error(`Invalid operator: '${operator}'`);
       }

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -328,7 +328,7 @@ const toDate = (value: unknown): Date => {
     return value;
   }
 
-  if (value && isNumber(value)) {
+  if (isNumber(value) && toNumber(value)) {
     return fromUnixTime(toNumber(value));
   }
 

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -8,6 +8,7 @@
 import parseISODate from "date-fns/parseISO";
 import dateIsValid from "date-fns/isValid";
 import dateIsDate from "date-fns/isDate";
+import fromUnixTime from "date-fns/fromUnixTime";
 import { configure } from "safe-stable-stringify";
 import { isWebUri } from "valid-url";
 import {
@@ -312,11 +313,12 @@ const toBigInt = (value: unknown): BigInt => {
 const isDate = (value: unknown): value is Date => dateIsDate(value);
 
 /**
- * This function parses an ISO date if possible, or throws an error if the value provided
+ * This function parses an ISO date or UNIX epoch timestamp if possible, or throws an error if the value provided
  * cannot be coerced into a Date object.
  *
  * - `util.types.toDate(new Date('1995-12-17T03:24:00'))` will return `Date('1995-12-17T09:24:00.000Z')` since a `Date` object was passed in.
  * - `util.types.toDate('2021-03-20')` will return `Date('2021-03-20T05:00:00.000Z')` since a valid ISO date was passed in.
+ * - `util.types.toDate(1616198400) will return `Date('2021-03-20T00:00:00.000Z')` since a UNIX epoch timestamp was passed in.
  * - `parseISODate('2021-03-20-05')` will throw an error since `value` was not a valid ISO date.
  * @param value The value to turn into a date.
  * @returns The date equivalent of `value`.
@@ -324,6 +326,10 @@ const isDate = (value: unknown): value is Date => dateIsDate(value);
 const toDate = (value: unknown): Date => {
   if (isDate(value)) {
     return value;
+  }
+
+  if (value && isNumber(value)) {
+    return fromUnixTime(toNumber(value));
   }
 
   if (typeof value === "string") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,6 +535,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.21.0":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.5.tgz#8492dddda9644ae3bda3b45eabe87382caee7200"
+  integrity sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -3168,10 +3175,12 @@ date-fns@2.28.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
-date-fns@2.29.3:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+date-fns@2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 dateformat@^4.5.0:
   version "4.6.3"
@@ -8018,6 +8027,11 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4:
   version "0.13.9"


### PR DESCRIPTION
The library that we use for datatime comparison, `date-fns`, dropped support for string dates (like `2023-05-23`) in v2.0.0. This PR expands our support for various timestamp formats. We can now compare `Date()` objects, ISO strings (like `"2030-03-20T12:50:30.105Z"`), or Unix epoch timestamps (like `1631568050` or its string equivalent).