### PR TITLE
Bump default Jest version for newly initialized code-native integrations

### DIFF
--- a/packages/generator-spectral/package.json
+++ b/packages/generator-spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/generator-spectral",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Yeoman generator for scaffolding out Prismatic components",
   "keywords": [
     "prismatic",

--- a/packages/generator-spectral/src/generators/formats/index.ts
+++ b/packages/generator-spectral/src/generators/formats/index.ts
@@ -94,10 +94,10 @@ class FormatsGenerator extends Generator {
       "@prismatic-io/eslint-config-spectral",
     ]);
     await this.addDevDependencies({
-      "@types/jest": "25.2.3",
-      "copy-webpack-plugin": "10.2.4",
-      jest: "26.6.3",
-      "ts-jest": "26.4.0",
+      "@types/jest": "29.5.11",
+      "copy-webpack-plugin": "11.0.0",
+      jest: "29.7.0",
+      "ts-jest": "29.1.1",
       "ts-loader": "9.3.0",
       typescript: "4.6.3",
       webpack: "5.72.0",

--- a/packages/generator-spectral/src/generators/integration/index.ts
+++ b/packages/generator-spectral/src/generators/integration/index.ts
@@ -135,10 +135,10 @@ class IntegrationGenerator extends Generator {
       "@prismatic-io/eslint-config-spectral",
     ]);
     await this.addDevDependencies({
-      "@types/jest": "26.0.24",
+      "@types/jest": "29.5.11",
       "copy-webpack-plugin": "11.0.0",
-      jest: "27.0.6",
-      "ts-jest": "27.0.3",
+      jest: "29.7.0",
+      "ts-jest": "29.1.1",
       "ts-loader": "9.2.3",
       typescript: "4.3.5",
       webpack: "5.76.3",


### PR DESCRIPTION
Similar to #171, this bumps the default version of Jest that is templated when a code-native integration is initialized. This is needed, as a more recent version of Jest is required for compatibility with the latest `axios` library.