### PR TITLE
Add cleanObject util function

### DIFF
--- a/packages/spectral/src/util.test.ts
+++ b/packages/spectral/src/util.test.ts
@@ -955,4 +955,26 @@ describe("util", () => {
       expect(util.types.toObject(value)).toStrictEqual(value);
     });
   });
+
+  describe("cleanObject", () => {
+    it('removes undefined, null and "" by default', () => {
+      const input = {
+        foo: "bar",
+        bar: undefined,
+        baz: null,
+        buz: false,
+        biz: "",
+      };
+      const expectedResult = { foo: "bar", buz: false };
+      expect(util.types.cleanObject(input)).toStrictEqual(expectedResult);
+    });
+
+    it("allows for custom predicates to be defined", () => {
+      const input = { foo: 1, bar: 2, baz: 3 };
+      const predicate = (v: number) => v % 2 === 0;
+      const expectedResult = { foo: 1, baz: 3 };
+      const result = util.types.cleanObject(input, predicate);
+      expect(result).toStrictEqual(expectedResult);
+    });
+  });
 });

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -9,6 +9,7 @@ import parseISODate from "date-fns/parseISO";
 import dateIsValid from "date-fns/isValid";
 import dateIsDate from "date-fns/isDate";
 import fromUnixTime from "date-fns/fromUnixTime";
+import { omitBy } from "lodash";
 import { configure } from "safe-stable-stringify";
 import { isWebUri } from "valid-url";
 import {
@@ -613,6 +614,26 @@ export const toObject = (value: unknown): object => {
   }
 };
 
+/**
+ * This function removes any properties of an object that match a certain predicate.
+ * By default properties with values of undefined, null and "" are removed.
+ *
+ * - `cleanObject({foo: undefined, bar: "abc", baz: null, buz: ""})` will return `{bar: "abc"}`
+ * - `cleanObject({foo: 1, bar: 2, baz: 3}, v => v % 2 === 0)` will filter even number values, returning `{foo: 1, baz: 3}`
+ *
+ * @param obj A key-value object to remove properties from
+ * @param predicate A function that returns true for properties to remove. Defaults to removing properties with undefined, null and "" values.
+ * @returns An object with certain properties removed
+ */
+const cleanObject = (
+  obj: Record<string, unknown>,
+  predicate?: (v: any) => boolean
+) => {
+  const defaultPredicate = (v: any) =>
+    v === undefined || v === null || v === "";
+  return omitBy(obj, predicate || defaultPredicate);
+};
+
 export default {
   types: {
     isBool,
@@ -647,5 +668,6 @@ export default {
     isConnection,
     isElement,
     toObject,
+    cleanObject,
   },
 };


### PR DESCRIPTION
When sending payloads via HTTP client to an API, many paramaters are optional and we end up needing a series of spread operators when constructing the request payload. For example,

```
   const body: CreateListBody = {
      name,
      ...(content && content.length && { content }),
      ...(dueDate !== undefined && { due_date: dueDate }),
      due_date_time: dueDateTime,
      ...(priority !== undefined && { priority }),
      ...(assigneeInt !== undefined && { assignee: assigneeInt }),
      ...(status && status.length && { status }),
    };
```

This could be simplified with the new `cleanObject` function:

```
const body: CreateListBody = util.types.cleanObject({
   name,
   content,
   due_date: dueDate,
   due_date_time: dueDateTime,
   priority,
   assignee: assigneeInt,
   status
})
``` 

The `cleanObject` function defaults to removing properties with values `undefined`, `null` or `""`, but any predicate can be passed in. For example:

```
cleanObject({foo: 1, bar: 2, baz: 3}, v => v % 2 === 0)
// { foo: 1, baz: 3 }
```