### PR TITLE
CNI - Fix Cleanup Bug

### DIFF
--- a/packages/spectral/src/generators/componentManifest/removeComponentManifest.ts
+++ b/packages/spectral/src/generators/componentManifest/removeComponentManifest.ts
@@ -1,4 +1,4 @@
-import { removeSync } from "fs-extra";
+import { rmSync, existsSync } from "fs";
 
 interface RemoveComponentManifestProps {
   destinationDir: string;
@@ -14,7 +14,9 @@ export const removeComponentManifest = ({
   }
 
   try {
-    removeSync(destinationDir);
+    if (existsSync(destinationDir)) {
+      rmSync(destinationDir, { recursive: true, force: true });
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
The 'fs-extra.remove' function didn't remove the previous manifest. Replacing it with 'rmSync' fixed the issue. The problem was likely caused by the presence of files and subdirectories, which prevented the function from removing everything altogether.