### PR TITLE
Fix CNI generation when using new connection types

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.4.4",
+  "version": "10.5.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -602,7 +602,6 @@ export const convertConfigVar = (
       key,
       stableKey,
       dataType: "connection",
-      orgOnly: false,
       useScopedConfigVar: stableKey,
     };
   }

--- a/packages/spectral/src/serverTypes/integration.ts
+++ b/packages/spectral/src/serverTypes/integration.ts
@@ -77,7 +77,6 @@ export interface DefaultRequiredConfigVariable {
 export interface OrganizationActivatedConnectionRequiredConfigVariable {
   key: string;
   dataType: "connection";
-  orgOnly: false;
   inputs?: never;
   useScopedConfigVar: string;
 }


### PR DESCRIPTION
`orgOnly` is no longer a valid property in an integration definition when using a scoped config var