### PR TITLE
Add basic connection template input validation

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.2",
+  "version": "10.5.3",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.1",
+  "version": "10.5.2",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds basic validation for `connectionTemplateInput` template strings. We check that:

* Keys referenced in the template string must be declared as inputs
* Keys referenced in the template do not reference other template inputs
* The template string contains some number of template slots