### PR TITLE
On Premise Connection Configuration

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@apidevtools/swagger-parser": "10.1.0",
-    "@prismatic-io/spectral": "8.0.3",
+    "@prismatic-io/spectral": "8.0.4",
     "lodash": "4.17.21",
     "number-to-words": "1.2.4",
     "openapi-types": "11.0.1",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -25,6 +25,7 @@ import {
   TriggerPayload,
   DataSourceConfigVar,
   ConfigPages,
+  OnPremiseConnectionDefinition,
 } from "./types";
 import { convertComponent } from "./serverTypes/convert";
 import { convertIntegration } from "./serverTypes/convertIntegration";
@@ -181,6 +182,16 @@ export const input = <T extends InputFieldDefinition>(definition: T): T =>
  * @returns This functions validates the shape of the `definition` object provided and returns the same connection object.
  */
 export const connection = <T extends DefaultConnectionDefinition>(
+  definition: T
+): T => definition;
+
+/**
+ * For information on writing custom component connections using on-premise resources, see
+ * https://prismatic.io/docs/custom-components/writing-custom-components/#adding-connections.
+ * @param definition An OnPremiseConnectionDefinition object that describes the type of a connection for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
+ * @returns This function validates the shape of the `definition` object provided and returns the same connection object.
+ */
+export const onPremiseConnection = <T extends OnPremiseConnectionDefinition>(
   definition: T
 ): T => definition;
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -206,7 +206,7 @@ export interface Connection {
   comments?: string;
   oauth2Type?: OAuth2Type;
   iconPath?: string;
-  inputs: (Input & { shown?: boolean })[];
+  inputs: (Input & { shown?: boolean; onPremiseControlled?: boolean })[];
 }
 
 export interface ConnectionValue {

--- a/packages/spectral/src/types-tests/ConnectionDefinition.test-d.ts
+++ b/packages/spectral/src/types-tests/ConnectionDefinition.test-d.ts
@@ -1,7 +1,7 @@
-import { expectAssignable } from "tsd";
-import { connection, KeyValuePair } from "..";
+import { expectAssignable, expectNotAssignable } from "tsd";
+import { onPremiseConnection, OnPremiseConnectionDefinition } from "..";
 
-const onPremiseConnectionDef = connection({
+const valid = onPremiseConnection({
   key: "basic",
   label: "Basic Connection",
   inputs: {
@@ -11,6 +11,7 @@ const onPremiseConnectionDef = connection({
       type: "string",
       required: true,
       shown: true,
+      onPremiseControlled: true,
       example: "192.168.0.1",
     },
     port: {
@@ -19,6 +20,7 @@ const onPremiseConnectionDef = connection({
       type: "string",
       required: true,
       shown: true,
+      onPremiseControlled: true,
       default: "1433",
     },
     username: {
@@ -36,28 +38,27 @@ const onPremiseConnectionDef = connection({
       shown: true,
     },
   },
-  onPremiseConfig: {
-    replacesInputs: ["host", "port"],
-    transform: (opc, inputConfig) => {
-      return {
-        ...inputConfig,
-        host: opc.host,
-        port: opc.port,
-      };
+});
+expectAssignable<OnPremiseConnectionDefinition>(valid);
+
+const invalid = {
+  key: "basic",
+  label: "Basic Connection",
+  inputs: {
+    username: {
+      label: "Username",
+      placeholder: "Username",
+      type: "string",
+      required: false,
+      shown: true,
+    },
+    password: {
+      label: "Password",
+      placeholder: "Password",
+      type: "password",
+      required: false,
+      shown: true,
     },
   },
-});
-type ExpectedInputValueType =
-  | string
-  | string[]
-  | KeyValuePair<string>[]
-  | undefined;
-type ExpectedConfigType = { [key: string]: ExpectedInputValueType };
-type ExpectedOnPrem = { host: string; port: string };
-type ExpectedFunc = (
-  opc: ExpectedOnPrem,
-  inp: ExpectedConfigType
-) => ExpectedConfigType;
-expectAssignable<ExpectedFunc | undefined>(
-  onPremiseConnectionDef.onPremiseConfig?.transform
-);
+};
+expectNotAssignable<OnPremiseConnectionDefinition>(invalid);

--- a/packages/spectral/src/types-tests/ConnectionDefinition.test-d.ts
+++ b/packages/spectral/src/types-tests/ConnectionDefinition.test-d.ts
@@ -1,0 +1,63 @@
+import { expectAssignable } from "tsd";
+import { connection, KeyValuePair } from "..";
+
+const onPremiseConnectionDef = connection({
+  key: "basic",
+  label: "Basic Connection",
+  inputs: {
+    host: {
+      label: "Host",
+      placeholder: "Host",
+      type: "string",
+      required: true,
+      shown: true,
+      example: "192.168.0.1",
+    },
+    port: {
+      label: "Port",
+      placeholder: "Port",
+      type: "string",
+      required: true,
+      shown: true,
+      default: "1433",
+    },
+    username: {
+      label: "Username",
+      placeholder: "Username",
+      type: "string",
+      required: false,
+      shown: true,
+    },
+    password: {
+      label: "Password",
+      placeholder: "Password",
+      type: "password",
+      required: false,
+      shown: true,
+    },
+  },
+  onPremiseConfig: {
+    replacesInputs: ["host", "port"],
+    transform: (opc, inputConfig) => {
+      return {
+        ...inputConfig,
+        host: opc.host,
+        port: opc.port,
+      };
+    },
+  },
+});
+type ExpectedInputValueType =
+  | string
+  | string[]
+  | KeyValuePair<string>[]
+  | undefined;
+type ExpectedConfigType = { [key: string]: ExpectedInputValueType };
+type ExpectedOnPrem = { host: string; port: string };
+type ExpectedFunc = (
+  opc: ExpectedOnPrem,
+  inp: ExpectedConfigType
+) => ExpectedConfigType;
+expectAssignable<ExpectedFunc | undefined>(
+  onPremiseConnectionDef.onPremiseConfig?.transform
+);

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -18,7 +18,25 @@ interface BaseConnectionDefinition {
   oauth2Type?: OAuth2Type;
 }
 
+interface OnPremiseConnectionInfo {
+  host: string;
+  port: string;
+}
+
+type ConnectionValues<T extends Record<string, ConnectionInput>> = {
+  [Key in keyof T]: T[Key]["default"];
+};
+
+interface OnPremiseConfig<T extends Record<string, ConnectionInput>> {
+  replacesInputs: (keyof T)[];
+  transform: (
+    opa: OnPremiseConnectionInfo,
+    inConfig: ConnectionValues<T>
+  ) => ConnectionValues<T>;
+}
+
 export interface DefaultConnectionDefinition extends BaseConnectionDefinition {
+  onPremiseConfig?: OnPremiseConfig<this["inputs"]>;
   inputs: {
     [key: string]: ConnectionInput;
   };

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -18,26 +18,19 @@ interface BaseConnectionDefinition {
   oauth2Type?: OAuth2Type;
 }
 
-interface OnPremiseConnectionInfo {
-  host: string;
-  port: string;
-}
-
-type ConnectionValues<T extends Record<string, ConnectionInput>> = {
-  [Key in keyof T]: T[Key]["default"];
-};
-
-interface OnPremiseConfig<T extends Record<string, ConnectionInput>> {
-  replacesInputs: (keyof T)[];
-  transform: (
-    opa: OnPremiseConnectionInfo,
-    inConfig: ConnectionValues<T>
-  ) => ConnectionValues<T>;
-}
-
 export interface DefaultConnectionDefinition extends BaseConnectionDefinition {
-  onPremiseConfig?: OnPremiseConfig<this["inputs"]>;
   inputs: {
+    [key: string]: ConnectionInput;
+  };
+}
+
+type OnPremiseConnectionInput = ConnectionInput & { onPremiseControlled: true };
+
+export interface OnPremiseConnectionDefinition
+  extends BaseConnectionDefinition {
+  inputs: {
+    host: OnPremiseConnectionInput;
+    port: OnPremiseConnectionInput;
     [key: string]: ConnectionInput;
   };
 }
@@ -75,5 +68,5 @@ export type OAuth2ConnectionDefinition =
 
 export type ConnectionDefinition =
   | DefaultConnectionDefinition
-  | OAuth2AuthorizationCodeConnectionDefinition
-  | OAuth2ClientCredentialConnectionDefinition;
+  | OnPremiseConnectionDefinition
+  | OAuth2ConnectionDefinition;


### PR DESCRIPTION
Adds `onPremiseConfig` optional metadata to enable on prem variants of connections. One shortcoming of the currently implementation is that the `replacesInputs` type doesn't have enough type inference to restrict it's array members to the keys of the `inputs` field. An attempt to address that exists on branch `rm/sc-18076/onprem-connections-generics` but it has tradeoffs.