### PR TITLE
CNI - Hoist OnPremConnectionConfig on Required Config Var

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -337,7 +337,10 @@ const convertComponentReference = (
         },
       );
 
-      return { ...result, [key]: { type: type, value: formattedValue, meta } };
+      return {
+        ...result,
+        [key]: { type: type, value: formattedValue, meta },
+      };
     }
 
     if ("configVar" in value) {
@@ -539,10 +542,10 @@ const convertConfigVar = (
       description,
       key,
       dataType: "connection",
+      onPremiseConnectionConfig,
       connection: {
         ...ref,
         template,
-        onPremiseConnectionConfig,
       },
       inputs,
       orgOnly,

--- a/packages/spectral/src/serverTypes/integration.ts
+++ b/packages/spectral/src/serverTypes/integration.ts
@@ -9,7 +9,6 @@ export type ComponentReference =
       };
       key: string;
       template?: string;
-      onPremiseConnectionConfig?: string;
     }
   | {
       component: {
@@ -19,7 +18,6 @@ export type ComponentReference =
       };
       key: string;
       template?: string;
-      onPremiseConnectionConfig?: string;
     };
 
 export type Input =
@@ -42,6 +40,7 @@ export interface ConnectionRequiredConfigVariable {
   description?: string;
   orgOnly?: boolean;
   dataType: "connection";
+  onPremiseConnectionConfig?: string;
   connection: ComponentReference;
   inputs?: Record<string, Input>;
   meta?: Record<string, unknown>;


### PR DESCRIPTION
To define a valid YAML configuration, we need to hoist the `onPremiseConnectionConfig` on the required configuration variable. in CNI, to satisfy the types correctly we need to be part of the connection variable used for type discrimination.

**CNI:**
```
export const configPages = {
  Connections: configPage({
    elements: {
      test: connectionConfigVar({
        stableKey: "b2b377ee-27ce-4f59-b248-b4dafdea93f3",
        dataType: "connection",
        connection: {
          component: "smtp",
          key: "smtpConnection",
          onPremiseConnectionConfig: "required",
          values: {
            host: {
              value: "eeee",
            },
            port: {
              value: "bbbb",
            },
            password: {
              value: "test",
            },
            username: {
              value: "asdf",
            },
          },
        },
      }),
     ...
```

**YAML Definition:**
```
definitionVersion: 7
isCodeNative: true
name: integration
description: Prism-generated Integration
requiredConfigVars:
  - stableKey: b2b377ee-27ce-4f59-b248-b4dafdea93f3
    key: test
    dataType: connection
    onPremiseConnectionConfig: required
    connection:
      component:
        key: smtp
        signature: 8fa897c05ed7612f9b6090f542c01f2f2581b976
        isPublic: true
      key: smtpConnection
    inputs:
      host:
        type: value
        value: eeee
        meta:
          orgOnly: false
          visibleToOrgDeployer: true
          visibleToCustomerDeployer: true
      port:
        type: value
        value: bbbb
        meta:
          orgOnly: false
          visibleToOrgDeployer: true
          visibleToCustomerDeployer: true
      password:
        type: value
        value: test
        meta:
          orgOnly: false
          visibleToOrgDeployer: true
          visibleToCustomerDeployer: true
...
```