### PR TITLE
Ensure correct docs links for public components

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.6.8",
+  "version": "7.6.9",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -27,8 +27,8 @@ import { convertComponent } from "./serverTypes/convert";
  * @param definition A ComponentDefinition type object, including display information, unique key, and a set of actions the component implements.
  * @returns This function returns a component object that has the shape the Prismatic API expects.
  */
-export const component = <T extends boolean>(
-  definition: ComponentDefinition<T>
+export const component = <TPublic extends boolean, TKey extends string>(
+  definition: ComponentDefinition<TPublic, TKey>
 ): ReturnType<typeof convertComponent> => convertComponent(definition);
 
 /**

--- a/packages/spectral/src/serverTypes/convert.ts
+++ b/packages/spectral/src/serverTypes/convert.ts
@@ -131,14 +131,14 @@ const convertConnection = ({
   };
 };
 
-export const convertComponent = <TPublic extends boolean>({
+export const convertComponent = <TPublic extends boolean, TKey extends string>({
   connections = [],
   actions = {},
   triggers = {},
   dataSources = {},
   hooks,
   ...definition
-}: ComponentDefinition<TPublic>): ServerComponent => {
+}: ComponentDefinition<TPublic, TKey>): ServerComponent => {
   const convertedActions = Object.entries(actions).reduce(
     (result, [actionKey, action]) => ({
       ...result,

--- a/packages/spectral/src/types-tests/ComponentDefinition.test-d.ts
+++ b/packages/spectral/src/types-tests/ComponentDefinition.test-d.ts
@@ -17,6 +17,6 @@ const publicDefinition = component({
     iconPath: "icon.png",
     category: "Application Connectors",
   },
-  documentationUrl: "https://example.com/docs",
+  documentationUrl: "https://prismatic.io/docs/components/public-definition/",
 });
 expectAssignable<Component>(publicDefinition);

--- a/packages/spectral/src/types/ComponentDefinition.ts
+++ b/packages/spectral/src/types/ComponentDefinition.ts
@@ -14,9 +14,12 @@ export interface ComponentHooks {
 }
 
 /** Defines attributes of a Component. */
-export type ComponentDefinition<TPublic extends boolean> = {
+export type ComponentDefinition<
+  TPublic extends boolean,
+  TKey extends string
+> = {
   /** Specifies unique key for this Component. */
-  key: string;
+  key: TKey;
   /** Specifies if this Component is available for all Organizations or only your own @default false */
   public?: TPublic;
   /** Defines how the Component is displayed in the Prismatic interface. */
@@ -34,7 +37,7 @@ export type ComponentDefinition<TPublic extends boolean> = {
 } & (TPublic extends true
   ? {
       /** Specified the URL for the Component Documentation. */
-      documentationUrl: string;
+      documentationUrl: `https://prismatic.io/docs/components/${TKey}/`;
     }
   : {
       documentationUrl?: string;


### PR DESCRIPTION
Mostly an internal-focused update. All of our public components have documentation links of the form `https://prismatic.io/docs/components/KEY`. We should put up guard rails to ensure new public components all have correct documentation URLs.