### PR TITLE
Add --version flag to component-manifest command

### DIFF
--- a/packages/spectral/src/generators/componentManifest/cli.ts
+++ b/packages/spectral/src/generators/componentManifest/cli.ts
@@ -8,7 +8,6 @@ import { createFlagHelpText } from "../utils/createFlagHelpText";
 import { getFlagsStringValue } from "../utils/getFlagStringValue";
 import { getFlagsBooleanValue } from "../utils/getFlagBooleanValue";
 import { isObjectWithOneTruthyKey, isObjectWithTruthyKeys } from "../../util";
-import { getSpectralVersion } from "../utils/getSpectralVersion";
 
 export const runMain = async (process: NodeJS.Process) => {
   const componentDir = process.cwd();
@@ -87,7 +86,8 @@ export const runMain = async (process: NodeJS.Process) => {
   };
 
   if (flags.version.value) {
-    console.log(getSpectralVersion());
+    const { version } = require("../../../package.json");
+    console.log(version);
     process.exit(0);
   }
 

--- a/packages/spectral/src/generators/componentManifest/cli.ts
+++ b/packages/spectral/src/generators/componentManifest/cli.ts
@@ -8,6 +8,7 @@ import { createFlagHelpText } from "../utils/createFlagHelpText";
 import { getFlagsStringValue } from "../utils/getFlagStringValue";
 import { getFlagsBooleanValue } from "../utils/getFlagBooleanValue";
 import { isObjectWithOneTruthyKey, isObjectWithTruthyKeys } from "../../util";
+import { getSpectralVersion } from "../utils/getSpectralVersion";
 
 export const runMain = async (process: NodeJS.Process) => {
   const componentDir = process.cwd();
@@ -69,6 +70,12 @@ export const runMain = async (process: NodeJS.Process) => {
       description:
         "This skips the signature verification process, always returning a component signature in the component manifest.",
     },
+    version: {
+      flag: ["--version"],
+      value: getFlagsBooleanValue({ args, flags: ["--version"] }),
+      description:
+        "Display the version of @prismatic-io/spectral this component manifest generator uses.",
+    },
     help: {
       flag: ["--help", "-h"],
       value: getFlagsBooleanValue({
@@ -78,6 +85,11 @@ export const runMain = async (process: NodeJS.Process) => {
       description: "Show this help message.",
     },
   };
+
+  if (flags.version.value) {
+    console.log(getSpectralVersion());
+    process.exit(0);
+  }
 
   if (flags.help.value) {
     createFlagHelpText({

--- a/packages/spectral/src/generators/utils/getSpectralVersion.ts
+++ b/packages/spectral/src/generators/utils/getSpectralVersion.ts
@@ -1,0 +1,9 @@
+import fs from "fs";
+import path from "path";
+
+export const getSpectralVersion = () => {
+  const packageInfo = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json")).toString("utf-8"),
+  );
+  return packageInfo.version;
+};

--- a/packages/spectral/src/generators/utils/getSpectralVersion.ts
+++ b/packages/spectral/src/generators/utils/getSpectralVersion.ts
@@ -1,9 +1,0 @@
-import fs from "fs";
-import path from "path";
-
-export const getSpectralVersion = () => {
-  const packageInfo = JSON.parse(
-    fs.readFileSync(path.join(__dirname, "..", "..", "..", "package.json")).toString("utf-8"),
-  );
-  return packageInfo.version;
-};


### PR DESCRIPTION
I had an older version of `component-manifest` installed locally, and couldn't readily identify which version of `@prismatic-io/spectral` it belonged to without digging in to global `node_modules`.

This exposes a `component-manifest --version` flag, which will print the version of `@prismatic-io/spectral` it came from.