### PR TITLE
CNI - Bugfix - Default keyvaluelist items not converting to valid YAML

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.1.2",
+  "version": "9.1.3",
   "description": "Utility library for building Prismatic components",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -499,7 +499,7 @@ const convertInputValue = (value: unknown, collectionType: CollectionType | unde
 };
 
 /** Converts a Config Var into the structure necessary for YAML generation. */
-const convertConfigVar = (
+export const convertConfigVar = (
   key: string,
   configVar: ConfigVar,
   referenceKey: string,
@@ -533,13 +533,28 @@ const convertConfigVar = (
           },
         );
 
-        const defaultValue = input.collection ? [] : "";
+        const defaultValue = input.collection
+          ? (input.default || []).map((defaultValue) => {
+              if (typeof defaultValue === "string") {
+                return {
+                  type: "value",
+                  value: defaultValue,
+                };
+              }
+
+              return {
+                name: defaultValue.key,
+                type: "value",
+                value: defaultValue.value,
+              };
+            })
+          : input.default || "";
 
         return {
           ...result,
           [key]: {
             type: input.collection ? "complex" : "value",
-            value: input.default || defaultValue,
+            value: defaultValue,
             meta,
           },
         };


### PR DESCRIPTION
This PR addresses a CNI issue where including default `keyvaluelist` items as the type hinting described would not build valid YAML. It includes:

* An update to `convertConfigVar` to enable both `keyvaluelist` and `valuelist` config vars to be processed properly
* Basic tests for config var input conversion