### PR TITLE
Component manifests - Escape input strings

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -52,7 +52,7 @@ export const createActions = async ({
           typeInterface: createTypeInterface(action.key ?? actionKey),
           import: createImport(action.key ?? actionKey),
           key: action.key || actionKey,
-          label: action.display.description,
+          label: action.display.label,
           description: action.display.description,
           inputs,
         },

--- a/packages/spectral/src/generators/componentManifest/docBlock.ts
+++ b/packages/spectral/src/generators/componentManifest/docBlock.ts
@@ -1,3 +1,4 @@
+import { escapeSpecialCharacters } from "../utils/escapeSpecialCharacters";
 import { ServerTypeInput } from "./getInputs";
 
 export const DOC_BLOCK_DEFAULT = (input: ServerTypeInput): string => {
@@ -34,9 +35,11 @@ export const addLine = ({ key, value, raw }: AddLineProps) => {
     return "";
   }
 
-  const sanitizedValue = JSON.stringify(value)
-    .replace(/(^"|"$)|(^'|'$)/g, "")
-    .trim();
+  const sanitizedValue = escapeSpecialCharacters(
+    JSON.stringify(value)
+      .replace(/(^"|"$)|(^'|'$)/g, "")
+      .trim(),
+  );
 
   return ` * ${key ? `@${key} ${sanitizedValue}` : sanitizedValue}\n`;
 };

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -1,5 +1,6 @@
 import type { Input as InputBase } from "../../serverTypes";
 import type { InputFieldDefinition } from "../../types/Inputs";
+import { escapeSpecialCharacters } from "../utils/escapeSpecialCharacters";
 import { DOC_BLOCK_DEFAULT } from "./docBlock";
 
 export type ServerTypeInput = InputBase & {
@@ -25,11 +26,12 @@ interface GetInputsProps {
 }
 
 const getDefaultValue = (value: ServerTypeInput["default"]) => {
-  if (value === undefined || value === "" || typeof value === "string") {
+  if (value === undefined || value === "") {
     return value;
   }
 
-  return JSON.stringify(value);
+  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
+  return escapeSpecialCharacters(stringValue);
 };
 
 export const getInputs = ({ inputs, docBlock = DOC_BLOCK_DEFAULT }: GetInputsProps): Input[] => {

--- a/packages/spectral/src/generators/utils/escapeSpecialCharacters.ts
+++ b/packages/spectral/src/generators/utils/escapeSpecialCharacters.ts
@@ -1,0 +1,12 @@
+/**
+ * This regex targets common characters that may be included in default
+ * input values (code comment blocks, backticks, etc) and would cause
+ * component-manifest build issues. More characters may be added
+ * as discovered.
+ */
+
+const escapeRegEx = /(\/|\\|\`|\$)/g;
+
+export const escapeSpecialCharacters = (value = ""): string => {
+  return value.replace(escapeRegEx, "\\$&");
+};


### PR DESCRIPTION
This PR addresses an issue where including `/* doc blocks */` or `` `backticked` `` values in input fields would cause the component manifest generator to fail.