### PR TITLE
More strictly define collection/default type combinations for different InputFields

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/harness-testing.test.ts
+++ b/packages/spectral/src/harness-testing.test.ts
@@ -95,16 +95,15 @@ const defaultedInput = input({
   label: "Defaulted",
   type: "string",
   required: false,
-  default: DEFAULTED_VALUE,
+  default: DEFAULTED_VALUE.toString(),
 });
 
 const defaultedCleanInput = input({
   label: "Defaulted Clean",
   type: "string",
   required: false,
-  default: DEFAULTED_VALUE,
-  clean: (value) =>
-    util.types.isInt(value) ? util.types.toInt(value) : DEFAULTED_VALUE,
+  default: DEFAULTED_VALUE.toString(),
+  clean: (value) => (util.types.isInt(value) ? value : DEFAULTED_VALUE),
 });
 
 const fooAction = action({

--- a/packages/spectral/src/types-tests/ExtractValue.test-d.ts
+++ b/packages/spectral/src/types-tests/ExtractValue.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from "tsd";
-import { ExtractValue, KeyValuePair } from "../types/ActionInputParameters";
+import { ExtractValue } from "../types/ActionInputParameters";
+import { KeyValuePair } from "../types/Inputs";
 
 const scalar: ExtractValue<boolean, undefined> = Boolean();
 expectType<boolean>(scalar);

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -1,6 +1,11 @@
 import { Inputs } from ".";
 import { ConditionalExpression } from "./conditional-logic";
-import { InputFieldCollection, InputCleanFunction, Connection } from "./Inputs";
+import {
+  InputFieldCollection,
+  InputCleanFunction,
+  Connection,
+  KeyValuePair,
+} from "./Inputs";
 
 /**
  * Collection of input parameters.
@@ -28,17 +33,3 @@ export type ExtractValue<
   : TCollection extends "valuelist"
   ? TType[]
   : TType;
-
-/**
- * KeyValuePair input parameter type.
- * This allows users to input multiple keys / values as an input.
- * To see an example of how this can be used, see the `tagging` input
- * of the `putObject` action of the AWS S3 component:
- * https://github.com/prismatic-io/examples/blob/main/components/aws-s3/src/actions.ts
- */
-export interface KeyValuePair<V = unknown> {
-  /** Key of the KeyValuePair */
-  key: string;
-  /** Value of the KeyValuePair */
-  value: V;
-}

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -109,102 +109,110 @@ interface BaseInputField {
   required?: boolean;
 }
 
-export interface StringInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "string";
+type CollectionOptions<T> =
+  | SingleValue<T>
+  | ValueListCollection<T>
+  | KeyValueListCollection<T>;
+
+interface SingleValue<T> {
   /** Collection type of the InputField */
-  collection?: InputFieldCollection;
+  collection?: undefined;
   /** Default value for this field. */
-  default?: unknown;
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
+  default?: T;
 }
 
-export interface DataInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "data";
+interface ValueListCollection<T> {
   /** Collection type of the InputField */
-  collection?: InputFieldCollection;
+  collection: "valuelist";
   /** Default value for this field. */
-  default?: unknown;
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
+  default?: T[];
 }
 
-export interface TextInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "text";
+interface KeyValueListCollection<T> {
   /** Collection type of the InputField */
-  collection?: InputFieldCollection;
+  collection: "keyvaluelist";
   /** Default value for this field. */
-  default?: unknown;
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
+  default?: { key: string; value: T }[];
 }
 
-export interface PasswordInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "password";
-  /** Collection type of the InputField */
-  collection?: InputFieldCollection;
-  /** Default value for this field. */
-  default?: unknown;
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
-}
+export type StringInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "string";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
 
-export interface BooleanInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "boolean";
-  /** Collection type of the InputField */
-  collection?: InputFieldCollection;
-  /** Default value for this field. */
-  default?: unknown;
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
-}
+export type DataInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "data";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
+
+export type TextInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "text";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
+
+export type PasswordInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "password";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
+
+export type BooleanInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "boolean";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
 
 /** Defines attributes of a CodeInputField. */
-export interface CodeInputField extends BaseInputField {
-  /** Data type the InputField will collect. */
-  type: "code";
-  /** Collection type of the InputField */
-  collection?: InputFieldCollection;
-  /** Default value for this field. */
-  default?: unknown;
-  /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
-  language:
-    | "css"
-    | "graphql"
-    | "handlebars"
-    | "hcl"
-    | "html"
-    | "javascript"
-    | "json"
-    | "liquid"
-    | "markdown"
-    | "mysql"
-    | "pgsql"
-    | "plaintext"
-    | "sql"
-    | "typescript"
-    | "xml"
-    | "yaml";
-  /** Dictates possible choices for the input. */
-  model?: InputFieldChoice[];
-  /** Clean function */
-  clean?: InputCleanFunction<this["default"]>;
-}
+export type CodeInputField = BaseInputField &
+  CollectionOptions<string> & {
+    /** Data type the InputField will collect. */
+    type: "code";
+    /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
+    language:
+      | "css"
+      | "graphql"
+      | "handlebars"
+      | "hcl"
+      | "html"
+      | "javascript"
+      | "json"
+      | "liquid"
+      | "markdown"
+      | "mysql"
+      | "pgsql"
+      | "plaintext"
+      | "sql"
+      | "typescript"
+      | "xml"
+      | "yaml";
+    /** Dictates possible choices for the input. */
+    model?: InputFieldChoice[];
+    /** Clean function */
+    clean?: InputCleanFunction<unknown>;
+  };
 
 /** Defines attributes of a ConditionalInputField. */
 export interface ConditionalInputField extends BaseInputField {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -1,6 +1,20 @@
 import { ConditionalExpression } from "./conditional-logic";
 import { JsonSchema, UISchemaElement } from "@jsonforms/core";
 
+/**
+ * KeyValuePair input parameter type.
+ * This allows users to input multiple keys / values as an input.
+ * To see an example of how this can be used, see the `tagging` input
+ * of the `putObject` action of the AWS S3 component:
+ * https://github.com/prismatic-io/examples/blob/main/components/aws-s3/src/actions.ts
+ */
+export interface KeyValuePair<V = unknown> {
+  /** Key of the KeyValuePair */
+  key: string;
+  /** Value of the KeyValuePair */
+  value: V;
+}
+
 export type Element = {
   key: string;
   label?: string;
@@ -132,7 +146,7 @@ interface KeyValueListCollection<T> {
   /** Collection type of the InputField */
   collection: "keyvaluelist";
   /** Default value for this field. */
-  default?: { key: string; value: T }[];
+  default?: KeyValuePair<T>[];
 }
 
 export type StringInputField = BaseInputField &


### PR DESCRIPTION
This PR focuses on two goals:
- The type of `default` is now known statically for all InputFields.
- The types of the `collection` and `default` properties are correctly coupled.

Other notes:
- `DataInputField` uses `Buffer` as its generic type instead of `string` like the other inputs.
- The `clean` functions remain the type `InputCleanFunction<unknown(, unknown)>`.