### PR TITLE
Require integrations to have a stableKey defined

### DIFF
--- a/packages/spectral-test/src/ConfigPages.test-d.ts
+++ b/packages/spectral-test/src/ConfigPages.test-d.ts
@@ -95,6 +95,7 @@ const triggerFlow = flow({
 });
 
 integration({
+  stableKey: "config-pages-integration",
   name: "Config Pages",
   flows: [basicFlow, triggerFlow],
   configPages,

--- a/packages/spectral-test/src/IntegrationDefinition.test-d.ts
+++ b/packages/spectral-test/src/IntegrationDefinition.test-d.ts
@@ -7,6 +7,7 @@ import { Component } from "@prismatic-io/spectral/dist/serverTypes";
 import { expectAssignable } from "tsd";
 
 const basicDefinition = integration({
+  stableKey: "basic-test-integration",
   name: "Basic Code Native Integration",
   description: "This is a basic Code Native Integration",
   category: "Basic",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Utility library for building Prismatic components and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -55,7 +55,7 @@ export const convertIntegration = (definition: IntegrationDefinition): ServerCom
   // Generate a unique reference key that will be used to reference the
   // actions, triggers, data sources, and connections that are created
   // inline as part of the integration definition.
-  const referenceKey = uuid();
+  const referenceKey = `${definition.stableKey}_cni_component`;
 
   const scopedConfigVars = definition.scopedConfigVars ?? {};
   const configVars: Record<string, ConfigVar> = Object.values({
@@ -97,6 +97,7 @@ export const convertIntegration = (definition: IntegrationDefinition): ServerCom
   return {
     ...cniComponent,
     codeNativeIntegrationYAML: cniYaml,
+    codeNativeIntegrationStableKey: definition.stableKey,
   };
 };
 
@@ -128,6 +129,7 @@ const convertConfigPages = (
 
 const codeNativeIntegrationYaml = (
   {
+    stableKey,
     name,
     description,
     category,
@@ -194,6 +196,7 @@ const codeNativeIntegrationYaml = (
   const result = {
     definitionVersion: DefinitionVersion,
     isCodeNative: true,
+    stableKey,
     name,
     description,
     category,

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -32,6 +32,7 @@ export interface Component {
   dataSources: Record<string, DataSource>;
   connections: Connection[];
   codeNativeIntegrationYAML?: string;
+  codeNativeIntegrationStableKey?: string;
 }
 
 export interface Action {

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -19,6 +19,8 @@ import {
 
 /** Defines attributes of a Code-Native Integration. */
 export type IntegrationDefinition = {
+  /** A unique, unchanging value that is used to maintain identity for the Integration even if the name changes. */
+  stableKey: string;
   /** The unique name for this Integration. */
   name: string;
   /** Optional description for this Integration. */


### PR DESCRIPTION
**Open questions:**

* Does adding `stableKey` to the integration definition require us to update the definition version?
  * Note: Either way we should not actually merge this until we confirm that the backend YAML validator can accept `stableKey`s on integrations.
* This is technically a breaking change but doesn't feel like it warrants a v10 => v11 bump. Addressing the fix is also very quick on the DX-side (just add a stableKey to the integration). Should we bump to 10.3.0 or 11?

Related prism change: https://github.com/prismatic-io/prism/pull/120