### PR TITLE
Add OAuth2Config interface to ConnectionDefinition

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -32,8 +32,14 @@ export interface OnPremConnectionDefinition extends BaseConnectionDefinition {
   };
 }
 
+interface OAuth2Config {
+  overrideGrantType?: string;
+  allowedTokenParams?: string[];
+}
+
 interface OAuth2AuthorizationCodeConnectionDefinition extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.AuthorizationCode;
+  oauth2Config?: OAuth2Config;
   /** The PKCE method (S256 or plain) that this OAuth 2.0 connection uses (if any) */
   oauth2PkceMethod?: OAuth2PkceMethod;
   inputs: {


### PR DESCRIPTION
Add explicit interface, `OAuth2Config`, to `ConnectionDefinition`. Only applicable to `OAuth2AuthorizationCodeConnectionDefinition`.