### PR TITLE
Simplify http debug logging

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.0.7-rc.2",
+  "version": "8.0.7",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.0.6",
+  "version": "8.0.7-rc.2",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"
@@ -44,6 +44,7 @@
     "form-data": "4.0.0",
     "jest-mock": "27.0.3",
     "lodash": "4.17.21",
+    "object-sizeof": "^2.6.4",
     "safe-stable-stringify": "2.3.1",
     "serialize-error": "8.1.0",
     "url-join": "5.0.0",

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -3,6 +3,8 @@ import axios, { AxiosResponse } from "axios";
 import { AxiosInstance, AxiosRequestConfig } from "axios";
 import axiosRetry, { IAxiosRetryConfig, exponentialDelay } from "axios-retry";
 import FormData from "form-data";
+import objectSizeof from "object-sizeof";
+
 import { action } from "../..";
 import { ActionInputParameters, Connection, KeyValuePair } from "../../types";
 import util from "../../util";
@@ -109,11 +111,47 @@ export const createClient = ({
 
   if (debug) {
     client.interceptors.request.use((request) => {
-      console.log(util.types.toJSON(request));
+      const { baseURL, headers, method, timeout, url, data } = request;
+      const dataSize = objectSizeof(data);
+      console.log(
+        util.types.toJSON(
+          {
+            type: "request",
+            baseURL,
+            headers,
+            method,
+            timeout,
+            url,
+            data:
+              dataSize > 1024 * 10 || Buffer.isBuffer(data)
+                ? `data <${dataSize} bytes>`
+                : data,
+          },
+          true,
+          true
+        )
+      );
       return request;
     });
     client.interceptors.response.use((response) => {
-      console.log(util.types.toJSON(response));
+      const { headers, status, statusText, data } = response;
+      const dataSize = objectSizeof(data);
+      console.log(
+        util.types.toJSON(
+          {
+            type: "response",
+            headers,
+            status,
+            statusText,
+            data:
+              dataSize > 1024 * 10 || Buffer.isBuffer(data)
+                ? `data <${dataSize} bytes>`
+                : data,
+          },
+          true,
+          true
+        )
+      );
       return response;
     });
   }

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -124,7 +124,7 @@ export const createClient = ({
             url,
             data:
               dataSize > 1024 * 10 || Buffer.isBuffer(data)
-                ? `data <${dataSize} bytes>`
+                ? `<data (${dataSize} bytes)>`
                 : data,
           },
           true,
@@ -145,7 +145,7 @@ export const createClient = ({
             statusText,
             data:
               dataSize > 1024 * 10 || Buffer.isBuffer(data)
-                ? `data <${dataSize} bytes>`
+                ? `<data (${dataSize} bytes)>`
                 : data,
           },
           true,

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -118,10 +118,10 @@ export const createClient = ({
           {
             type: "request",
             baseURL,
+            url,
             headers,
             method,
             timeout,
-            url,
             data:
               dataSize > 1024 * 10 || Buffer.isBuffer(data)
                 ? `<data (${dataSize} bytes)>`

--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -645,6 +645,41 @@ describe("util", () => {
       );
     });
 
+    it("serialize JSON with default options", () => {
+      const payload = { foo: "bar", baz: "buz" };
+      expect(util.types.toJSON(payload)).toStrictEqual(
+        `{\n  "baz": "buz",\n  "foo": "bar"\n}`
+      );
+    });
+
+    it("serialize JSON with pretty print and retain key order", () => {
+      const payload = { foo: "bar", baz: "buz" };
+      expect(util.types.toJSON(payload, true, true)).toStrictEqual(
+        `{\n  "foo": "bar",\n  "baz": "buz"\n}`
+      );
+    });
+
+    it("serialize JSON without pretty print and retain key order", () => {
+      const payload = { foo: "bar", baz: "buz" };
+      expect(util.types.toJSON(payload, false, true)).toStrictEqual(
+        '{"foo":"bar","baz":"buz"}'
+      );
+    });
+
+    it("serialize JSON with pretty print and don't retain key order", () => {
+      const payload = { foo: "bar", baz: "buz" };
+      expect(util.types.toJSON(payload, true, false)).toStrictEqual(
+        `{\n  "baz": "buz",\n  "foo": "bar"\n}`
+      );
+    });
+
+    it("serialize JSON without pretty print and don't retain key order", () => {
+      const payload = { foo: "bar", baz: "buz" };
+      expect(util.types.toJSON(payload, false, false)).toStrictEqual(
+        '{"baz":"buz","foo":"bar"}'
+      );
+    });
+
     it("removes functions", () => {
       const value = {
         foo: () => {

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -564,11 +564,20 @@ const isJSON = (value: string): boolean => {
  * This function accepts an arbitrary object/value and safely serializes it (handles cyclic references).
  *
  * @param value Arbitrary object/value to serialize.
+ * @param prettyPrint When true, convert to pretty printed JSON with 2 spaces and newlines. When false, JSON is compact.
+ * @param retainKeyOrder When true, the order of keys in the JSON output will be the same as the order in the input object.
  * @returns JSON serialized text that can be safely logged.
  */
-const toJSON = (value: unknown): string => {
-  const stringify = configure({ circularValue: undefined });
-  return stringify(value, null, 2);
+const toJSON = (
+  value: unknown,
+  prettyPrint = true,
+  retainKeyOrder = false
+): string => {
+  const stringify = configure({
+    circularValue: undefined,
+    deterministic: !retainKeyOrder,
+  });
+  return prettyPrint ? stringify(value, null, 2) : stringify(value);
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,6 +2792,14 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz"
@@ -5092,7 +5100,7 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -7452,6 +7460,13 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-sizeof@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/object-sizeof/-/object-sizeof-2.6.4.tgz#cdcb6697ac20978ddfa57d6d4f5fae8e7b8509dc"
+  integrity sha512-YuJAf7Bi61KROcYmXm8RCeBrBw8UOaJDzTm1gp0eU7RjYi1xEte3/Nmg/VyPaHcJZ3sNojs1Y0xvSrgwkLmcFw==
+  dependencies:
+    buffer "^6.0.3"
 
 object.assign@^4.1.4:
   version "4.1.4"


### PR DESCRIPTION
Currently, if you select `debug: true` in a `createClient` function, you can run out of memory if you request sufficiently large binary files (i.e. a several MB PDF file). This is due to the JSON serialization of the PDF file's `Buffer`.

This PR simplifies or extends a few things:

1. When `debug: true` is enabled for an HTTP client, extraneous properties of `request` and `response` are no longer logged. Axios provides lots of metadata about the request (like `maxFreeSockets` that simply aren't helpful when debugging a request in Prismatic. Relevant properties, like base URL, url, HTTP method, headers, status code and payload are retained. 
2. When a payload is "large" (> 10KB) or when it's a binary file (represented as a `Buffer`), the data will be represented as `<data (10000000 bytes)>`. Headers, URL, etc., will still be accessible.
3. Key order will be retained when logging out request/response (so, you'll see the most important things like URL and headers first, data after). `toJSON` has been updated so that you can optionally retain key order.