### PR TITLE
CNI: Support custom OAuth2 URI redirects on connections

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -642,7 +642,10 @@ export const convertConfigVar = (
         };
       }, {}),
       orgOnly,
-      meta,
+      meta: {
+        ...meta,
+        ...("oauth2Config" in configVar ? configVar.oauth2Config ?? {} : {}),
+      },
     };
   }
 
@@ -671,7 +674,10 @@ export const convertConfigVar = (
       },
       inputs,
       orgOnly,
-      meta,
+      meta: {
+        ...meta,
+        ...("oauth2Config" in configVar ? configVar.oauth2Config ?? {} : {}),
+      },
     };
   }
 

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -35,9 +35,14 @@ interface OAuth2Config {
   allowedTokenParams?: string[];
 }
 
+export interface OAuth2UrlOverrides {
+  oAuthSuccessRedirectUri?: string;
+  oAuthFailureRedirectUri?: string;
+}
+
 interface OAuth2AuthorizationCodeConnectionDefinition extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.AuthorizationCode;
-  oauth2Config?: OAuth2Config;
+  oauth2Config?: OAuth2Config & OAuth2UrlOverrides;
   /** The PKCE method (S256 or plain) that this OAuth 2.0 connection uses (if any) */
   oauth2PkceMethod?: OAuth2PkceMethod;
   inputs: {
@@ -52,6 +57,7 @@ interface OAuth2AuthorizationCodeConnectionDefinition extends BaseConnectionDefi
 
 interface OAuth2ClientCredentialConnectionDefinition extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.ClientCredentials;
+  oauth2Config?: OAuth2UrlOverrides;
   inputs: {
     tokenUrl: ConnectionInput;
     scopes: ConnectionInput;


### PR DESCRIPTION
This change adds the ability to configure custom redirect URI's on connectionConfigVars using either connectionDefinitions or prebuilt connections.