### PR TITLE
Add .vscode directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .rush
 .turbo
-.vscode
 
 # Logs
 logs

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "biome.lspBin": "./packages/spectral/node_modules/@biomejs/biome/bin/biome",
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,1 @@
+packages/spectral/biome.jsonc

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",


### PR DESCRIPTION
Without a .vscode directory, my VS Code's prettier and biome plugins fight with one another over formatting. This explicitly declares that biome is the formatter for this project (which it already is).