### PR TITLE
CNI - Update derived type interfaces to format invalid type interfaces names

### DIFF
--- a/packages/spectral-test/src/testData.test-d.ts
+++ b/packages/spectral-test/src/testData.test-d.ts
@@ -146,6 +146,7 @@ export const componentRegistry = {
             required: true,
           },
         },
+        key: "jsonFormDataSource",
       },
       stringDataSource: {
         dataSourceType: "string",
@@ -156,17 +157,20 @@ export const componentRegistry = {
             required: true,
           },
         },
+        key: "stringDataSource",
       },
     },
     connections: {
       exampleConnection: {
         perform: (inputs: { foo: string }) => Promise.resolve<unknown>(inputs),
         inputs: {},
+        key: "exampleConnection",
       },
       onPremConnection: {
         perform: (inputs: { foo: string }) => Promise.resolve(inputs),
         inputs: {},
         onPremAvailable: true,
+        key: "onPremConnection",
       },
     },
   }),
@@ -188,6 +192,7 @@ export const componentRegistry = {
           showIdInDropdown: boolean;
         }) => Promise.resolve<unknown>(inputs),
         inputs: {},
+        key: "selectChannels",
       },
     },
     connections: {
@@ -198,6 +203,7 @@ export const componentRegistry = {
           signingSecret: string;
         }) => Promise.resolve<unknown>(inputs),
         inputs: {},
+        key: "slackOAuth",
       },
     },
   }),
@@ -210,6 +216,7 @@ export const componentRegistry = {
       hmac: {
         perform: (inputs: { secret: string; secret2: string }) => Promise.resolve<unknown>(inputs),
         inputs: {},
+        key: "hmac",
       },
     },
     dataSources: {},

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.5",
+  "version": "9.0.7",
   "description": "Utility library for building Prismatic components",
