### PR TITLE
Make Bin executables Cross Platform compatible

### DIFF
--- a/packages/spectral/.eslintignore
+++ b/packages/spectral/.eslintignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+bin/

--- a/packages/spectral/bin/component-manifest.js
+++ b/packages/spectral/bin/component-manifest.js
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+
+require("../dist/generators/componentManifest/cli.js");

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "homepage": "https://prismatic.io",
   "bin": {
-    "component-manifest": "./dist/generators/componentManifest/cli.js"
+    "component-manifest": "./bin/component-manifest.js"
   },
   "bugs": {
     "url": "https://github.com/prismatic-io/spectral"
@@ -28,8 +28,7 @@
     "build": "yarn run format && yarn run lint && yarn run clean && tsc",
     "build:templates": "copyfiles --error -u 1 src/**/templates/**/* dist",
     "dev": "tsc -w",
-    "cli:permission": "chmod +x dist/generators/**/cli.js",
-    "postbuild": "yarn run build:templates && yarn run cli:permission",
+    "postbuild": "yarn run build:templates",
     "prepack": "yarn run build",
     "format": "yarn run lint-fix && prettier --loglevel error --write 'src/**/*.ts' '*.{ts,js,json}' '!sidebars.{js,jse}'",
     "check-format": "prettier --check 'src/**/*.ts' '*.{ts,js,json}' '!sidebars.{js,jse}'",

--- a/packages/spectral/src/generators/componentManifest/cli.ts
+++ b/packages/spectral/src/generators/componentManifest/cli.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { createComponentManifest } from "./index";
 import {
   COMPONENT_DIR,


### PR DESCRIPTION
**Issue:**

Our `bin` executables currently reference the **tsc** compiled `cli.ts -> cli.js` file. However, Typescript does not maintain the files' runtime permissions and resets them to the least amount of privileges. 

The configuration for this is:

```
"bin": {
    "component-manifest": "./dist/generators/componentManifest/cli.js"
  },
```

To work around this, we introduced an npm script that runs after the build process to provide the generated `cli.js` file with its executable permission. However, the issue with this is it's not cross-platform compatible.

**Solution:**

Instead, we'll have a static `bin` directory as a sibling to the `src` and `dist` folders. This `bin` directory will need to be published along with Spectral. This `bin` folder will contain executable files that reference their corresponding CLI functionality.

Current Issue in Microsoft TypeScript Github repository: https://github.com/Microsoft/TypeScript/issues/26060.