### PR TITLE
Add connection templates to code-native reference connections

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -326,7 +326,7 @@ const convertConfigVar = (
       ...pick(configVar, ["stableKey", "description", "orgOnly"]),
       key,
       dataType: "connection",
-      connection: ref,
+      connection: { ...ref, template: configVar.connection.template },
       inputs,
     };
   }

--- a/packages/spectral/src/serverTypes/integration.ts
+++ b/packages/spectral/src/serverTypes/integration.ts
@@ -7,6 +7,7 @@ export interface ComponentReference {
     isPublic: boolean;
   };
   key: string;
+  template?: string;
 }
 
 export type Input =

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -205,7 +205,9 @@ type ConnectionDefinitionConfigVar = BaseConfigVar &
   Omit<ConnectionDefinition, "label" | "comments" | "key">;
 type ConnectionReferenceConfigVar<TComponents extends ComponentSelector<any>> =
   BaseConfigVar & {
-    connection: ToComponentReferences<"connection", TComponents>;
+    connection: ToComponentReferences<"connection", TComponents> & {
+      template?: string;
+    };
   };
 
 /** Defines attributes of a Config Var that represents a Connection. */
@@ -378,6 +380,7 @@ export interface ComponentReference<
   component: string | { key: string; isPublic: boolean };
   key: string;
   values?: { [key: string]: ValueReference<TValueType, TConfigPages> };
+  template?: string;
 }
 
 export const isComponentReference = (


### PR DESCRIPTION
When building a code-native integration, you may want to reference an existing connection template https://prismatic.io/docs/connections/#connection-templates. This change allows you to specify a `template` by name when you reference an existing component's connection.