### PR TITLE
Add customerActivatedConnection helper function

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.3.13",
+  "version": "10.4.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -104,7 +104,19 @@ export const connectionConfigVar = <T extends ConnectionConfigVar = ConnectionCo
 /**
  * For information on writing Code Native Integrations, see
  * https://prismatic.io/docs/code-native-integrations/#adding-config-vars.
- * @param definition A Customer Connection Config Var type object.
+ * @param definition A Customer-Activated Connection Config Var type object.
+ * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
+ */
+export const customerActivatedConnection = <T extends { stableKey: string }>(
+  definition: T,
+): OrganizationActivatedConnectionConfigVar => {
+  return { ...definition, dataType: "connection" };
+};
+
+/**
+ * For information on writing Code Native Integrations, see
+ * https://prismatic.io/docs/code-native-integrations/#adding-config-vars.
+ * @param definition An Organization-Activated Connection Config Var type object.
  * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
  */
 export const organizationActivatedConnection = <T extends { stableKey: string }>(

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -26,7 +26,7 @@ import {
   isJsonFormDataSourceConfigVar,
   TriggerReference,
   TriggerEventFunctionReturn,
-  isOrganizationActivatedConnectionConfigVar,
+  isConnectionScopedConfigVar,
 } from "../types";
 import {
   Component as ServerComponent,
@@ -578,7 +578,7 @@ export const convertConfigVar = (
   referenceKey: string,
   componentRegistry: ComponentRegistry,
 ): ServerRequiredConfigVariable => {
-  if (isOrganizationActivatedConnectionConfigVar(configVar)) {
+  if (isConnectionScopedConfigVar(configVar)) {
     const { stableKey } = pick(configVar, ["stableKey"]);
 
     return {

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -1,13 +1,20 @@
 import { type ConfigVar, isConnectionDefinitionConfigVar, isConnectionReferenceConfigVar } from ".";
 import type { UnionToIntersection } from "./utils";
 
+export type CustomerActivatedConnectionConfigVar = {
+  dataType: "connection";
+  stableKey: string;
+};
+
 export type OrganizationActivatedConnectionConfigVar = {
   dataType: "connection";
   stableKey: string;
 };
 
 /* More types may eventually be added to this union. */
-export type ScopedConfigVar = OrganizationActivatedConnectionConfigVar;
+export type ScopedConfigVar =
+  | CustomerActivatedConnectionConfigVar
+  | OrganizationActivatedConnectionConfigVar;
 
 /**
  * Root ScopedConfigVars type exposed for augmentation.
@@ -43,7 +50,7 @@ type CreateScopedConfigVars<TScopedConfigVarMap> = keyof TScopedConfigVarMap ext
 
 export type ScopedConfigVarMap = CreateScopedConfigVars<IntegrationDefinitionScopedConfigVars>;
 
-export const isOrganizationActivatedConnectionConfigVar = (
+export const isConnectionScopedConfigVar = (
   cv: ConfigVar,
 ): cv is OrganizationActivatedConnectionConfigVar =>
   "dataType" in cv &&


### PR DESCRIPTION
This adds the `customerActivatedConnection` helper function for use in CNI when referencing Customer-Activated connections by their `stableKey` in Prismatic.