### PR TITLE
Add polledNoChanges field to polling TriggerResults

### DIFF
--- a/packages/spectral-test/src/PollingTriggerDefinition.test-d.ts
+++ b/packages/spectral-test/src/PollingTriggerDefinition.test-d.ts
@@ -19,7 +19,7 @@ const myPollingTrigger = pollingTrigger({
   },
   pollAction: myAction,
   perform: async (context, payload, params) => {
-    return Promise.resolve({ payload, polledNewChanges: false });
+    return Promise.resolve({ payload, polledNoChanges: true });
   },
 });
 
@@ -29,7 +29,7 @@ const pollingTriggerWithoutAction = pollingTrigger({
     description: "My Polling Trigger Description",
   },
   perform: async (context, payload, params) => {
-    return Promise.resolve({ payload, polledNewChanges: false });
+    return Promise.resolve({ payload, polledNoChanges: true });
   },
 });
 

--- a/packages/spectral-test/src/PollingTriggerDefinition.test-d.ts
+++ b/packages/spectral-test/src/PollingTriggerDefinition.test-d.ts
@@ -19,7 +19,7 @@ const myPollingTrigger = pollingTrigger({
   },
   pollAction: myAction,
   perform: async (context, payload, params) => {
-    return Promise.resolve({ payload });
+    return Promise.resolve({ payload, polledNewChanges: false });
   },
 });
 
@@ -29,7 +29,7 @@ const pollingTriggerWithoutAction = pollingTrigger({
     description: "My Polling Trigger Description",
   },
   perform: async (context, payload, params) => {
-    return Promise.resolve({ payload });
+    return Promise.resolve({ payload, polledNewChanges: false });
   },
 });
 

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from "./types";
 import { convertComponent } from "./serverTypes/convertComponent";
 import { convertIntegration } from "./serverTypes/convertIntegration";
-import { PollingTriggerDefinition, PollingTriggerResult } from "./types/PollingTriggerDefinition";
+import { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
 
 /**
  * This function creates a Integration object that can be
@@ -177,11 +177,26 @@ export const pollingTrigger = <
   TInputs extends Inputs,
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
-  TResult extends PollingTriggerResult<TPayload>,
+  TAllowsBranching extends boolean,
+  TResult extends TriggerResult<TAllowsBranching, TPayload>,
   TActionInputs extends Inputs,
 >(
-  definition: PollingTriggerDefinition<TInputs, TConfigVars, TPayload, TResult, TActionInputs>,
-): PollingTriggerDefinition<TInputs, TConfigVars, TPayload, TResult, TActionInputs> => {
+  definition: PollingTriggerDefinition<
+    TInputs,
+    TConfigVars,
+    TPayload,
+    TAllowsBranching,
+    TResult,
+    TActionInputs
+  >,
+): PollingTriggerDefinition<
+  TInputs,
+  TConfigVars,
+  TPayload,
+  TAllowsBranching,
+  TResult,
+  TActionInputs
+> => {
   return { ...definition, triggerType: "polling" };
 };
 

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from "./types";
 import { convertComponent } from "./serverTypes/convertComponent";
 import { convertIntegration } from "./serverTypes/convertIntegration";
-import { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
+import { PollingTriggerDefinition, PollingTriggerResult } from "./types/PollingTriggerDefinition";
 
 /**
  * This function creates a Integration object that can be
@@ -177,7 +177,7 @@ export const pollingTrigger = <
   TInputs extends Inputs,
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
-  TResult extends TriggerResult<boolean, TPayload>,
+  TResult extends PollingTriggerResult<TPayload>,
   TActionInputs extends Inputs,
 >(
   definition: PollingTriggerDefinition<TInputs, TConfigVars, TPayload, TResult, TActionInputs>,

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -8,7 +8,6 @@ import type {
   PollingContext,
   PollingTriggerPerformFunction,
   TriggerResult,
-  TriggerResultType,
 } from "../types";
 import { type PollingTriggerDefinition } from "../types/PollingTriggerDefinition";
 import { uniq } from "lodash";

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -121,7 +121,7 @@ export const createPollingPerform = (
 
       return {
         ...rest,
-        returnType: polledNoChanges ? "polled_no_changes" : "completed",
+        resultType: polledNoChanges ? "polled_no_changes" : "completed",
       };
     } catch (error) {
       throw errorHandler ? errorHandler(error) : error;

--- a/packages/spectral/src/types/PollingTriggerDefinition.ts
+++ b/packages/spectral/src/types/PollingTriggerDefinition.ts
@@ -9,6 +9,7 @@ import type {
   ActionDefinition,
   ActionContext,
   ActionInputParameters,
+  TriggerBaseResult,
 } from ".";
 
 export interface PollingContext<
@@ -26,12 +27,17 @@ export interface PollingContext<
   };
 }
 
+export interface PollingTriggerResult<TPayload extends TriggerPayload = TriggerPayload>
+  extends TriggerBaseResult<TPayload> {
+  polledNewChanges: boolean;
+}
+
 export type PollingTriggerPerformFunction<
   TInputs extends Inputs,
   TActionInputs extends Inputs,
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
-  TResult extends TriggerResult<boolean, TPayload> = TriggerResult<boolean, TPayload>,
+  TResult extends PollingTriggerResult = PollingTriggerResult,
 > = (
   context: ActionContext<TConfigVars> & PollingContext<TActionInputs>,
   payload: TPayload,
@@ -46,7 +52,7 @@ export type PollingTriggerDefinition<
   TInputs extends Inputs = Inputs,
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
-  TResult extends TriggerResult<boolean, TPayload> = TriggerResult<boolean, TPayload>,
+  TResult extends PollingTriggerResult<TPayload> = PollingTriggerResult<TPayload>,
   TActionInputs extends Inputs = Inputs,
   TAction extends ActionDefinition<TActionInputs> = ActionDefinition<TActionInputs>,
   TCombinedInputs extends TInputs & TActionInputs = TInputs & TActionInputs,

--- a/packages/spectral/src/types/PollingTriggerDefinition.ts
+++ b/packages/spectral/src/types/PollingTriggerDefinition.ts
@@ -49,7 +49,7 @@ export type PollingTriggerPerformFunction<
  * PollingTriggerDefinition is the type of the object that is passed in to `pollingTrigger` function to
  * define a component trigger.
  */
-export type PollingTriggerDefinition<
+export interface PollingTriggerDefinition<
   TInputs extends Inputs = Inputs,
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
@@ -61,7 +61,7 @@ export type PollingTriggerDefinition<
   TActionInputs extends Inputs = Inputs,
   TAction extends ActionDefinition<TActionInputs> = ActionDefinition<TActionInputs>,
   TCombinedInputs extends TInputs & TActionInputs = TInputs & TActionInputs,
-> = {
+> {
   triggerType?: "polling";
   /** Defines how the Action is displayed in the Prismatic interface. */
   display: ActionDisplayDefinition;
@@ -84,7 +84,9 @@ export type PollingTriggerDefinition<
   inputs?: TInputs;
   /** Determines whether this Trigger allows Conditional Branching. */
   allowsBranching?: TAllowsBranching;
-};
+  /** An example of the payload outputted by this Trigger. */
+  examplePayload?: Awaited<ReturnType<this["perform"]>>;
+}
 
 export const isPollingTriggerDefinition = (ref: unknown): ref is PollingTriggerDefinition =>
   typeof ref === "object" && ref !== null && "triggerType" in ref && ref.triggerType === "polling";

--- a/packages/spectral/src/types/TriggerResult.ts
+++ b/packages/spectral/src/types/TriggerResult.ts
@@ -21,8 +21,8 @@ export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   failed?: boolean;
   /** A field populated by the Prismatic platform which may refer to an object that contains data about any error that resulted in failure. */
   error?: Record<string, unknown>;
-  /** A field populated by the Prismatic platform which labels the trigger's return type. */
-  returnType?: TriggerResultType;
+  /** A field populated by the Prismatic platform which labels the trigger's result type. */
+  resultType?: TriggerResultType;
   /** An optional field that component authors can use to denote their CNI trigger result as having a polling response. */
   polledNoChanges?: boolean;
 }

