### PR TITLE
Update ActionContexts to support debug methods

### DIFF
--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -950,14 +950,26 @@ const convertOnExecution =
       {},
     );
 
-    return onExecution(
-      {
-        ...context,
-        components: componentMethods,
-        invokeFlow: createInvokeFlow(context, { isCNI: true }),
+    const actionContext = {
+      ...context,
+      components: componentMethods,
+      invokeFlow: createInvokeFlow(context, { isCNI: true }),
+      debug: {
+        enabled: Boolean(context.globalDebug),
+        timeElapsed: {
+          start: (label: string) => {},
+          end: (label: string) => {},
+        },
+        memoryUsage: (label: string, showDetail: boolean) => {},
+        allowedMemory: Number(context.runnerAllocatedMemoryMb),
+        results: {
+          timeElapsed: [],
+          memoryUsage: [],
+        },
       },
-      params,
-    );
+    };
+
+    return onExecution(actionContext, params);
   };
 
 /** Creates the structure necessary to import a Component as part of a

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -14,6 +14,7 @@ import {
   ComponentManifest,
   FlowInvoker,
   ExecutionFrame,
+  DebugContext,
 } from "../types";
 
 interface DisplayDefinition {
@@ -78,11 +79,6 @@ export type ActionContext<
   executionState: Record<string, unknown>;
   integrationState: Record<string, unknown>;
   configVars: TConfigVars;
-  components: {
-    [K in keyof TComponentActions]: {
-      [A in keyof TComponentActions[K]]: TComponentActions[K][A]["perform"];
-    };
-  };
   stepId: string;
   executionId: string;
   webhookUrls: Record<string, string>;
@@ -94,9 +90,20 @@ export type ActionContext<
   integration: IntegrationAttributes;
   flow: FlowAttributes;
   startedAt: string;
-  invokeFlow: FlowInvoker<TFlows>;
   executionFrame: ExecutionFrame;
-  globalDebug: boolean;
+
+  // @TODO - Hidden from the user-facing ActionContext.
+  globalDebug?: boolean;
+  runnerAllocatedMemoryMb?: number;
+
+  // @TODO - Added by the Spectral layer. Separate these out eventually
+  components: {
+    [K in keyof TComponentActions]: {
+      [A in keyof TComponentActions[K]]: TComponentActions[K][A]["perform"];
+    };
+  };
+  invokeFlow: FlowInvoker<TFlows>;
+  debug: DebugContext;
 };
 
 type TriggerOptionChoice = "invalid" | "valid" | "required";

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -187,7 +187,19 @@ const createActionContext = <
       stepName: "some-step",
       loopPath: "",
     },
-    globalDebug: false,
+    debug: {
+      enabled: false,
+      timeElapsed: {
+        start: (label: string) => {},
+        end: (label: string) => {},
+      },
+      memoryUsage: (label: string, showDetail: boolean) => {},
+      allowedMemory: 1024,
+      results: {
+        timeElapsed: [],
+        memoryUsage: [],
+      },
+    },
     ...context,
   };
 };

--- a/packages/spectral/src/types/ActionPerformFunction.ts
+++ b/packages/spectral/src/types/ActionPerformFunction.ts
@@ -25,6 +25,40 @@ interface CustomLineage {
   customSource: string;
 }
 
+export interface DebugContext {
+  /** Denotes whether code should be executed in debug mode. */
+  enabled: boolean;
+  /** Helper methods for measuring how long a process takes between a start and end mark. Only runs if debug.enabled is true. */
+  timeElapsed: {
+    start: (label: string) => void;
+    end: (label: string) => void;
+  };
+  /** Measures memory usage up until that point in the process. Only runs if debug.enabled is true. */
+  memoryUsage: (label: string, showDetail: boolean) => void;
+  /** Memory limit in MB */
+  allowedMemory: number;
+  /** Resulting debug measurements that can be logged or saved. */
+  results: DebugResult;
+}
+
+interface DebugResult {
+  timeElapsed: Array<{
+    marks: Array<string>;
+    duration: number;
+  }>;
+  memoryUsage: Array<{
+    mark: string;
+    rss: number;
+    detail?: {
+      rss: number;
+      heapTotal: number;
+      heapUsed: number;
+      external: number;
+      arrayBuffers: number;
+    };
+  }>;
+}
+
 export type ExecutionFrame =
   | ({
       invokedByExecutionJWT: string;
@@ -44,11 +78,17 @@ export type FlowInvoker<TFlows extends Readonly<string[]> | undefined> = (
 
 /** Definition of the function to perform when an Action is invoked. */
 export type ActionPerformFunction<
-  TInputs extends Inputs,
-  TConfigVars extends ConfigVarResultCollection,
-  TComponentActions extends Record<string, ComponentManifest["actions"]>,
-  TAllowsBranching extends boolean | undefined,
-  TReturn extends ActionPerformReturn<TAllowsBranching, unknown>,
+  TInputs extends Inputs = Inputs,
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TComponentActions extends Record<string, ComponentManifest["actions"]> = Record<
+    string,
+    ComponentManifest["actions"]
+  >,
+  TAllowsBranching extends boolean | undefined = undefined,
+  TReturn extends ActionPerformReturn<TAllowsBranching, unknown> = ActionPerformReturn<
+    TAllowsBranching,
+    unknown
+  >,
 > = (
   context: ActionContext<TConfigVars, TComponentActions>,
   params: ActionInputParameters<TInputs>,
@@ -103,10 +143,10 @@ export type ActionContext<
   flow: FlowAttributes;
   /** The time in UTC that execution started. */
   startedAt: string;
-  /** Function to invoke an execution of another flow.. */
+  /** Function to invoke an execution of another flow. */
   invokeFlow: FlowInvoker<TFlows>;
   /** Reference to the current execution and, when applicable, the current step. */
   executionFrame: ExecutionFrame;
-  /** Denotes whether code should be executed in debug mode. */
-  globalDebug: boolean;
+  /** Contains methods, flags, and data to support debug modes. */
+  debug: DebugContext;
 };


### PR DESCRIPTION
Currently there are two `ActionContext` types in spectral -- one to represent the context passed by the runner, and the other to represent the context presented to the end user.

We want to support divergence in these two types, though currently there is an unclear mix of references to the `ServerActionContext` and `ActionContext` throughout the conversion layer -- rather than sorting that out as part of the debug support work; I've marked areas with `TODOs` to be returned to later and have this current approach up for feedback.