### PR TITLE
Support htmlElement configVars

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.2",
+  "version": "10.4.3",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.3",
+  "version": "10.4.4",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -27,6 +27,7 @@ import {
   TriggerReference,
   TriggerEventFunctionReturn,
   isConnectionScopedConfigVar,
+  isHtmlElementConfigVar,
 } from "../types";
 import {
   Component as ServerComponent,
@@ -122,7 +123,12 @@ const convertConfigPages = (
           type: "htmlElement",
           value,
         };
-      } else if ("dataType" in value && value.dataType === "htmlElement") {
+      } else if (
+        value &&
+        typeof value === "object" &&
+        "dataType" in value &&
+        value.dataType === "htmlElement"
+      ) {
         return {
           type: "htmlElement",
           value: key,
@@ -198,7 +204,7 @@ const codeNativeIntegrationYaml = (
   const requiredConfigVars: Array<ServerRequiredConfigVariable> = [];
 
   Object.entries(configVarMap).forEach(([key, configVar]) => {
-    if ("dataType" in configVar && configVar.dataType !== "htmlElement") {
+    if (!isHtmlElementConfigVar(configVar)) {
       requiredConfigVars.push(convertConfigVar(key, configVar, referenceKey, componentRegistry));
     }
   });

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -37,7 +37,8 @@ export type ConfigVarDataType =
   | "schedule"
   | "objectSelection"
   | "objectFieldMap"
-  | "jsonForm";
+  | "jsonForm"
+  | "htmlElement";
 
 type ConfigVarDataTypeDefaultValueMap<
   TMap extends Record<ConfigVarDataType, unknown> = {
@@ -52,6 +53,7 @@ type ConfigVarDataTypeDefaultValueMap<
     objectSelection: ObjectSelection;
     objectFieldMap: ObjectFieldMap;
     jsonForm: JSONForm;
+    htmlElement: string;
   },
 > = TMap;
 
@@ -68,6 +70,7 @@ type ConfigVarDataTypeRuntimeValueMap<
     objectSelection: ObjectSelection;
     objectFieldMap: ObjectFieldMap;
     jsonForm: unknown;
+    htmlElement: string;
   },
 > = TMap;
 
@@ -194,6 +197,8 @@ type JsonFormDataSourceDefinitionConfigVar = DataSourceDefinitionConfigVar & {
   validationMode?: ValidationMode;
 };
 
+type HtmlElementConfigVar = CreateStandardConfigVar<"htmlElement">;
+
 export type StandardConfigVar =
   | StringConfigVar
   | DateConfigVar
@@ -205,7 +210,8 @@ export type StandardConfigVar =
   | ScheduleConfigVar
   | ObjectSelectionConfigVar
   | ObjectFieldMapConfigVar
-  | JsonFormConfigVar;
+  | JsonFormConfigVar
+  | HtmlElementConfigVar;
 
 // Data Source Config Vars
 type BaseDataSourceConfigVar<TDataSourceType extends DataSourceType = DataSourceType> =

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -412,6 +412,9 @@ export type ConfigVars = Prettify<UnionToIntersection<ExtractConfigVars<ConfigPa
   Prettify<UnionToIntersection<ExtractConfigVars<UserLevelConfigPages>>> &
   Prettify<UnionToIntersection<ExtractScopedConfigVars<ScopedConfigVarMap>>>;
 
+export const isHtmlElementConfigVar = (cv: ConfigVar): cv is HtmlElementConfigVar =>
+  "dataType" in cv && cv.dataType === "htmlElement";
+
 export const isCodeConfigVar = (cv: ConfigVar): cv is CodeConfigVar =>
   "dataType" in cv && cv.dataType === "code";
 


### PR DESCRIPTION
Previously CNI developers could not define `htmlElement` config vars in their config pages. This change makes it so the typing supports it & that they get converted into proper YAML (i.e. htmlElements should not show in the `requiredConfigVars` block)