### PR TITLE
Add no-unused-vars rule to eslint

### DIFF
--- a/packages/eslint-config-spectral/package.json
+++ b/packages/eslint-config-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/eslint-config-spectral",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint config for building Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/eslint-config-spectral/src/index.ts
+++ b/packages/eslint-config-spectral/src/index.ts
@@ -31,6 +31,7 @@ module.exports = {
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-base-to-string": "off",
+    "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/prefer-nullish-coalescing": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
   },


### PR DESCRIPTION
When generating a component from an OpenAPI spec, some action files will include an import of `util` from `@prismatic-io/spectral`, but will not use `util` in inputs. Running a subsequent `npm run format` of the generated project, then, yields `@typescript-eslint/no-unused-vars` errors. This downgrades those errors to warnings so the format can continue to run.