### PR TITLE
CNI - Allow ValidationMode definition for JSON forms

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.1.0",
+  "version": "9.1.2",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -20,6 +20,7 @@ import {
   CollectionType,
   KeyValuePair,
   ComponentManifest,
+  isJsonFormConfigVar,
 } from "../types";
 import {
   Component as ServerComponent,
@@ -603,6 +604,13 @@ const convertConfigVar = (
 
   if (isScheduleConfigVar(configVar)) {
     result.scheduleType = "custom";
+  }
+
+  if (isJsonFormConfigVar(configVar)) {
+    result.meta = {
+      ...result.meta,
+      validationMode: configVar?.validationMode ?? "ValidateAndShow",
+    };
   }
 
   if (isDataSourceDefinitionConfigVar(configVar)) {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -21,6 +21,7 @@ import {
   KeyValuePair,
   ComponentManifest,
   isJsonFormConfigVar,
+  isJsonFormDataSourceConfigVar,
 } from "../types";
 import {
   Component as ServerComponent,
@@ -606,7 +607,7 @@ const convertConfigVar = (
     result.scheduleType = "custom";
   }
 
-  if (isJsonFormConfigVar(configVar)) {
+  if (isJsonFormConfigVar(configVar) || isJsonFormDataSourceConfigVar(configVar)) {
     result.meta = {
       ...result.meta,
       validationMode: configVar?.validationMode ?? "ValidateAndShow",
@@ -630,6 +631,13 @@ const convertConfigVar = (
     result.dataType = componentRegistry[ref.component.key].dataSources[ref.key].dataSourceType;
     result.dataSource = ref;
     result.inputs = inputs;
+
+    if (configVar.validationMode) {
+      result.meta = {
+        ...result.meta,
+        validationMode: configVar.validationMode,
+      };
+    }
   }
 
   return result;

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -1,3 +1,4 @@
+import { ValidationMode } from "@jsonforms/core";
 import {
   type DataSourceDefinition,
   type ConnectionDefinition,
@@ -183,7 +184,9 @@ type ObjectSelectionConfigVar = CreateStandardConfigVar<"objectSelection">;
 
 type ObjectFieldMapConfigVar = CreateStandardConfigVar<"objectFieldMap">;
 
-type JsonFormConfigVar = CreateStandardConfigVar<"jsonForm">;
+type JsonFormConfigVar = CreateStandardConfigVar<"jsonForm"> & {
+  validationMode?: ValidationMode;
+};
 
 export type StandardConfigVar =
   | StringConfigVar
@@ -368,6 +371,9 @@ export const isCodeConfigVar = (cv: ConfigVar): cv is CodeConfigVar =>
 
 export const isScheduleConfigVar = (cv: ConfigVar): cv is ScheduleConfigVar =>
   "dataType" in cv && cv.dataType === "schedule";
+
+export const isJsonFormConfigVar = (cv: ConfigVar): cv is JsonFormConfigVar =>
+  "dataType" in cv && cv.dataType === "jsonForm";
 
 export const isDataSourceDefinitionConfigVar = (
   cv: ConfigVar,

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -188,6 +188,10 @@ type JsonFormConfigVar = CreateStandardConfigVar<"jsonForm"> & {
   validationMode?: ValidationMode;
 };
 
+type JsonFormDataSourceDefinitionConfigVar = DataSourceDefinitionConfigVar & {
+  validationMode?: ValidationMode;
+};
+
 export type StandardConfigVar =
   | StringConfigVar
   | DateConfigVar
@@ -209,10 +213,17 @@ type BaseDataSourceConfigVar<TDataSourceType extends DataSourceType = DataSource
         collectionType?: CollectionType | undefined;
       } & BaseConfigVar
     : TDataSourceType extends Exclude<DataSourceType, CollectionDataSourceType>
-      ? BaseConfigVar & {
-          dataSourceType: TDataSourceType;
-          collectionType?: undefined;
-        }
+      ? TDataSourceType extends Extract<DataSourceType, "jsonForm">
+        ? BaseConfigVar & {
+            dataSourceType: Extract<DataSourceType, "jsonForm">;
+            dataSource?: never;
+            collectionType?: undefined;
+            validationMode?: ValidationMode;
+          }
+        : BaseConfigVar & {
+            dataSourceType: TDataSourceType;
+            collectionType?: undefined;
+          }
       :
           | ({
               dataSourceType: Extract<CollectionDataSourceType, TDataSourceType>;
@@ -240,6 +251,7 @@ type DataSourceReferenceConfigVar =
   ComponentRegistryDataSource extends infer TDataSourceReference extends ComponentRegistryDataSource
     ? Omit<BaseDataSourceConfigVar<TDataSourceReference["dataSourceType"]>, "dataSourceType"> & {
         dataSource: TDataSourceReference["reference"];
+        validationMode?: ValidationMode;
       }
     : never;
 
@@ -374,6 +386,11 @@ export const isScheduleConfigVar = (cv: ConfigVar): cv is ScheduleConfigVar =>
 
 export const isJsonFormConfigVar = (cv: ConfigVar): cv is JsonFormConfigVar =>
   "dataType" in cv && cv.dataType === "jsonForm";
+
+export const isJsonFormDataSourceConfigVar = (
+  cv: ConfigVar,
+): cv is JsonFormDataSourceDefinitionConfigVar =>
+  "dataSourceType" in cv && cv.dataSourceType === "jsonForm";
 
 export const isDataSourceDefinitionConfigVar = (
   cv: ConfigVar,


### PR DESCRIPTION
This change allows users to define a `ValidationMode` for JSON forms via CNI.

This PR:
* Converts `validationMode` definitions into YAML when relevant
* Adds `validationMode` type hinting
* Adds simple type tests
* Bumps `spectral` version