### PR TITLE
Only include the EJS (Embedded JavaScript) templates in the 'build:template' script to prevent unnecessary file copies.

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "yarn run format && yarn run lint && yarn run clean && tsc",
-    "build:templates": "copyfiles --error -u 1 src/**/templates/**/* dist",
+    "build:templates": "copyfiles --error -u 1 src/**/templates/**/*.ejs dist",
     "dev": "tsc -w",
     "cli:permission": "chmod +x dist/generators/**/cli.js",
     "postbuild": "yarn run build:templates && yarn run cli:permission",


### PR DESCRIPTION
This means that you should only include the EJS template files in the 'build:template' script during the build process. This will help prevent the unnecessary copying of files that are not needed for the final build, which can help optimize the build process and reduce the size of the final output.