-  "keywords": ["prismatic"],
+  "keywords": [
+    "prismatic"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://prismatic.io",
@@ -36,7 +38,9 @@
     "test": "jest",
     "docs": "rm -f sidebars.{js,jse} && typedoc"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "dependencies": {
     "@jsonforms/core": "3.0.0",
     "axios": "1.6.2",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,10 +1,8 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.7",
+  "version": "9.0.6",
   "description": "Utility library for building Prismatic components",
-  "keywords": [
-    "prismatic"
-  ],
+  "keywords": ["prismatic"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://prismatic.io",
@@ -38,9 +36,7 @@
     "test": "jest",
     "docs": "rm -f sidebars.{js,jse} && typedoc"
   },
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "dependencies": {
     "@jsonforms/core": "3.0.0",
     "axios": "1.6.2",

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -4,6 +4,8 @@ import { type Input, getInputs } from "./getInputs";
 import { type Imports, getImports } from "./getImports";
 import { helpers } from "./helpers";
 import { createTemplate } from "../utils/createTemplate";
+import { createTypeInterface } from "../utils/createTypeInterface";
+import { createImport } from "../utils/createImport";
 import type { Component } from "../../serverTypes";
 
 interface CreateActionsProps {
@@ -26,9 +28,9 @@ export const createActions = async ({
   }
 
   const actionIndex = await renderActionsIndex({
-    actions: Object.entries(component.actions ?? {}).map(([actionKey, action]) => {
+    imports: Object.entries(component.actions ?? {}).map(([actionKey, action]) => {
       return {
-        key: action.key || actionKey,
+        import: createImport(action.key || actionKey),
       };
     }),
     dryRun,
@@ -47,6 +49,8 @@ export const createActions = async ({
 
       return await renderAction({
         action: {
+          typeInterface: createTypeInterface(action.key || actionKey),
+          import: createImport(action.key || actionKey),
           key: action.key || actionKey,
           label: action.display.description,
           description: action.display.description,
@@ -72,8 +76,8 @@ export const createActions = async ({
 };
 
 interface RenderActionsIndexProps {
-  actions: {
-    key: string;
+  imports: {
+    import: string;
   }[];
   dryRun: boolean;
   verbose: boolean;
@@ -82,7 +86,7 @@ interface RenderActionsIndexProps {
 }
 
 const renderActionsIndex = async ({
-  actions,
+  imports,
   dryRun,
   verbose,
   sourceDir,
@@ -92,7 +96,7 @@ const renderActionsIndex = async ({
     source: path.join(sourceDir, "actions", "index.ts.ejs"),
     destination: path.join(destinationDir, "actions", "index.ts"),
     data: {
-      actions,
+      imports,
     },
     dryRun,
     verbose,
@@ -101,6 +105,8 @@ const renderActionsIndex = async ({
 
 interface RenderActionProps {
   action: {
+    typeInterface: string;
+    import: string;
     key: string;
     label: string;
     description: string;
@@ -123,7 +129,7 @@ const renderAction = async ({
 }: RenderActionProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "actions", "action.ts.ejs"),
-    destination: path.join(destinationDir, "actions", `${action.key}.ts`),
+    destination: path.join(destinationDir, "actions", `${action.import}.ts`),
     data: {
       action,
       helpers,

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -30,7 +30,7 @@ export const createActions = async ({
   const actionIndex = await renderActionsIndex({
     imports: Object.entries(component.actions ?? {}).map(([actionKey, action]) => {
       return {
-        import: createImport(action.key || actionKey),
+        import: createImport(action.key ?? actionKey),
       };
     }),
     dryRun,
@@ -49,8 +49,8 @@ export const createActions = async ({
 
       return await renderAction({
         action: {
-          typeInterface: createTypeInterface(action.key || actionKey),
-          import: createImport(action.key || actionKey),
+          typeInterface: createTypeInterface(action.key ?? actionKey),
+          import: createImport(action.key ?? actionKey),
           key: action.key || actionKey,
           label: action.display.description,
           description: action.display.description,

--- a/packages/spectral/src/generators/componentManifest/createConnections.ts
+++ b/packages/spectral/src/generators/componentManifest/createConnections.ts
@@ -4,6 +4,8 @@ import { type Input, getInputs } from "./getInputs";
 import { type Imports, getImports } from "./getImports";
 import { helpers } from "./helpers";
 import { createTemplate } from "../utils/createTemplate";
+import { createTypeInterface } from "../utils/createTypeInterface";
+import { createImport } from "../utils/createImport";
 import type { Component } from "../../serverTypes";
 
 interface CreateConnectionsProps {
@@ -26,9 +28,9 @@ export const createConnections = async ({
   }
 
   const connectionIndex = await renderConnectionsIndex({
-    connections: (component.connections ?? []).map((connection) => {
+    imports: (component.connections ?? []).map((connection) => {
       return {
-        key: connection.key,
+        import: createImport(connection.key),
       };
     }),
     dryRun,
@@ -51,6 +53,8 @@ export const createConnections = async ({
 
       return await renderConnection({
         connection: {
+          typeInterface: createTypeInterface(connection.key),
+          import: createImport(connection.key),
           key: connection.key,
           label: connection.label,
           comments: connection.comments,
@@ -77,8 +81,8 @@ export const createConnections = async ({
 };
 
 interface RenderConnectionsIndexProps {
-  connections: {
-    key: string;
+  imports: {
+    import: string;
   }[];
   dryRun: boolean;
   verbose: boolean;
@@ -87,7 +91,7 @@ interface RenderConnectionsIndexProps {
 }
 
 const renderConnectionsIndex = async ({
-  connections,
+  imports,
   dryRun,
   verbose,
   sourceDir,
@@ -97,7 +101,7 @@ const renderConnectionsIndex = async ({
     source: path.join(sourceDir, "connections", "index.ts.ejs"),
     destination: path.join(destinationDir, "connections", "index.ts"),
     data: {
-      connections,
+      imports,
     },
     dryRun,
     verbose,
@@ -106,6 +110,8 @@ const renderConnectionsIndex = async ({
 
 interface RenderConnectionProps {
   connection: {
+    typeInterface: string;
+    import: string;
     key: string;
     label: string;
     comments?: string;
@@ -129,7 +135,7 @@ const renderConnection = async ({
 }: RenderConnectionProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "connections", "connection.ts.ejs"),
-    destination: path.join(destinationDir, "connections", `${connection.key}.ts`),
+    destination: path.join(destinationDir, "connections", `${connection.import}.ts`),
     data: {
       connection,
       helpers,

--- a/packages/spectral/src/generators/componentManifest/createDataSources.ts
+++ b/packages/spectral/src/generators/componentManifest/createDataSources.ts
@@ -4,6 +4,8 @@ import { type Input, getInputs } from "./getInputs";
 import { type Imports, getImports } from "./getImports";
 import { helpers } from "./helpers";
 import { createTemplate } from "../utils/createTemplate";
+import { createTypeInterface } from "../utils/createTypeInterface";
+import { createImport } from "../utils/createImport";
 import type { Component } from "../../serverTypes";
 import { DataSourceType } from "../../types";
 
@@ -27,9 +29,9 @@ export const createDataSources = async ({
   }
 
   const dataSourceIndex = await renderDataSourcesIndex({
-    dataSources: Object.entries(component.dataSources ?? {}).map(([dataSourceKey, dataSource]) => {
+    imports: Object.entries(component.dataSources ?? {}).map(([dataSourceKey, dataSource]) => {
       return {
-        key: dataSource.key || dataSourceKey,
+        import: createImport(dataSource.key || dataSourceKey),
       };
     }),
     dryRun,
@@ -48,6 +50,8 @@ export const createDataSources = async ({
 
       return await renderDataSource({
         dataSource: {
+          type: createTypeInterface(dataSource.key || dataSourceKey),
+          import: createImport(dataSource.key || dataSourceKey),
           key: dataSource.key || dataSourceKey,
           label: dataSource.display.label,
           description: dataSource.display.description,
@@ -74,8 +78,8 @@ export const createDataSources = async ({
 };
 
 interface RenderDataSourcesProps {
-  dataSources: {
-    key: string;
+  imports: {
+    import: string;
   }[];
   dryRun: boolean;
   verbose: boolean;
@@ -84,7 +88,7 @@ interface RenderDataSourcesProps {
 }
 
 const renderDataSourcesIndex = async ({
-  dataSources,
+  imports,
   dryRun,
   verbose,
   sourceDir,
@@ -94,7 +98,7 @@ const renderDataSourcesIndex = async ({
     source: path.join(sourceDir, "dataSources", "index.ts.ejs"),
     destination: path.join(destinationDir, "dataSources", "index.ts"),
     data: {
-      dataSources,
+      imports,
     },
     dryRun,
     verbose,
@@ -103,6 +107,8 @@ const renderDataSourcesIndex = async ({
 
 interface RenderDataSourceProps {
   dataSource: {
+    type: string;
+    import: string;
     key: string;
     label: string;
     description: string;
@@ -126,7 +132,7 @@ const renderDataSource = async ({
 }: RenderDataSourceProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "dataSources", "dataSource.ts.ejs"),
-    destination: path.join(destinationDir, "dataSources", `${dataSource.key}.ts`),
+    destination: path.join(destinationDir, "dataSources", `${dataSource.import}.ts`),
     data: {
       dataSource,
       helpers,

--- a/packages/spectral/src/generators/componentManifest/createTriggers.ts
+++ b/packages/spectral/src/generators/componentManifest/createTriggers.ts
@@ -4,6 +4,8 @@ import { type Input, getInputs } from "./getInputs";
 import { type Imports, getImports } from "./getImports";
 import { helpers } from "./helpers";
 import { createTemplate } from "../utils/createTemplate";
+import { createTypeInterface } from "../utils/createTypeInterface";
+import { createImport } from "../utils/createImport";
 import type { Component } from "../../serverTypes";
 
 interface CreateTriggersProps {
@@ -26,9 +28,9 @@ export const createTriggers = async ({
   }
 
   const triggersIndex = await renderTriggersIndex({
-    triggers: Object.entries(component.triggers ?? {}).map(([triggerKey, trigger]) => {
+    imports: Object.entries(component.triggers ?? {}).map(([triggerKey, trigger]) => {
       return {
-        key: trigger.key || triggerKey,
+        import: createImport(trigger.key || triggerKey),
       };
     }),
     dryRun,
@@ -47,6 +49,8 @@ export const createTriggers = async ({
 
       return await renderTrigger({
         trigger: {
+          typeInterface: createTypeInterface(trigger.key || triggerKey),
+          import: createImport(trigger.key || triggerKey),
           key: trigger.key || triggerKey,
           label: trigger.display.description,
           description: trigger.display.description,
@@ -72,8 +76,8 @@ export const createTriggers = async ({
 };
 
 interface RenderTriggersIndexProps {
-  triggers: {
-    key: string;
+  imports: {
+    import: string;
   }[];
   dryRun: boolean;
   verbose: boolean;
@@ -82,7 +86,7 @@ interface RenderTriggersIndexProps {
 }
 
 const renderTriggersIndex = async ({
-  triggers,
+  imports,
   dryRun,
   verbose,
   sourceDir,
@@ -92,7 +96,7 @@ const renderTriggersIndex = async ({
     source: path.join(sourceDir, "triggers", "index.ts.ejs"),
     destination: path.join(destinationDir, "triggers", "index.ts"),
     data: {
-      triggers,
+      imports,
     },
     dryRun,
     verbose,
@@ -101,6 +105,8 @@ const renderTriggersIndex = async ({
 
 interface RenderTriggerProps {
   trigger: {
+    typeInterface: string;
+    import: string;
     key: string;
     label: string;
     description: string;
@@ -123,7 +129,7 @@ const renderTrigger = async ({
 }: RenderTriggerProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "triggers", "trigger.ts.ejs"),
-    destination: path.join(destinationDir, "triggers", `${trigger.key}.ts`),
+    destination: path.join(destinationDir, "triggers", `${trigger.import}.ts`),
     data: {
       helpers,
       imports,

--- a/packages/spectral/src/generators/componentManifest/helpers.ts
+++ b/packages/spectral/src/generators/componentManifest/helpers.ts
@@ -1,9 +1,11 @@
 import { capitalizeFirstLetter } from "../utils/capitalizeFirstLetter";
 import { createDependencyImports } from "../utils/createDependencyImports";
+import { formatType } from "../utils/formatType";
 import { generatePackageJsonVersion } from "../utils/generatePackageJsonVersion";
 
 export const helpers = {
   createDependencyImports,
   capitalizeFirstLetter,
   generatePackageJsonVersion,
+  formatType,
 };

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -1,7 +1,7 @@
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
-export interface <%= helpers.capitalizeFirstLetter(action.key) %>Values {
-<%- include('../partials/performArgs.ejs', { inputs: action.inputs }) -%>
+export interface <%= action.typeInterface %>Values {
+<%- include('../partials/performArgs.ejs', { inputs: action.inputs, helpers }) -%>
 }
 
 /**
@@ -9,11 +9,12 @@ export interface <%= helpers.capitalizeFirstLetter(action.key) %>Values {
  *
  * @description <%- action.description %>
  */
-export const <%= action.key %> = {
+export const <%= action.import %> = {
+  key: "<%= action.key %>",
   perform: <TReturn>(
-    _values: <%= helpers.capitalizeFirstLetter(action.key) %>Values
+    _values: <%= action.typeInterface %>Values
   ): Promise<TReturn> => Promise.resolve<TReturn>({} as TReturn),
   inputs: {
-    <%- include('../partials/inputs.ejs', { inputs: action.inputs }) -%>
+    <%- include('../partials/inputs.ejs', { inputs: action.inputs, helpers }) -%>
   }
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/index.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/index.ts.ejs
@@ -1,1 +1,1 @@
-<%- include('../partials/importBarrel.ejs', { imports: actions }) -%>
+<%- include('../partials/importBarrel.ejs', { imports }) -%>

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -1,7 +1,7 @@
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
-export interface <%= helpers.capitalizeFirstLetter(connection.key) %>Values {
-<%- include('../partials/performArgs.ejs', { inputs: connection.inputs }) -%>
+export interface <%= connection.typeInterface %>Values {
+<%- include('../partials/performArgs.ejs', { inputs: connection.inputs, helpers }) -%>
 }
 
 /**
@@ -9,14 +9,15 @@ export interface <%= helpers.capitalizeFirstLetter(connection.key) %>Values {
  *
  * @comments <%- connection.comments %>
  */
-export const <%= connection.key %> = {
+export const <%= connection.import %> = {
+  key: "<%= connection.key %>",
   perform: (
-    _values: <%= helpers.capitalizeFirstLetter(connection.key) %>Values
+    _values: <%= connection.typeInterface %>Values
   ): Promise<void> => Promise.resolve(),
   <%_ if (connection.onPremAvailable) { -%>
   onPremAvailable: true,
   <%_ } -%>
   inputs: {
-    <%- include('../partials/inputs.ejs', { inputs: connection.inputs }) -%>
+    <%- include('../partials/inputs.ejs', { inputs: connection.inputs, helpers }) -%>
   }
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/connections/index.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/index.ts.ejs
@@ -1,1 +1,1 @@
-<%- include('../partials/importBarrel.ejs', { imports: connections }) -%>
+<%- include('../partials/importBarrel.ejs', { imports }) -%>

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -1,7 +1,7 @@
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
-export interface <%= helpers.capitalizeFirstLetter(dataSource.key) %>Values {
-<%- include('../partials/performArgs.ejs', { inputs: dataSource.inputs }) -%>
+export interface <%= dataSource.typeInterface %>Values {
+<%- include('../partials/performArgs.ejs', { inputs: dataSource.inputs, helpers }) -%>
 }
 
 /**
@@ -9,12 +9,13 @@ export interface <%= helpers.capitalizeFirstLetter(dataSource.key) %>Values {
  *
  * @description <%- dataSource.description %>
  */
-export const <%= dataSource.key %> = {
+export const <%= dataSource.import %> = {
+  key: "<%= dataSource.key %>",
   perform: (
-    _values: <%= helpers.capitalizeFirstLetter(dataSource.key) %>Values
+    _values: <%= dataSource.typeInterface %>Values
   ): Promise<void> => Promise.resolve(),
   dataSourceType: "<%= dataSource.dataSourceType %>",
   inputs: {
-    <%- include('../partials/inputs.ejs', { inputs: dataSource.inputs }) -%>
+    <%- include('../partials/inputs.ejs', { inputs: dataSource.inputs, helpers }) -%>
   }
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/index.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/index.ts.ejs
@@ -1,1 +1,1 @@
-<%- include('../partials/importBarrel.ejs', { imports: dataSources }) -%>
+<%- include('../partials/importBarrel.ejs', { imports }) -%>

--- a/packages/spectral/src/generators/componentManifest/templates/partials/importBarrel.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/partials/importBarrel.ejs
@@ -1,9 +1,9 @@
 <% imports.forEach((item) => { -%>
-import { <%= item.key %> } from "./<%= item.key %>";
+import { <%= item.import %> } from "./<%= item.import %>";
 <% }); -%>
 
 export default {
   <%_ imports.forEach((item) => { -%>
-  <%= item.key %>,
+  <%= item.import %>,
   <%_ }); -%>
 }

--- a/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
@@ -1,5 +1,5 @@
 <% inputs.forEach((input) => { -%>
-  <%= input.key %>: {
+  <%- helpers.formatType(input.key) %>: {
     inputType: "<%= input.inputType %>",
     <%_ if (input.collection) { -%>
     collection: "<%= input.collection %>",

--- a/packages/spectral/src/generators/componentManifest/templates/partials/performArgs.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/partials/performArgs.ejs
@@ -1,4 +1,4 @@
 <% inputs.forEach((input) => { -%>
   <%- input.docBlock -%>
-  <%= input.key %><%= input.required ? "" : "?" %>: <%- input.valueType.type ? input.valueType.type : input.valueType %>;
+  <%- helpers.formatType(input.key) %><%= input.required ? "" : "?" %>: <%- input.valueType.type ? input.valueType.type : input.valueType %>;
 <% }); -%>

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/index.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/index.ts.ejs
@@ -1,1 +1,1 @@
-<%- include('../partials/importBarrel.ejs', { imports: triggers }) -%>
+<%- include('../partials/importBarrel.ejs', { imports }) -%>

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -1,7 +1,7 @@
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
-export interface <%= helpers.capitalizeFirstLetter(trigger.key) %>Values {
-<%- include('../partials/performArgs.ejs', { inputs: trigger.inputs }) -%>
+export interface <%= trigger.typeInterface %>Values {
+<%- include('../partials/performArgs.ejs', { inputs: trigger.inputs, helpers }) -%>
 }
 
 /**
@@ -9,11 +9,12 @@ export interface <%= helpers.capitalizeFirstLetter(trigger.key) %>Values {
  *
  * @description <%- trigger.description %>
  */
-export const <%= trigger.key %> = {
+export const <%= trigger.import %> = {
+  key: "<%= trigger.key %>",
   perform: <TReturn>(
-    _values: <%= helpers.capitalizeFirstLetter(trigger.key) %>Values
+    _values: <%= trigger.typeInterface %>Values
   ): Promise<TReturn> => Promise.resolve<TReturn>({} as TReturn),
   inputs: {
-    <%- include('../partials/inputs.ejs', { inputs: trigger.inputs }) -%>
+    <%- include('../partials/inputs.ejs', { inputs: trigger.inputs, helpers }) -%>
   }
 } as const;

--- a/packages/spectral/src/generators/utils/createImport.ts
+++ b/packages/spectral/src/generators/utils/createImport.ts
@@ -1,0 +1,3 @@
+import { camelCase } from "lodash";
+
+export const createImport = (key: string) => camelCase(key);

--- a/packages/spectral/src/generators/utils/createTypeInterface.ts
+++ b/packages/spectral/src/generators/utils/createTypeInterface.ts
@@ -1,0 +1,4 @@
+import { camelCase } from "lodash";
+import { capitalizeFirstLetter } from "./capitalizeFirstLetter";
+
+export const createTypeInterface = (key: string) => capitalizeFirstLetter(camelCase(key));

--- a/packages/spectral/src/generators/utils/formatType.ts
+++ b/packages/spectral/src/generators/utils/formatType.ts
@@ -1,0 +1,1 @@
+export const formatType = (key: string) => (key?.match(/[^a-zA-Z0-9]/) ? `"${key}"` : key);

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -306,7 +306,15 @@ const convertComponentReference = (
     key: componentReference.key,
   };
 
-  const manifestEntry = manifest[referenceType][componentReference.key];
+  const manifestEntry =
+    Object.values(manifest[referenceType]).find((entry) => entry.key === componentReference.key) ||
+    manifest[referenceType][componentReference.key];
+
+  if (!manifestEntry) {
+    throw new Error(
+      `Component with key "${componentReference.component}" does not have an entry with key "${componentReference.key}" in the component registry.`,
+    );
+  }
 
   const inputs = Object.entries(componentReference.values ?? {}).reduce((result, [key, value]) => {
     const manifestEntryInput = manifestEntry.inputs[key];

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -18,22 +18,26 @@ interface BaseInput {
 }
 
 export interface ComponentManifestAction {
+  key: string;
   perform: (values: any) => Promise<unknown>;
   inputs: Record<string, BaseInput>;
 }
 
 export interface ComponentManifestTrigger {
+  key: string;
   perform: (values: any) => Promise<unknown>;
   inputs: Record<string, BaseInput>;
 }
 
 export interface ComponentManifestDataSource {
+  key: string;
   perform: (values: any) => Promise<unknown>;
   dataSourceType: DataSourceType;
   inputs: Record<string, BaseInput>;
 }
 
 export interface ComponentManifestConnection {
+  key: string;
   perform: (values: any) => Promise<unknown>;
   onPremAvailable?: boolean;
   inputs: Record<string, BaseInput & { onPremControlled?: boolean }>;

--- a/packages/spectral/src/types/ComponentRegistry.ts
+++ b/packages/spectral/src/types/ComponentRegistry.ts
@@ -112,7 +112,7 @@ type ComponentRegistryFunctionsByType = UnionToIntersection<
                                   > & {
                                     reference: ComponentReference<{
                                       component: TComponentKey;
-                                      key: ComponentRegistry[TComponentKey][TComponentReferenceType][TComponentPropertyKey]["key"];
+                                      key: TComponentPropertyKey;
                                       values: {
                                         [Key in keyof TInputs]: ComponentReferenceTypeValueMap<
                                           TInputs[Key]

--- a/packages/spectral/src/types/ComponentRegistry.ts
+++ b/packages/spectral/src/types/ComponentRegistry.ts
@@ -112,7 +112,7 @@ type ComponentRegistryFunctionsByType = UnionToIntersection<
                                   > & {
                                     reference: ComponentReference<{
                                       component: TComponentKey;
-                                      key: TComponentPropertyKey;
+                                      key: ComponentRegistry[TComponentKey][TComponentReferenceType][TComponentPropertyKey]["key"];
                                       values: {
                                         [Key in keyof TInputs]: ComponentReferenceTypeValueMap<
                                           TInputs[Key]


### PR DESCRIPTION
**DRAFT**

In older legacy components, some did not utilize the `action()`, `connection()`, `dataSource()`, and `trigger()` wrappers. This enabled developers at the time to add the `key` property with arbitrary values, including invalid ones like `computemd5-sha1` and `Smartsheet OAuth2`. Now, we need to convert these to adhere to valid interface and import file naming conventions.

```
# azure-service-bus, bynder, fluent-commerce, servicedesk-plus, smartsheet, hash

SyntaxError: ',' expected. (2:20)
  1 | import { oauth } from "./oauth";
> 2 | import { connection-string } from "./connection-string";

SyntaxError: ',' expected. (1:21)
> 1 | import { Smartsheet OAuth2 } from "./Smartsheet OAuth2";
    |                     ^
  2 | import { apiKey } from "./apiKey";

SyntaxError: ',' expected. (7:20)
   5 | import { computemd4 } from "./computemd4";
   6 | import { computemd5 } from "./computemd5";
>  7 | import { computemd5-sha1 } from "./computemd5-sha1";
     |                    ^
   8 | import { computeripemd160 } from "./computeripemd160";
   9 | import { computesha1 } from "./computesha1";
  10 | import { computesha224 } from "./computesha224";
    at hV (file:///Users/ryan/src/spectral/node_modules/prettier/plugins/typescript.mjs:23:524)
    at UV (file:///Users/ryan/src/spectral/node_modules/prettier/plugins/typescript.mjs:25:14870)
    at Object.WV [as parse] (file:///Users/ryan/src/spectral/node_modules/prettier/plugins/typescript.mjs:25:15270)
    at parse (file:///Users/ryan/src/spectral/node_modules/prettier/index.mjs:16786:24)
    at async coreFormat (file:///Users/ryan/src/spectral/node_modules/prettier/index.mjs:18107:7)
    at async formatWithCursor (file:///Users/ryan/src/spectral/node_modules/prettier/index.mjs:18309:14)
    at async Module.format2 (file:///Users/ryan/src/spectral/node_modules/prettier/index.mjs:21504:25) {
  loc: { start: { line: 7, column: 20 }, end: { line: 7, column: 20 } },
  ```
  
The input keys have arbitrary values, which could potentially include non-alphanumeric characters. To ensure proper formatting, we'll need to check if the input keys contain any characters outside the range of [a-zA-Z0-9] and, if so, add quotes around the 'type' field.

```
SyntaxError: Property or signature expected. (30:3)
  28 |  * @placeholder Ocp-Apim-Subscription-Key
  29 |  */
> 30 |   ocp-apim-subscription-key: string;
     |   ^
  31 |    /**
  32 |  * Sage 200 Edition
  33 |  * The Sage 200 Edition you are connecting to.
    at qe (/Users/ryan/.asdf/installs/nodejs/18.20.3/lib/node_modules/@prismatic-io/spectral/node_modules/prettier/parser-typescript.js:1:15607)
```

---

**Update naming convention solution:**

The action, trigger, connection, and datasource keys should remain consistent with what they named.

**Component:**

```
export const connectionString = connection({
  key: "connection-string",
  label: "Connection String",
  inputs: {
    connectionString: {
      label: "Connection String",
      type: "password",
      required: true,
      shown: true,
      comments:
        "The connection string for your Azure Service Bus namespace. You can find this in the Azure Portal under the 'Shared access policies' tab.",
    },
  },
});
```

**Manifest:**

```
# connectionString.ts <-- UPDATED FILE NAME (MATTERS)

export interface ConnectionStringValues { <-- UPDATED INTERFACE (DOESN'T MATTER)
  /**
   * Connection String
   * The connection string for your Azure Service Bus namespace. You can find this in the Azure Portal under the 'Shared access policies' tab.
   *
   */
  connectionString: string;
}

/**
 * Connection String
 *
 */
export const connectionString = {
  key: "connection-string", <-- PRESERVED KEY (MATTERS)
  perform: (_values: ConnectionStringValues): Promise<void> =>
    Promise.resolve(),
  inputs: {
    connectionString: {
      inputType: "password",
      collection: undefined,
      required: true,
    },
  },
} as const;
```

**CNI:**

```
example: connectionConfigVar({
  stableKey: "2503a901-63d9-4b54-a2ba-bc241ae54a2b",
  dataType: "connection",
  connection: {
    component: "azureServiceBus",
    key: "connection-string",
    values: {
      connectionString: {
        value: "",
      },
    },
  },
}),
```