### PR TITLE
Fix the contains function to handle stringified numbers

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/conditionalLogic/index.test.ts
+++ b/packages/spectral/src/conditionalLogic/index.test.ts
@@ -387,6 +387,32 @@ describe("evaluate", () => {
     });
   });
 
+  test("evaluate BinaryOperator.in with array of numbers and value that is a number", () => {
+    expect(evaluate([BinaryOperator.in, 2, [1, 2, 3]])).toStrictEqual(true);
+  });
+
+  test("evaluate BinaryOperator.in with array of numbers and value that is a stringified number", () => {
+    expect(evaluate([BinaryOperator.in, "2", [1, 2, 3]])).toStrictEqual(true);
+  });
+
+  test("evaluate BinaryOperator.in with array of stringified numbers and value that is a stringified number", () => {
+    expect(evaluate([BinaryOperator.in, "2", ["1", "2", "3"]])).toStrictEqual(
+      true
+    );
+  });
+
+  test("evaluate BinaryOperator.in with array of numbers including zero and value that is a stringified false", () => {
+    expect(evaluate([BinaryOperator.in, "false", [0, 1, 2]])).toStrictEqual(
+      false
+    );
+  });
+
+  test("evaluate BinaryOperator.in with array of numbers including zero and value that is a false", () => {
+    expect(evaluate([BinaryOperator.in, false, [0, 1, 2]])).toStrictEqual(
+      false
+    );
+  });
+
   // TODO: Add more coverage for false evaluations.
   // describe("false expressions", () => {});
 

--- a/packages/spectral/src/conditionalLogic/index.ts
+++ b/packages/spectral/src/conditionalLogic/index.ts
@@ -73,7 +73,10 @@ export const contains = (container: unknown, containee: unknown): boolean => {
   if (typeof container === "object" && container !== null) {
     if (Array.isArray(container)) {
       // Array member check.
-      return container.includes(containee);
+      return (
+        container.includes(containee) ||
+        container.includes(parseValue(containee))
+      );
     }
     // Object attribute check (set membership).
     return Object.prototype.hasOwnProperty.call(container, `${containee}`);
@@ -238,9 +241,9 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case BinaryOperator.lessThanOrEqual:
           return left <= right;
         case BinaryOperator.in:
-          return contains(right, left);
+          return contains(right, leftTerm);
         case BinaryOperator.notIn:
-          return !contains(right, left);
+          return !contains(right, leftTerm);
         case BinaryOperator.exactlyMatches:
           return left === right || _.isEqual(left, right);
         case BinaryOperator.doesNotExactlyMatch:


### PR DESCRIPTION
The `contains` function is designed to determine if an element is contained within an array (or object, or string... but this PR relates to arrays).

For strings, it works as expected - `"foo"` is contained in `["foo", "bar"]`.
For numbers, it works as expected - `2` is contained in `[1,2,3]`.
For stringified numbers, it does not work as expected. It currently returns `false` if you check if `"2"` is contained in `["1", "2", "3"]`.

That's because the element you check is passed through the `parseValue` function, which checks if the value is a string and, if so, the value is `JSON.parse`'d. `JSON.parse("2")` becomes `2`, and `2 !== "2"`.

This PR loosens restrictions on contains, so that the value `"2"` would be passed to `contains`, and both the values `"2"` and `2` would be searched for in the array.