### PR TITLE
Expose FlowExecutionContext types to better support abstracting action calls

### DIFF
--- a/packages/spectral-test/src/ComponentReference.test-d.ts
+++ b/packages/spectral-test/src/ComponentReference.test-d.ts
@@ -38,6 +38,7 @@ expectAssignable<
   | "onPremConnection"
   | "slackOAuth"
   | "selectChannels"
+  | "postMessage"
   | "hmac"
 >(slackRef.key);
 

--- a/packages/spectral-test/src/IntegrationDefinition.test-d.ts
+++ b/packages/spectral-test/src/IntegrationDefinition.test-d.ts
@@ -1,4 +1,8 @@
-import { integration } from "@prismatic-io/spectral";
+import {
+  integration,
+  FlowExecutionContext,
+  FlowExecutionContextActions,
+} from "@prismatic-io/spectral";
 import { Component } from "@prismatic-io/spectral/dist/serverTypes";
 import { expectAssignable } from "tsd";
 
@@ -23,6 +27,9 @@ const basicDefinition = integration({
         });
       },
       onExecution: async (context, params) => {
+        expectAssignable<(inputs: { connection: string; channel: string }) => Promise<any>>(
+          context.components.slack.postMessage,
+        );
         console.log(`Action context: ${JSON.stringify(context)}`);
         console.log(`Action params: ${JSON.stringify(params)}`);
         return Promise.resolve({
@@ -33,3 +40,11 @@ const basicDefinition = integration({
   ],
 });
 expectAssignable<Component>(basicDefinition);
+expectAssignable<Parameters<FlowExecutionContext["components"]["slack"]["postMessage"]>[0]>({
+  connection: "testConnection",
+  channel: "testChannel",
+});
+expectAssignable<Parameters<FlowExecutionContextActions["slack"]["postMessage"]>[0]>({
+  connection: "testConnection",
+  channel: "testChannel",
+});

--- a/packages/spectral-test/src/testData.test-d.ts
+++ b/packages/spectral-test/src/testData.test-d.ts
@@ -178,7 +178,22 @@ export const componentRegistry = {
     key: "slack",
     public: true,
     signature: "slack-signature" as const,
-    actions: {},
+    actions: {
+      postMessage: {
+        perform: (inputs: { connection: string; channel: string }) =>
+          Promise.resolve<unknown>(inputs),
+        inputs: {
+          connection: {
+            inputType: "connection",
+            required: true,
+          },
+          channel: {
+            inputType: "string",
+            required: true,
+          },
+        },
+      },
+    },
     triggers: {},
     dataSources: {
       selectChannels: {

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -13,6 +13,7 @@ import {
   UserLevelConfigPages,
   ValueExpression,
   ConfigVarExpression,
+  ActionContext,
 } from ".";
 
 /** Defines attributes of a Code-Native Integration. */
@@ -48,6 +49,31 @@ export type IntegrationDefinition = {
   componentRegistry?: ComponentRegistry;
 };
 
+export type FlowOnExecution<TTriggerPayload extends TriggerPayload> = ActionPerformFunction<
+  {
+    onTrigger: {
+      type: "data";
+      label: string;
+      clean: (value: unknown) => { results: TTriggerPayload };
+    };
+  },
+  ConfigVars,
+  {
+    [Key in keyof ComponentRegistry]: ComponentRegistry[Key]["actions"];
+  },
+  false,
+  ActionPerformReturn<false, unknown>
+>;
+
+export type FlowExecutionContext = ActionContext<
+  ConfigVars,
+  {
+    [Key in keyof ComponentRegistry]: ComponentRegistry[Key]["actions"];
+  }
+>;
+
+export type FlowExecutionContextActions = FlowExecutionContext["components"];
+
 /** Defines attributes of a Flow of a Code-Native Integration. */
 export interface Flow<TTriggerPayload extends TriggerPayload = TriggerPayload> {
   /** The unique name for this Flow. */
@@ -81,21 +107,7 @@ export interface Flow<TTriggerPayload extends TriggerPayload = TriggerPayload> {
   /** Specifies the function to execute when an Instance of an Integration is deleted. */
   onInstanceDelete?: TriggerEventFunction<Inputs, ConfigVars>;
   /** Specifies the main function for this Flow */
-  onExecution: ActionPerformFunction<
-    {
-      onTrigger: {
-        type: "data";
-        label: string;
-        clean: (value: unknown) => { results: TTriggerPayload };
-      };
-    },
-    ConfigVars,
-    {
-      [Key in keyof ComponentRegistry]: ComponentRegistry[Key]["actions"];
-    },
-    false,
-    ActionPerformReturn<false, unknown>
-  >;
+  onExecution: FlowOnExecution<TTriggerPayload>;
 }
 
 /** Defines attributes of a Preprocess Flow Configuration used by a Flow of an Integration. */


### PR DESCRIPTION
It's common for developers to want to abstract function calls using existing component actions. Extracting those types from the execution context was pretty difficult and required some inside knowledge about how module augmentation works. This exposes those types for use in these cases.