### PR TITLE
Default ActionContext/DataSourceContext config var generics

### DIFF
--- a/packages/spectral/src/types/ActionPerformFunction.ts
+++ b/packages/spectral/src/types/ActionPerformFunction.ts
@@ -23,7 +23,9 @@ export type ActionPerformFunction<
 ) => Promise<TReturn>;
 
 /** Context provided to perform method containing helpers and contextual data */
-export type ActionContext<TConfigVars extends ConfigVarResultCollection> = {
+export type ActionContext<
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection
+> = {
   /** Logger for permanent logging; console calls are also captured */
   logger: ActionLogger;
   /** A a flow-specific key/value store that may be used to store small amounts of data that is persisted between Instance executions */

--- a/packages/spectral/src/types/DataSourcePerformFunction.ts
+++ b/packages/spectral/src/types/DataSourcePerformFunction.ts
@@ -8,11 +8,12 @@ import {
 } from ".";
 
 /** Context provided to perform method containing helpers and contextual data */
-export type DataSourceContext<TConfigVars extends ConfigVarResultCollection> =
-  Pick<
-    ActionContext<TConfigVars>,
-    "logger" | "customer" | "instance" | "user" | "configVars"
-  >;
+export type DataSourceContext<
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection
+> = Pick<
+  ActionContext<TConfigVars>,
+  "logger" | "customer" | "instance" | "user" | "configVars"
+>;
 
 /** Definition of the function to perform when a Data Source is invoked. */
 export type DataSourcePerformFunction<


### PR DESCRIPTION
This eases direct usage of the types, particularly in contexts where type inference won't be able to determine a more specific type.