--- a/packages/spectral/src/types/TriggerResult.ts
+++ b/packages/spectral/src/types/TriggerResult.ts
@@ -19,6 +19,8 @@ export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   failed?: boolean;
   /** A field populated by the Prismatic platform which may refer to an object that contains data about any error that resulted in failure. */
   error?: Record<string, unknown>;
+  /** An optional field that component authors can use to denote their CNI trigger result as having a polling response. */
+  polledNewChanges?: boolean;
 }
 
 /** Represents the result of a Trigger action that uses branching. */

--- a/packages/spectral/src/types/TriggerResult.ts
+++ b/packages/spectral/src/types/TriggerResult.ts
@@ -1,6 +1,8 @@
 import { TriggerPayload } from "./TriggerPayload";
 import { HttpResponse } from "./HttpResponse";
 
+export type TriggerResultType = "completed" | "polled_no_changes";
+
 /** Represents the result of a Trigger action. */
 export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   /** The payload in the request that invoked the Integration, which is returned as a result for later use. */
@@ -19,8 +21,10 @@ export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   failed?: boolean;
   /** A field populated by the Prismatic platform which may refer to an object that contains data about any error that resulted in failure. */
   error?: Record<string, unknown>;
+  /** A field populated by the Prismatic platform which labels the trigger's return type. */
+  returnType?: TriggerResultType;
   /** An optional field that component authors can use to denote their CNI trigger result as having a polling response. */
-  polledNewChanges?: boolean;
+  polledNoChanges?: boolean;
 }
 
 /** Represents the result of a Trigger action that uses branching. */

--- a/packages/spectral/src/types/TriggerResult.ts
+++ b/packages/spectral/src/types/TriggerResult.ts
@@ -1,8 +1,6 @@
 import { TriggerPayload } from "./TriggerPayload";
 import { HttpResponse } from "./HttpResponse";
 
-export type TriggerResultType = "completed" | "polled_no_changes";
-
 /** Represents the result of a Trigger action. */
 export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   /** The payload in the request that invoked the Integration, which is returned as a result for later use. */
@@ -21,8 +19,6 @@ export interface TriggerBaseResult<TPayload extends TriggerPayload> {
   failed?: boolean;
   /** A field populated by the Prismatic platform which may refer to an object that contains data about any error that resulted in failure. */
   error?: Record<string, unknown>;
-  /** A field populated by the Prismatic platform which labels the trigger's result type. */
-  resultType?: TriggerResultType;
   /** An optional field that component authors can use to denote their CNI trigger result as having a polling response. */
   polledNoChanges?: boolean;
 }


### PR DESCRIPTION
Setting this field to `true` will mark the execution as having no results in the backend, thus resulting in filterable logs in the frontend UI.

Other notes:
* Added support for conditional branching in polling triggers (was not intentionally excluded previously)
* Updated types
