### PR TITLE
Support importMetadata

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",


### PR DESCRIPTION
This PR supports adding build/import-specific metadata to generated CNI.

This should not be merged until the definition schemas are updated in the backend.