### PR TITLE
Refine collection type handling for CNI config vars

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "8.1.6",
+  "version": "8.1.7",
   "description": "Utility library for building Prismatic components",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -278,9 +278,9 @@ const convertFlow = (
 };
 
 /** Converts a Config Var into the structure necessary for YAML generation. */
-const convertConfigVar = (
+const convertConfigVar = <TComponents extends ComponentSelector<any>>(
   key: string,
-  configVar: ConfigVar<any>,
+  configVar: ConfigVar<TComponents>,
   referenceKey: string
 ): ServerRequiredConfigVariable => {
   const meta = pick(configVar, [

--- a/packages/spectral/src/types-tests/ConfigVars.test-d.ts
+++ b/packages/spectral/src/types-tests/ConfigVars.test-d.ts
@@ -1,5 +1,6 @@
-import { expectAssignable } from "tsd";
+import { expectAssignable, expectError } from "tsd";
 import type {
+  DataSourceConfigVar,
   ExtractConfigVars,
   GetElements,
 } from "../types/IntegrationDefinition";
@@ -66,3 +67,19 @@ expectAssignable<Connection>(null as unknown as ConnectionVars["A Connection"]);
 expectAssignable<Connection>(
   null as unknown as ConnectionVars["Ref Connection"]
 );
+
+// Subset of data source types support collections.
+expectAssignable<DataSourceConfigVar<any>>({
+  perform: async () => Promise.resolve({ result: "string" }),
+  stableKey: "ds",
+  dataSourceType: "picklist",
+  collectionType: "valuelist",
+});
+
+// Distinct subset of data source types does not support collections.
+expectError<DataSourceConfigVar<any>>({
+  perform: async () => Promise.resolve({ result: "string" }),
+  stableKey: "ds",
+  dataSourceType: "jsonForm",
+  collectionType: "valuelist",
+});

--- a/packages/spectral/src/types/DataSourceResult.ts
+++ b/packages/spectral/src/types/DataSourceResult.ts
@@ -16,6 +16,10 @@ type DataSourceTypeMap = {
 };
 
 export type DataSourceType = keyof DataSourceTypeMap;
+export type CollectionDataSourceType = Exclude<
+  DataSourceType,
+  "objectSelection" | "objectFieldMap" | "jsonForm"
+>;
 
 export type DataSourceResultType = DataSourceTypeMap[DataSourceType];
 


### PR DESCRIPTION
This better aligns CNI `collectionType` configuration with the Designer's; no `collectionType` for schedule or connection `dataType`s or for a few types of data sources.