### PR TITLE
Return custom headers from an action in a synchronous request

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -227,6 +227,7 @@ interface ServerPerformDataStructureReturn {
     | unknown;
   contentType?: string;
   statusCode?: number;
+  headers?: Record<string, string>;
   instanceState?: Record<string, unknown>;
   crossFlowState?: Record<string, unknown>;
   executionState?: Record<string, unknown>;
@@ -239,6 +240,7 @@ interface ServerPerformDataReturn {
   data: Buffer | string | unknown;
   contentType: string;
   statusCode?: number;
+  headers?: Record<string, string>;
   instanceState?: Record<string, unknown>;
   crossFlowState?: Record<string, unknown>;
   executionState?: Record<string, unknown>;

--- a/packages/spectral/src/types/ActionPerformReturn.ts
+++ b/packages/spectral/src/types/ActionPerformReturn.ts
@@ -6,6 +6,8 @@ export interface ActionPerformDataReturn<ReturnData> {
   contentType?: string;
   /** The HTTP Status code that will be used if this terminates a synchronous invocation  */
   statusCode?: number;
+  /** The HTTP headers that will be sent back if this terminates a synchronous invocation */
+  headers?: Record<string, string>;
   /** An optional object, the keys and values of which will be persisted in the flow-specific instanceState and available for subsequent actions and executions */
   instanceState?: Record<string, unknown>;
   /** An optional object, the keys and values of which will be persisted in the crossFlowState and available in any flow for subsequent actions and executions */


### PR DESCRIPTION
When invoking a flow synchronously, you can return a response body, content type and HTTP status code to the caller from the last step of the integration. With an upcoming change, you'll also be able to return custom headers. This will be helpful when responding with redirects, etc.