### PR TITLE
Export conditional logic methods to support YAML => CNI converter tool

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.1",
+  "version": "10.4.2",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.3.13",
+  "version": "10.3.14",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/conditionalLogic/index.ts
+++ b/packages/spectral/src/conditionalLogic/index.ts
@@ -2,7 +2,6 @@ import {
   ConditionalExpression,
   BooleanOperator,
   TermExpression,
-  BooleanExpression,
   UnaryOperator,
   BinaryOperator,
 } from "./types";
@@ -120,11 +119,11 @@ export const isDeepEqual = (left: unknown, right: unknown): boolean => {
 };
 
 export const evaluatesTrue = (value: string | boolean): boolean => {
-  return typeof value === "string" ? ["t", "true", "y", "yes"].includes(value) : !!value;
+  return typeof value === "string" ? ["t", "true", "y", "yes"].includes(value) : value;
 };
 
 export const evaluatesFalse = (value: string | boolean): boolean => {
-  return typeof value === "string" ? ["f", "false", "n", "no"].includes(value) : !!value;
+  return typeof value === "string" ? ["f", "false", "n", "no"].includes(value) : value;
 };
 
 export const evaluatesNull = (value: unknown): boolean => {
@@ -165,7 +164,7 @@ export const dateIsBefore = (left: unknown, right: unknown): boolean => {
 };
 
 export const dateIsEqual = (left: unknown, right: unknown): boolean => {
-  return isBefore(util.types.toDate(left), util.types.toDate(right));
+  return isDateEqual(util.types.toDate(left), util.types.toDate(right));
 };
 
 export const evaluate = (expression: ConditionalExpression): boolean => {
@@ -285,9 +284,9 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case BinaryOperator.notIn:
           return !contains(right, leftTerm);
         case BinaryOperator.exactlyMatches:
-          return left === right || _isEqual(left, right);
+          return left === right || isDeepEqual(left, right);
         case BinaryOperator.doesNotExactlyMatch:
-          return !(left === right || _isEqual(left, right));
+          return !(left === right || isDeepEqual(left, right));
         case BinaryOperator.startsWith:
           return `${right}`.startsWith(`${left}`);
         case BinaryOperator.doesNotStartWith:

--- a/packages/spectral/src/conditionalLogic/index.ts
+++ b/packages/spectral/src/conditionalLogic/index.ts
@@ -101,7 +101,7 @@ export const parseDate = (value: unknown): Date => {
   throw new Error("Invalid argument type");
 };
 
-const isEqual = (left: unknown, right: unknown): boolean =>
+export const isEqual = (left: unknown, right: unknown): boolean =>
   left == right ||
   _isEqualWith(left, right, (objectA, objectB) => {
     if (typeof objectA === "object" || typeof objectB === "object") {
@@ -114,6 +114,59 @@ const isEqual = (left: unknown, right: unknown): boolean =>
 
     return objectA == objectB;
   });
+
+export const isDeepEqual = (left: unknown, right: unknown): boolean => {
+  return _isEqual(left, right);
+};
+
+export const evaluatesTrue = (value: string | boolean): boolean => {
+  return typeof value === "string" ? ["t", "true", "y", "yes"].includes(value) : !!value;
+};
+
+export const evaluatesFalse = (value: string | boolean): boolean => {
+  return typeof value === "string" ? ["f", "false", "n", "no"].includes(value) : !!value;
+};
+
+export const evaluatesNull = (value: unknown): boolean => {
+  const nullValues: Array<unknown> = [undefined, null, 0, Number.NaN, false, ""];
+  return nullValues.includes(value);
+};
+
+export const evaluatesEmpty = (value: string | Array<unknown>): boolean => {
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "string") {
+    return value.length === 0;
+  }
+
+  throw new Error("Please provide an array or string");
+};
+
+export const evaluatesNotEmpty = (value: string | Array<unknown>): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === "string") {
+    return value.length > 0;
+  }
+
+  throw new Error("Please provide an array or string");
+};
+
+export const dateIsAfter = (left: unknown, right: unknown): boolean => {
+  return isAfter(util.types.toDate(left), util.types.toDate(right));
+};
+
+export const dateIsBefore = (left: unknown, right: unknown): boolean => {
+  return isBefore(util.types.toDate(left), util.types.toDate(right));
+};
+
+export const dateIsEqual = (left: unknown, right: unknown): boolean => {
+  return isBefore(util.types.toDate(left), util.types.toDate(right));
+};
 
 export const evaluate = (expression: ConditionalExpression): boolean => {
   const [valid, message] = validate(expression);
@@ -149,9 +202,9 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case UnaryOperator.isTrue:
           if (typeof left === "string") {
             const lowerValue = left.toLowerCase();
-            if (["t", "true", "y", "yes"].includes(lowerValue)) {
+            if (evaluatesTrue(lowerValue)) {
               return true;
-            } else if (["f", "false", "n", "no"].includes(lowerValue)) {
+            } else if (evaluatesFalse(lowerValue)) {
               return false;
             }
           }
@@ -159,25 +212,27 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case UnaryOperator.isFalse:
           if (typeof left === "string") {
             const lowerValue = left.toLowerCase();
-            if (["t", "true", "y", "yes"].includes(lowerValue)) {
+            if (evaluatesTrue(lowerValue)) {
               return false;
-            } else if (["f", "false", "n", "no"].includes(lowerValue)) {
+            } else if (evaluatesFalse(lowerValue)) {
               return true;
             }
           }
           return !left;
         case UnaryOperator.doesNotExist:
-          return [undefined, null, 0, Number.NaN, false, ""].includes(left);
+          return evaluatesNull(left);
         case UnaryOperator.exists:
-          return ![undefined, null, 0, Number.NaN, false, ""].includes(left);
+          return !evaluatesNull(left);
         case UnaryOperator.isEmpty:
           if (Array.isArray(left)) {
-            return left.length === 0;
+            return evaluatesEmpty(left);
           }
+
           // leftTerm is used here, since "123" would be cast to 123 and would not be a string
           if (typeof leftTerm === "string") {
-            return leftTerm.length === 0;
+            return evaluatesEmpty(leftTerm);
           }
+
           throw new Error("Please provide an array or string");
         case UnaryOperator.isNotEmpty:
           if (Array.isArray(left)) {
@@ -242,11 +297,11 @@ export const evaluate = (expression: ConditionalExpression): boolean => {
         case BinaryOperator.doesNotEndWith:
           return !`${right}`.endsWith(`${left}`);
         case BinaryOperator.dateTimeAfter:
-          return isAfter(util.types.toDate(left), util.types.toDate(right));
+          return dateIsAfter(util.types.toDate(left), util.types.toDate(right));
         case BinaryOperator.dateTimeBefore:
-          return isBefore(util.types.toDate(left), util.types.toDate(right));
+          return dateIsBefore(util.types.toDate(left), util.types.toDate(right));
         case BinaryOperator.dateTimeSame:
-          return isDateEqual(util.types.toDate(left), util.types.toDate(right));
+          return dateIsEqual(util.types.toDate(left), util.types.toDate(right));
         default:
           throw new Error(`Invalid operator: '${operator}'`);
       }


### PR DESCRIPTION
This PR supports the eventual release of the [YAML > CNI converter tool](https://github.com/prismatic-io/prism/pull/126) in prism.

Currently, the alpha version of the tool converts conditional in this way:

```ts
import { evaluate } from "@prismatic-io/spectral/dist/conditionalLogic";

if (
  evaluate([
    BooleanOperator.and,
    [BinaryOperator.equal, someReference, "some value"],
  ])
) {
  // body here
}
```

While it works, it is pretty unreadable and unnecessarily reveals how we evaluate conditionals. Leaning on the `evaluate` directly function is also something we probably don't want to encourage.

With the introduction of this PR, conditionals can now render like this:

```ts
import { isEqual } from "@prismatic-io/spectral/dist/conditionalLogic";

if (isEqual(someReference, "some value")) {
  // body here
}
```

While we don't necessarily want devs to lean on these newly exposed conditionalLogic methods either, it is more abstracted & readable than `evaluate`.

I originally wanted to do something simpler, like `"someReference === "some value"`, but found that our evaluate logic does some more customized checks than this (e.g. for "is true" evaluations,  we accept string literals like "y" or "yes"). In order to make sure that the generated CNI works as closely to the original low-code as possible, I chose to expose these methods. I also chose to expose them all at the spectral level, instead of introducing `lodash` or `date-fns` as explicit dependencies of the resulting CNI.