### PR TITLE
Input Type - Inference issue with collection types

### DIFF
--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -158,84 +158,78 @@ interface KeyValueListCollection<T> {
   default?: KeyValuePair<T>[];
 }
 
-export type StringInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "string";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type StringInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "string";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
-export type DataInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "data";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type DataInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "data";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
-export type TextInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "text";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type TextInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "text";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
-export type PasswordInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "password";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type PasswordInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "password";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
-export type BooleanInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "boolean";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type BooleanInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "boolean";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
 /** Defines attributes of a CodeInputField. */
-export type CodeInputField = BaseInputField &
-  CollectionOptions<string> & {
-    /** Data type the InputField will collect. */
-    type: "code";
-    /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
-    language:
-      | "css"
-      | "graphql"
-      | "handlebars"
-      | "hcl"
-      | "html"
-      | "javascript"
-      | "json"
-      | "liquid"
-      | "markdown"
-      | "mysql"
-      | "pgsql"
-      | "plaintext"
-      | "sql"
-      | "typescript"
-      | "xml"
-      | "yaml";
-    /** Dictates possible choices for the input. */
-    model?: InputFieldChoice[];
-    /** Clean function */
-    clean?: InputCleanFunction<unknown>;
-  };
+export type CodeInputField = BaseInputField & {
+  /** Data type the InputField will collect. */
+  type: "code";
+  /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
+  language:
+    | "css"
+    | "graphql"
+    | "handlebars"
+    | "hcl"
+    | "html"
+    | "javascript"
+    | "json"
+    | "liquid"
+    | "markdown"
+    | "mysql"
+    | "pgsql"
+    | "plaintext"
+    | "sql"
+    | "typescript"
+    | "xml"
+    | "yaml";
+  /** Dictates possible choices for the input. */
+  model?: InputFieldChoice[];
+  /** Clean function */
+  clean?: InputCleanFunction<unknown>;
+} & CollectionOptions<string>;
 
 /** Defines attributes of a ConditionalInputField. */
 export interface ConditionalInputField extends BaseInputField {


### PR DESCRIPTION
Reorder the type intersections to correctly infer types. 

Issue:
![Screenshot 2024-07-08 at 10 29 12 AM](https://github.com/prismatic-io/spectral/assets/5714439/c5ab67a6-236d-4cd1-8bb9-10ed17461db0)

Now we get (which is correct): 
![Screenshot 2024-07-08 at 10 26 00 AM](https://github.com/prismatic-io/spectral/assets/5714439/b565c794-505c-4a83-90eb-93d109fba477)

![Screenshot 2024-07-08 at 10 26 10 AM](https://github.com/prismatic-io/spectral/assets/5714439/29942f32-8f67-4251-bd3d-17e0f4e7465b)
