### PR TITLE
Add code-native integrations to project descriptions

### DIFF
--- a/packages/eslint-config-spectral/package.json
+++ b/packages/eslint-config-spectral/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prismatic-io/eslint-config-spectral",
   "version": "2.0.2",
-  "description": "ESLint config for building Prismatic components",
+  "description": "ESLint config for building Prismatic components and code-native integrations",
   "keywords": [
     "prismatic",
     "eslint"

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prismatic-io/spectral",
   "version": "9.1.4",
-  "description": "Utility library for building Prismatic components",
+  "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Not bumping Spectral version, since this change is cosmetic and can go out with the next version of Spectral.