### PR TITLE
CNI - Resolved issues with import types concerning collections

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/getImports.ts
+++ b/packages/spectral/src/generators/componentManifest/getImports.ts
@@ -15,10 +15,10 @@ export const getImports = ({ inputs }: GetImportsProps) => {
     return {
       ...acc,
       [input.valueType.module]: acc[input.valueType.module]
-        ? !acc[input.valueType.module].includes(input.valueType.type)
-          ? [...acc[input.valueType.module], input.valueType.type]
+        ? !acc[input.valueType.module].includes(input.valueType.import)
+          ? [...acc[input.valueType.module], input.valueType.import]
           : acc[input.valueType.module]
-        : [input.valueType.type],
+        : [input.valueType.import],
     };
   }, {} as Imports);
 };


### PR DESCRIPTION
- Removed the unused `DocBlock` type.
- Consolidated redundant conditionals.
- Resolved issues with import types concerning collections. The problem was that when the input was a collection, we didn’t account for the possibility of it being an external type. Instead, we mistakenly assumed it was a string type, which was incorrect.