### PR TITLE
Require langauge for syntax highlighting for code inputs

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.7",
+  "version": "7.6.8",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -182,8 +182,24 @@ export interface CodeInputField extends BaseInputField {
   collection?: InputFieldCollection;
   /** Default value for this field. */
   default?: unknown;
-  /** Code language of this field. */
-  language?: string;
+  /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
+  language:
+    | "css"
+    | "graphql"
+    | "handlebars"
+    | "hcl"
+    | "html"
+    | "javascript"
+    | "json"
+    | "liquid"
+    | "markdown"
+    | "mysql"
+    | "pgsql"
+    | "plaintext"
+    | "sql"
+    | "typescript"
+    | "xml"
+    | "yaml";
   /** Dictates possible choices for the input. */
   model?: InputFieldChoice[];
   /** Clean function */


### PR DESCRIPTION
Inputs with `type: "code"` default to using `javascript` syntax highlighting when no `language` is specified. Code inputs are rarely JavaScript, though, and more commonly `graphql`, `sql`, `xml`, `html`, etc. This change requires a user to specify syntax highlighting language when an input of `type: "code"` is used, and includes the languages we support syntax highlighting for. Users can specify `plaintext` to indicate that they do not want syntax highlighting. 