### PR TITLE
Run input clean functions even if value not explicitly provided

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.1.1",
+  "version": "10.2.0",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/perform.test.ts
+++ b/packages/spectral/src/serverTypes/perform.test.ts
@@ -1,0 +1,26 @@
+import { cleanParams, type CleanFn } from "./perform";
+
+describe("cleanParams", () => {
+  it.each<{
+    params: Record<string, unknown>;
+    cleaners: Record<string, CleanFn | undefined>;
+    expected: Record<string, unknown>;
+  }>([
+    // Ensure all empty produces empty values collection
+    { params: {}, cleaners: {}, expected: {} },
+    // Ensure matched cleaners produce expected result
+    {
+      params: { foo: null },
+      cleaners: { foo: (v: unknown) => "changed" },
+      expected: { foo: "changed" },
+    },
+    // Ensure cleaners run even if input value not explicitly provided
+    {
+      params: {},
+      cleaners: { foo: (v: unknown) => "ran" },
+      expected: { foo: "ran" },
+    },
+  ])("runs input clean functions", ({ params, cleaners, expected }) => {
+    expect(cleanParams(params, cleaners)).toStrictEqual(expected);
+  });
+});

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -9,6 +9,7 @@ import type {
   PollingTriggerPerformFunction,
 } from "../types";
 import { type PollingTriggerDefinition } from "../types/PollingTriggerDefinition";
+import { uniq } from "lodash";
 
 export type PerformFn = (...args: any[]) => Promise<any>;
 export type CleanFn = (...args: any[]) => any;
@@ -20,14 +21,17 @@ interface CreatePerformProps {
   errorHandler?: ErrorHandler;
 }
 
-const cleanParams = (
+export const cleanParams = (
   params: Record<string, unknown>,
   cleaners: InputCleaners,
-): Record<string, any> =>
-  Object.entries(params).reduce<Record<string, any>>((result, [key, value]) => {
+): Record<string, any> => {
+  const keys = uniq([...Object.keys(params), ...Object.keys(cleaners)]);
+  return keys.reduce<Record<string, any>>((result, key) => {
+    const value = params[key];
     const cleanFn = cleaners[key];
     return { ...result, [key]: cleanFn ? cleanFn(value) : value };
   }, {});
+};
 
 export const createPerform = (
   performFn: PerformFn,


### PR DESCRIPTION
Previous behavior was to iterate over the collection of provided inputs but this meant that certain scenarios, such as version upgrades, wouldn't get an opportunity to run input clean functions if the value wasn't present in the collection of input values.

Now clean functions will be given `undefined` and an opportunity to run and clean the value into something usable/expected.