### PR TITLE
isBufferDataPayload should return true only if the data property is a Buffer

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.6",
+  "version": "7.6.7",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -397,6 +397,26 @@ describe("util", () => {
       );
     });
 
+    it("detects buffer data payload missing optional content type", () => {
+      const payloadTypes = fc.record({ data: bufferArbitrary });
+      fc.assert(
+        fc.property(payloadTypes, (v) => {
+          expect(util.types.isBufferDataPayload(v)).toStrictEqual(true);
+        })
+      );
+    });
+
+    it("does not detect non-buffers as buffer data payloads", () => {
+      const payloadTypes = fc.record({
+        data: fc.oneof(fc.string(), fc.object()),
+      });
+      fc.assert(
+        fc.property(payloadTypes, (v) => {
+          expect(util.types.isBufferDataPayload(v)).toStrictEqual(false);
+        })
+      );
+    });
+
     it("coerces string to plain text buffer", () => {
       fc.assert(
         fc.property(fc.string(), (v) => {

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -402,14 +402,13 @@ const keyValPairListToObject = <TValue = unknown>(
 
 /**
  * This function tests if the object provided is a Prismatic `DataPayload` object.
- * A `DataPayload` object is an object with a `data` attribute, and optional `contentType` attribute.
+ * A `DataPayload` object is an object with a `data` attribute that is a Buffer, and optional `contentType` attribute.
  *
  * @param value The value to test
  * @returns This function returns true if `value` is a DataPayload object, and false otherwise.
  */
-const isBufferDataPayload = (value: unknown): value is DataPayload => {
-  return value instanceof Object && "data" in value;
-};
+const isBufferDataPayload = (value: unknown): value is DataPayload =>
+  value instanceof Object && "data" in value && Buffer.isBuffer(value["data"]);
 
 /**
  * Many libraries for third-party API that handle binary files expect `Buffer` objects.


### PR DESCRIPTION
`isBufferDataPayload` was misidentifying objects of the form 
```
{
  "data" : {
    "foo": "bar"
  }
}
```
as `DataPayload` objects because they are an object with a `data` property.

But, the check is missing a critical piece: the `data` property needs to be a `Buffer`. This change checks that the object's `data` property is a `Buffer`.