### PR TITLE
Make debug context available in polling & trigger executions

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -142,7 +142,13 @@ const createInvokePollAction = <TInputs extends Inputs>(
        * Running clean twice can have unwanted behavior depending on how users have implemented
        * their clean functions.
        */
-      return await action.perform(context, params);
+      return await action.perform(
+        {
+          ...context,
+          debug: createDebugContext(context),
+        },
+        params,
+      );
     } catch (error) {
       throw errorHandler ? errorHandler(error) : error;
     }
@@ -185,6 +191,7 @@ export const createPollingPerform = (
             };
           },
         },
+        debug: createDebugContext(context),
       };
 
       const triggerPerform = createPerform(trigger.perform, {


### PR DESCRIPTION
`createDebugContext` wasn't getting called when constructing contexts for triggers and polling actions, causing references to `context.debug` and its contained methods to fail at runtime.

In retrospect maybe this was a good enough reason to consider defining the debug methods in the runner instead, to prevent having to augment the context in so many places in the spectral layer, but for now this will at least fix the problem.