### PR TITLE
Do not template inputs for readOnly properties in OpenAPI-generate components

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",


### PR DESCRIPTION
An object can be defined in an OpenAPI spec with properties that are `readOnly`. It's handy to be able to reference that same object for a `requestBody` and for a return value (to prevent having to maintain two versions of the same object). But, we're currently templating out inputs for `readOnly` properties. We should filter out the `readOnly` properties as we generate inputs.