### PR TITLE
Handle operationIds with leading numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "tsd": "turbo run tsd",
     "check": "turbo run check",
     "lint": "turbo run lint",
-    "docs": "turbo run docs"
+    "docs": "turbo run docs",
+    "all": "turbo run all"
   },
   "devDependencies": {
     "turbo": "^1.8.5"

--- a/packages/generator-spectral/jest.config.ts
+++ b/packages/generator-spectral/jest.config.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import { defaults } from "jest-config";
 import type { Config } from "@jest/types";
 
@@ -7,8 +6,9 @@ const config: Config.InitialOptions = {
   testEnvironment: "node",
   testPathIgnorePatterns: [
     ...defaults.testPathIgnorePatterns,
+    "tmp",
     "templates",
-    ".*\.test\.js"
+    ".*.test.js",
   ],
 };
 

--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/formats/readers/openapi/actions.ts
+++ b/packages/generator-spectral/src/generators/formats/readers/openapi/actions.ts
@@ -1,9 +1,9 @@
 import { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { camelCase, isEmpty, startCase } from "lodash";
-import { toWords } from "number-to-words";
 import { getInputs } from "./inputs";
 import { Action, Input, stripUndefined } from "../../utils";
 import { WriterFunction } from "ts-morph";
+import { toGroupTag, toOperationName } from "./util";
 
 const buildPerformFunction = (
   pathTemplate: string,
@@ -61,13 +61,6 @@ const buildPerformFunction = (
       .writeLine("}");
 };
 
-/** Convert path to grouping tag. */
-const toGroupTag = (path: string): string =>
-  camelCase(path === "/" ? "root" : path.split("/")[1]).replace(
-    /^(\d+)/,
-    (_, match) => toWords(match)
-  );
-
 const buildAction = (
   path: string,
   verb: string,
@@ -77,7 +70,9 @@ const buildAction = (
     | OpenAPIV3_1.ParameterObject
   )[] = []
 ): Action => {
-  const operationName = camelCase(operation.operationId || `${verb} ${path}`);
+  const operationName = toOperationName(
+    operation.operationId || `${verb} ${path}`
+  );
 
   const { pathInputs, queryInputs, bodyInputs } = getInputs(
     operation,

--- a/packages/generator-spectral/src/generators/formats/readers/openapi/util.test.ts
+++ b/packages/generator-spectral/src/generators/formats/readers/openapi/util.test.ts
@@ -1,0 +1,11 @@
+import { toOperationName } from "./util";
+
+describe("toOperationName", () => {
+  it.each([
+    { value: "foo/bar", expected: "fooBar" },
+    { value: ",foo_bar", expected: "fooBar" },
+    { value: "12345foobar", expected: "one2345Foobar" },
+  ])("sanitizes operation ids", ({ value, expected }) => {
+    expect(toOperationName(value)).toEqual(expected);
+  });
+});

--- a/packages/generator-spectral/src/generators/formats/readers/openapi/util.ts
+++ b/packages/generator-spectral/src/generators/formats/readers/openapi/util.ts
@@ -1,0 +1,17 @@
+import { camelCase } from "lodash";
+import { toWords } from "number-to-words";
+
+/** Convert path to grouping tag. */
+export const toGroupTag = (path: string): string =>
+  camelCase(path === "/" ? "root" : path.split("/")[1]).replace(
+    /^(\d+)/,
+    (_, match) => toWords(match)
+  );
+
+export const toOperationName = (operationName: string): string =>
+  camelCase(
+    operationName.replace(
+      /^([0-9])(.+)$/,
+      (_, num, rest) => `${toWords(num)}${rest}`
+    )
+  );

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,10 @@
     },
     "docs": {
       "outputs": ["docs/**"]
+    },
+    "all": {
+      "dependsOn": ["check", "lint", "build", "test", "tsd"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
Variables cannot start with numbers so convert those to text, similar to what was done for the "action groups" (filenames).