### PR TITLE
CNI - Fix Model union types that are objects, arrays, escaped characters

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -89,7 +89,11 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], ValueType> = {
 
 const getInputValueType = (input: ServerTypeInput) => {
   const valueType = input.model
-    ? input.model.map((choice) => `"${choice.value}"`).join(" | ")
+    ? input.model
+        .map((choice) => {
+          return `\`${choice.value.replaceAll("\r", "\\r").replaceAll("\n", "\\n")}\``;
+        })
+        .join(" | ")
     : INPUT_TYPE_MAP[input.type as InputFieldDefinition["type"]] || "never";
 
   if (input.collection === "keyvaluelist") {


### PR DESCRIPTION
The components that utilize models can employ an arbitrary data type, which can be arrays, objects, or even escaped characters. To properly type this, we need to validate what these data types are and then return the correct corresponding types.


```
# duro-plm

SyntaxError: ';' expected. (15:17)
  13 |  * @example [{\&#34;con\&#34;: \&#34;asc\&#34;}]
  14 |  */
> 15 |   orderBy?: "[{"con": "asc"}]" | "[{"con": "desc"}]" | "[{"lastModified": "asc"}]" | "[{"lastModified": "desc"}]" | "[{"name": "asc"}]" | "[{"name": "desc"}]";
     |                 ^
  16 |    /**
  17 |  * First N Items
  18 |  * The number of items to return.
```

```
# text-manipulation

SyntaxError: Unterminated string literal. (18:18)
  16 |  * @placeholder The type of newline to use
  17 |  */
> 18 |   newlineType?: "
     |                  ^
  19 | " | "
  20 | ";
  21 |    /**
```