### PR TITLE
Add support for connection avatar icons

### DIFF
--- a/packages/spectral-test/src/ConnectionDefinition.test-d.ts
+++ b/packages/spectral-test/src/ConnectionDefinition.test-d.ts
@@ -3,7 +3,10 @@ import { expectAssignable, expectNotAssignable } from "tsd";
 
 const valid = onPremConnection({
   key: "basic",
-  label: "Basic Connection",
+  display: {
+    label: "Basic Connection",
+    description: "",
+  },
   inputs: {
     host: {
       label: "Host",
@@ -43,7 +46,10 @@ expectAssignable<OnPremConnectionDefinition>(valid);
 
 const invalid = {
   key: "basic",
-  label: "Basic Connection",
+  display: {
+    label: "Basic Connection",
+    description: "",
+  },
   inputs: {
     username: {
       label: "Username",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "9.3.1",
+  "version": "10.0.0",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/harness-testing.test.ts
+++ b/packages/spectral/src/harness-testing.test.ts
@@ -6,7 +6,10 @@ import util from "./util";
 
 const testConnection = connection({
   key: "connection",
-  label: "Test Connection",
+  display: {
+    label: "Test Connection",
+    description: "",
+  },
   oauth2Type: OAuth2Type.AuthorizationCode,
   inputs: {
     authorizeUrl: {

--- a/packages/spectral/src/invoke-testing.test.ts
+++ b/packages/spectral/src/invoke-testing.test.ts
@@ -3,8 +3,10 @@ import { invoke, invokeTrigger, invokeDataSource, createConnection } from "./tes
 
 const myConnection = connection({
   key: "myConnection",
-  label: "My Connection",
-  comments: "This is my connection",
+  display: {
+    label: "My Connection",
+    description: "This is my connection",
+  },
   inputs: {
     username: {
       label: "Username",

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,0 +1,22 @@
+import { connection } from "..";
+import { convertConnection } from "./convertComponent";
+
+describe("convertConnection", () => {
+  const label = "My Basic Connection";
+  const description = "This is a basic connection.";
+
+  const basicConnection = connection({
+    key: "my-basic-connection",
+    display: {
+      label,
+      description,
+    },
+    inputs: {},
+  });
+
+  it("correctly converts the display block", async () => {
+    const convertedConnection = convertConnection(basicConnection);
+    expect(convertedConnection.label).toBe(label);
+    expect(convertedConnection.comments).toBe(description);
+  });
+});

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -146,14 +146,23 @@ const convertDataSource = (
   };
 };
 
-const convertConnection = ({
+export const convertConnection = ({
   inputs = {},
   ...connection
 }: ConnectionDefinition): ServerConnection => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
 
+  const {
+    display: { label, icons, description: comments },
+    ...remaining
+  } = connection;
+
   return {
-    ...connection,
+    ...remaining,
+    label,
+    comments,
+    iconPath: icons?.oauth2ConnectionIconPath,
+    avatarIconPath: icons?.avatarPath,
     inputs: convertedInputs,
   };
 };

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -973,7 +973,13 @@ const codeNativeIntegrationComponent = (
 
   const convertedTriggers = flows.reduce<Record<string, ServerTrigger>>(
     (result, { name, onTrigger, onInstanceDeploy, onInstanceDelete, schedule }) => {
-      if (!flowUsesWrapperTrigger({ onTrigger, onInstanceDelete, onInstanceDeploy })) {
+      if (
+        !flowUsesWrapperTrigger({
+          onTrigger,
+          onInstanceDelete,
+          onInstanceDeploy,
+        })
+      ) {
         // In this scenario, the user has defined an existing component trigger
         // without any custom behavior, so we don't need to wrap anything.
         return result;
@@ -1067,12 +1073,16 @@ const codeNativeIntegrationComponent = (
         convertInput(key, value),
       );
 
-      const connection = pick(configVar, ["oauth2Type", "iconPath"]);
+      const connection = pick(configVar, ["oauth2Type"]);
+      const { avatarPath: avatarIconPath, oauth2ConnectionIconPath: iconPath } =
+        configVar.icons ?? {};
 
       return [
         ...result,
         {
           ...connection,
+          iconPath,
+          avatarIconPath,
           inputs: convertedInputs,
           key: camelCase(key),
           label: key,

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -213,6 +213,7 @@ export interface Connection {
   comments?: string;
   oauth2Type?: OAuth2Type;
   iconPath?: string;
+  avatarIconPath?: string;
   inputs: (Input & { shown?: boolean; onPremControlled?: boolean })[];
 }
 

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -270,7 +270,8 @@ type ConnectionDefinitionConfigVar =
   ConnectionDefinition extends infer TConnectionDefinitionType extends ConnectionDefinition
     ? TConnectionDefinitionType extends infer TConnectionDefinition extends ConnectionDefinition
       ? BaseConnectionConfigVar &
-          Omit<TConnectionDefinition, "inputs" | "label" | "comments" | "key"> & {
+          Omit<TConnectionDefinition, "inputs" | "display" | "key"> & {
+            icons?: TConnectionDefinition["display"]["icons"];
             inputs: {
               [Key in keyof TConnectionDefinition["inputs"]]: TConnectionDefinition["inputs"][Key] &
                 ConfigVarInputVisibility;
@@ -382,7 +383,9 @@ type ExtractConfigVars<TConfigPages extends { [key: string]: ConfigPage }> =
     : never;
 
 type ExtractScopedConfigVars<
-  TScopedConfigVarMap extends { [key: string]: string | OrganizationActivatedConnectionConfigVar },
+  TScopedConfigVarMap extends {
+    [key: string]: string | OrganizationActivatedConnectionConfigVar;
+  },
 > = keyof TScopedConfigVarMap extends infer TScopedConfigVarName
   ? TScopedConfigVarName extends keyof TScopedConfigVarMap
     ? TScopedConfigVarMap[TScopedConfigVarName] extends infer TScopedConfigVar

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -1,4 +1,4 @@
-import type { ConnectionInput, OnPremConnectionInput } from ".";
+import type { ConnectionDisplayDefinition, ConnectionInput, OnPremConnectionInput } from ".";
 
 export enum OAuth2Type {
   ClientCredentials = "client_credentials",
@@ -12,9 +12,7 @@ export enum OAuth2PkceMethod {
 
 interface BaseConnectionDefinition {
   key: string;
-  label: string;
-  comments?: string;
-  iconPath?: string;
+  display: ConnectionDisplayDefinition;
   oauth2Type?: OAuth2Type;
 }
 

--- a/packages/spectral/src/types/DisplayDefinition.ts
+++ b/packages/spectral/src/types/DisplayDefinition.ts
@@ -36,3 +36,13 @@ export interface ActionDisplayDefinition extends DisplayDefinition {
   /** Indicate that this Action is important and/or commonly used from the parent Component. Should be enabled sparingly. */
   important?: boolean;
 }
+
+/** Connection-specific Display attributes. */
+export interface ConnectionDisplayDefinition extends DisplayDefinition {
+  icons?: {
+    /** Path to icon to use for this Connection. Path should be relative to the built component source. */
+    avatarPath?: string;
+    /** Path to icon to use for this Connection's "Connect" button. Path should be relative to the built component source. */
+    oauth2ConnectionIconPath?: string;
+  };
+}


### PR DESCRIPTION
This adds support for the new `connectionAvatarIcon`. This allows distinguishing between the icon displayed as the avatar and the icon used for the OAuth connect button.

In order to support this for components and CNI there is a breaking change for connection definitions. `label` and `comment` are now nested in a `display` block to match other definition interfaces. This display block defines `icons` for both avatar icon and oAuthConnectionButton icon.