### PR TITLE
Bump default Jest version for custom components

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/component/index.ts
+++ b/packages/generator-spectral/src/generators/component/index.ts
@@ -115,10 +115,10 @@ class ComponentGenerator extends Generator {
       "@prismatic-io/eslint-config-spectral",
     ]);
     await this.addDevDependencies({
-      "@types/jest": "26.0.24",
+      "@types/jest": "29.5.11",
       "copy-webpack-plugin": "11.0.0",
-      jest: "27.0.6",
-      "ts-jest": "27.0.3",
+      jest: "29.7.0",
+      "ts-jest": "29.1.1",
       "ts-loader": "9.2.3",
       typescript: "4.3.5",
       webpack: "5.76.3",


### PR DESCRIPTION
Version 27.0.x of Jest has some deficiencies when processing ECMAScript modules that is solved in more recent versions. This bumps the default version of Jest that is installed when a new custom component is initialized. 