### PR TITLE
Fix array types for valuelist inputs that have models

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.3.7",
+  "version": "10.3.8",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -125,8 +125,8 @@ const getInputValueType = (input: ServerTypeInput): ValueType => {
 
   if (input.collection === "valuelist") {
     return typeof valueType === "string"
-      ? `${valueType}[]`
-      : { ...valueType, type: `${valueType.type}[]` };
+      ? `Array<${valueType}>`
+      : { ...valueType, type: `Array<${valueType.type}>` };
   }
 
   return valueType;


### PR DESCRIPTION
HubSpot has a datasource with an input that is a `valuelist` with a `model`, defined like this:

```
export const objectsToSelect = input({
  label: "Objects to Select",
  type: "string",
  collection: "valuelist",
  model: [
    { label: "Contacts", value: "Contacts" },
    { label: "Companies", value: "Companies" },
    { label: "Deals", value: "Deals" },
    { label: "Tickets", value: "Tickets" },
    { label: "Calls", value: "Calls" },
    { label: "Line Items", value: "Line Items" },
  ],
  required: false,
  comments: "The objects to include in the selection list.",
  clean: (value: unknown): string[] => {
    return util.types.isPicklist(value)
      ? (value as string[]).map((name) => name.trim())
      : [];
  },
});
```

Currently, the component manifest generated from this input reads
```
objectsToSelect?: `Contacts` | `Companies` | `Deals` | `Tickets` | `Calls` | `Line Items`[];
```

But, that's not quite right. We don't want the string `"Contacts"` or the string `"Companies"` or an array of `["Line Items", "Line Items", "Line Items"]`. We want an array, where the strings in the array are the values listed above, like `["Deals", "Companies", "Line Items"]`.

This updates the manifest generator to create a more correct
```
objectsToSelect?: Array<`Contacts` | `Companies` | `Deals` | `Tickets` | `Calls` | `Line Items`>;
``` 

Tested and verified with the HubSpot component.