### PR TITLE
Add ability to define a data source that backs an action input

### DIFF
--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,5 @@
-import { connection } from "..";
-import { convertConnection } from "./convertComponent";
+import { connection, input } from "..";
+import { convertConnection, convertInput } from "./convertComponent";
 
 describe("convertConnection", () => {
   const label = "My Basic Connection";
@@ -18,5 +18,23 @@ describe("convertConnection", () => {
     const convertedConnection = convertConnection(basicConnection);
     expect(convertedConnection.label).toBe(label);
     expect(convertedConnection.comments).toBe(description);
+  });
+});
+
+describe("convertInput", () => {
+  const dataSourceKey = "string-data-source";
+  const basicInputWithDataSource = input({
+    label: "Basic Input",
+    type: "string",
+    default: "Default String Input",
+    dataSource: dataSourceKey,
+  });
+
+  it("correctly converts an input data source", () => {
+    const basicInputWithDataSourceKey = "basicInputWithDataSource";
+    const convertedInput = convertInput(basicInputWithDataSourceKey, basicInputWithDataSource);
+
+    expect(convertedInput.key).toBe(basicInputWithDataSourceKey);
+    expect(convertedInput.dataSource).toBe(dataSourceKey);
   });
 });

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -27,7 +27,6 @@ import {
   isPollingTriggerDefinition,
   PollingTriggerDefinition,
 } from "../types/PollingTriggerDefinition";
-import { input, util } from "..";
 
 export const convertInput = (
   key: string,

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -307,4 +307,5 @@ export interface Input {
   model?: InputFieldChoice[];
   language?: string;
   onPremiseControlled?: boolean;
+  dataSource?: string;
 }

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -138,6 +138,8 @@ interface BaseInputField {
   example?: string;
   /** Indicate if this InputField is required. */
   required?: boolean;
+  /** Key of the data source that can be used to set the value of this input. */
+  dataSource?: string;
 }
 
 type CollectionOptions<T> = SingleValue<T> | ValueListCollection<T> | KeyValueListCollection<T>;


### PR DESCRIPTION
Component authors may now provide the key of a data source from the component that will be used to provide the value of the input when configuring the action in Prismatic.