### PR TITLE
CNI - Connection Reference/Definition Visibility

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.0.8",
+  "version": "9.1.0",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -36,7 +36,7 @@ export const convertInput = (
     collection === "keyvaluelist" && typeof label === "object" ? label.key : undefined;
 
   return {
-    ...omit(rest, ["onPremControlled"]),
+    ...omit(rest, ["onPremControlled", "permissionAndVisibilityType", "visibleToOrgDeployer"]),
     key,
     type,
     default: defaultValue ?? InputFieldDefaultMap[type],

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -524,6 +524,13 @@ const convertConfigVar = (
           return result;
         }
 
+        const meta = convertInputPermissionAndVisibility(
+          pick(input, ["permissionAndVisibilityType", "visibleToOrgDeployer"]) as {
+            permissionAndVisibilityType?: PermissionAndVisibilityType;
+            visibleToOrgDeployer?: boolean;
+          },
+        );
+
         const defaultValue = input.collection ? [] : "";
 
         return {
@@ -531,6 +538,7 @@ const convertConfigVar = (
           [key]: {
             type: input.collection ? "complex" : "value",
             value: input.default || defaultValue,
+            meta,
           },
         };
       }, {}),

--- a/packages/spectral/src/types/ComponentRegistry.ts
+++ b/packages/spectral/src/types/ComponentRegistry.ts
@@ -1,5 +1,5 @@
-import { ComponentManifest, PermissionAndVisibilityType } from ".";
-import { Prettify, UnionToIntersection } from "./utils";
+import type { ComponentManifest, ConfigVarVisibility } from ".";
+import type { Prettify, UnionToIntersection } from "./utils";
 
 /**
  * Root ComponentRegistry type exposed for augmentation.
@@ -29,19 +29,6 @@ export type ComponentRegistry = keyof IntegrationDefinitionComponentRegistry ext
         : never
     >;
 
-export interface ConnectionInputPermissionAndVisibility {
-  /**
-   * Optional value that sets the permission and visibility of the Config Var. @default "customer"
-   *
-   * "customer" - Customers can view and edit the Config Var.
-   * "embedded" - Customers cannot view or update the Config Var as the value will be set programmatically.
-   * "organization" - Customers cannot view or update the Config Var as it will always have a default value or be set by the organization.
-   */
-  permissionAndVisibilityType?: PermissionAndVisibilityType;
-  /** Optional value that specifies whether this Config Var is visible to an Organization deployer. @default true */
-  visibleToOrgDeployer?: boolean;
-}
-
 export type ConfigVarExpression = { configVar: string };
 export type ValueExpression<TValueType = unknown> = {
   value: TValueType;
@@ -58,8 +45,7 @@ type ComponentReferenceTypeValueMap<
     actions: ValueExpression<TValue>;
     triggers: ValueExpression<TValue> | ConfigVarExpression;
     dataSources: ValueExpression<TValue> | ConfigVarExpression;
-    connections: (ValueExpression<TValue> | ConfigVarExpression) &
-      ConnectionInputPermissionAndVisibility;
+    connections: (ValueExpression<TValue> | ConfigVarExpression) & ConfigVarVisibility;
   },
 > = TMap;
 

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -1,4 +1,4 @@
-import { ConnectionInput, OnPremConnectionInput } from ".";
+import type { ConnectionInput, OnPremConnectionInput } from ".";
 
 export enum OAuth2Type {
   ClientCredentials = "client_credentials",

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -95,7 +95,9 @@ export type ConnectionInput = (
   | TextInputField
   | PasswordInputField
   | BooleanInputField
-) & { shown?: boolean };
+) & {
+  shown?: boolean;
+};
 
 export type OnPremConnectionInput = {
   onPremControlled: true;


### PR DESCRIPTION
Allow users to set the visibility of Config Var Connections inputs, whether it's for reference or definitions config var connections in CNI. Here are the properties you can use: 

- `permissionAndVisibilityType`: Choose from "customer," "embedded," or "organization."
- `visibleToOrgDeployer`: Set this to true or false.

![Screen Shot 2024-08-01 at 19 05 55 PM](https://github.com/user-attachments/assets/aaf32a39-dab9-4386-bbc1-80713b679f20)

![Screen Shot 2024-08-01 at 19 05 09 PM](https://github.com/user-attachments/assets/2147b099-0e80-41cf-bcf1-607cb80358a5)

