### PR TITLE
Fix generated input types in component manifests

### DIFF
--- a/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
@@ -1,11 +1,10 @@
 <% inputs.forEach((input) => { -%>
   <%= input.key %>: {
-    valueType: "<%- input.valueType.type ? input.valueType.type : input.valueType %>",
     inputType: "<%= input.inputType %>",
     <%_ if (input.collection) { -%>
-    collection: "<%= input.collection %>" as const,
+    collection: "<%= input.collection %>",
     <%_ } else { -%>
-    collection: null,
+    collection: undefined,
     <%_ } -%>
     <%_ if (input.default) { -%>
     default: <%= input.default %>,
@@ -16,5 +15,5 @@
     <%_ if (typeof input.onPremControlled !== "undefined") { -%>
     onPremControlled: <%= input.onPremControlled %>,
     <%_ } -%>
-  },
+  } as const,
 <% }); -%>

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,3 +1,5 @@
+import { CollectionType, InputFieldType } from ".";
+
 export interface ComponentManifest {
   key: string;
   public: boolean;
@@ -8,45 +10,29 @@ export interface ComponentManifest {
   connections: Record<string, ComponentManifestConnection>;
 }
 
+interface BaseInput {
+  inputType: InputFieldType;
+  collection?: CollectionType | undefined;
+  required?: boolean;
+  default?: unknown;
+}
+
 export interface ComponentManifestAction {
   perform: (values: any) => Promise<unknown>;
-  inputs: Record<
-    string,
-    {
-      inputType: string;
-      collection: "keyvaluelist" | "valuelist" | null;
-    }
-  >;
+  inputs: Record<string, BaseInput>;
 }
 
 export interface ComponentManifestTrigger {
   perform: (values: any) => Promise<unknown>;
-  inputs: Record<
-    string,
-    {
-      inputType: string;
-      collection: "keyvaluelist" | "valuelist" | null;
-    }
-  >;
+  inputs: Record<string, BaseInput>;
 }
 
 export interface ComponentManifestDataSource {
   perform: (values: any) => Promise<unknown>;
-  inputs: Record<
-    string,
-    {
-      inputType: string;
-      collection: "keyvaluelist" | "valuelist" | null;
-    }
-  >;
+  inputs: Record<string, BaseInput>;
 }
 export interface ComponentManifestConnection {
   perform: (values: any) => Promise<unknown>;
-  inputs: Record<
-    string,
-    {
-      inputType: string;
-      collection: "keyvaluelist" | "valuelist" | null;
-    }
-  >;
+  onPremAvailable?: boolean;
+  inputs: Record<string, BaseInput & { onPremControlled?: boolean }>;
 }


### PR DESCRIPTION
For any of the properties in the `inputs` object of a manifest function we need to cast `as const` so the specific value carries through for use in spectral's types.