### PR TITLE
Polling triggers: Clean poll action inputs only once

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.3.10",
+  "version": "10.3.11",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",


### PR DESCRIPTION
By the time inputs make it to an `invokeAction` call in a trigger, they have already been cleaned. Depending on how the clean functions, running clean twice can lead to unwanted behavior here (e.g. the "keyValPairToObject" util expecting an array and returning an object; running it twice causes errors).