### PR TITLE
Add default retryCondition method to AxiosRetryConfig

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -1,7 +1,11 @@
 import { isEmpty } from "lodash";
 import axios, { AxiosResponse } from "axios";
 import { AxiosInstance, AxiosRequestConfig } from "axios";
-import axiosRetry, { IAxiosRetryConfig, exponentialDelay } from "axios-retry";
+import axiosRetry, {
+  IAxiosRetryConfig,
+  exponentialDelay,
+  isNetworkOrIdempotentRequestError,
+} from "axios-retry";
 import FormData from "form-data";
 import objectSizeof from "object-sizeof";
 
@@ -83,7 +87,11 @@ const toAxiosRetryConfig = ({
 }: RetryConfig): IAxiosRetryConfig => ({
   ...rest,
   retryDelay: computeRetryDelay(retryDelay, useExponentialBackoff),
-  retryCondition: retryAllErrors ? () => true : retryCondition,
+  retryCondition: retryAllErrors
+    ? () => true
+    : typeof retryCondition === "function"
+      ? retryCondition
+      : isNetworkOrIdempotentRequestError,
 });
 
 export const createClient = ({


### PR DESCRIPTION
Some users were ending up in a situation where leaving `retryCondition` undefined would result in a `retryCondition is not a function` error.

Normally leaving this field blank shouldn't cause issues (`retryCondition` is an optional field), but this fallback should cover any strange corner cases.