### PR TITLE
Fix component generation with undefined inputs

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.2",
+  "version": "10.4.3",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -27,7 +27,6 @@ import {
   isPollingTriggerDefinition,
   PollingTriggerDefinition,
 } from "../types/PollingTriggerDefinition";
-import { input, util } from "..";
 
 export const convertInput = (
   key: string,
@@ -89,7 +88,7 @@ export const convertTrigger = (
   hooks?: ComponentHooks,
 ): ServerTrigger => {
   const { onInstanceDeploy, onInstanceDelete } = trigger;
-  const inputs: Inputs = trigger.inputs as Inputs;
+  const inputs: Inputs = trigger.inputs ?? {};
   const isPollingTrigger = isPollingTriggerDefinition(trigger);
 
   const triggerInputKeys = Object.keys(inputs);


### PR DESCRIPTION
It's possible for polling triggers to have undefined inputs. This falls back to an empty object in that case.