### PR TITLE
Add HTTP status code and response headers to error handler

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -170,6 +170,8 @@ export const handleErrors = (error: unknown): unknown => {
     return {
       message,
       data: response?.data,
+      status: response?.status,
+      headers: response?.headers,
     };
   }
   return error;


### PR DESCRIPTION
When an error is thrown by Axios, it's handy to have access to the HTTP status and response headers returned from the API, without needing to parse the HTTP status code from the error message.

This makes it so when HTTP responses are caught by the generic HTTP client's `handleErrors` function, the response's status code and headers are included alongside the response's data in the error that is yielded. 

![image](https://github.com/prismatic-io/spectral/assets/3622586/d7c73121-c22c-4ba4-bcf8-6788bc1699a7)

That'll make [step-level error handling](https://prismatic.io/docs/building-integrations/#step-error-handling) easier.