### PR TITLE
JSON Forms data results can be arrays in addition to key/value objects

### DIFF
--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -62,7 +62,7 @@ export type JSONForm = {
   /**
    * Optional default data to use in the inputs of your form
    */
-  data?: Record<string, unknown>;
+  data?: Record<string, unknown> | unknown[];
 };
 
 export type DynamicObjectSelection = string;


### PR DESCRIPTION
A JSON form can yield an object (`Record<string, unknown>`) or it can return an array if the schema has a top-level array declared (like this example https://prismatic.io/docs/jsonforms/playground/?key=basic-array). 

Our TypeScript should allow for both.