### PR TITLE
Add search params to debug output

### DIFF
--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -107,13 +107,14 @@ export const createClient = ({
 
   if (debug) {
     client.interceptors.request.use((request) => {
-      const { baseURL, headers, method, timeout, url, data } = request;
+      const { baseURL, headers, method, timeout, url, data, params } = request;
       const dataSize = objectSizeof(data);
       console.log(
         util.types.toJSON(
           {
             type: "request",
             baseURL,
+            params,
             url,
             headers,
             method,


### PR DESCRIPTION
This adds search parameters to debug log lines when debugging an HTTP request. 

![Screenshot 2024-09-26 at 11 34 40 AM](https://github.com/user-attachments/assets/76847ae0-04ad-4836-8094-2d4b36a97247)
