### PR TITLE
Fix YAML definition generation for valuelist inputs of data sources

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.3.8",
+  "version": "10.3.9",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -365,7 +365,9 @@ const convertComponentReference = (
                 type: "value",
                 value: JSON.stringify(v),
               }))
-            : value.value;
+            : manifestEntryInput.collection === "valuelist" && Array.isArray(value.value)
+              ? value.value.map((v) => ({ type: "value", value: v }))
+              : value.value;
 
         const formattedValue =
           type === "complex" || typeof valueExpr === "string"


### PR DESCRIPTION
Currently, if you have a code-native data source config variable with an input that is a `collection: "valuelist"` (like `objectsToSelect` below) we expect a `value` that is an array of strings, like this:

```
      "Hubspot Objects": dataSourceConfigVar({
        stableKey: "my-hubspot-objects",
        dataSource: {
          component: "hubspot",
          key: "getObjectSelection",
          values: {
            connection: { configVar: "HubSpot API Key" },
            includeCustomObjects: { value: true },
            objectsToSelect: { value: ["Companies", "Contacts"] },
          },
        },
      }),
```

That's great and correct, but currently our code-native YAML definition generator generates YAML that reads:

```
      objectsToSelect:
        type: complex
        value:
          - Contacts
          - Companies
```

That's incorrect. It should read:

```
      objectsToSelect:
        type: complex
        value:
          - type: value
            value: Companies
          - type: value
            value: Contacts
```

This change updates our integration YAML generator to correctly handle `valuelist` inputs of data sources, like we do for `keyvaluelist` collections in the preceding lines.