### PR TITLE
Remove dependency on @jsonforms/core

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.1",
+  "version": "10.5.2",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",
@@ -38,7 +38,6 @@
   },
   "files": ["dist/"],
   "dependencies": {
-    "@jsonforms/core": "3.0.0",
     "axios": "1.8.3",
     "axios-retry": "4.5.0",
     "date-fns": "2.30.0",

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -1,4 +1,4 @@
-import { ValidationMode } from "@jsonforms/core";
+import { ValidationMode } from "./jsonforms/ValidationMode";
 import {
   type DataSourceDefinition,
   type ConnectionDefinition,

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -1,5 +1,6 @@
 import { ConditionalExpression } from "./conditional-logic";
-import { JsonSchema, UISchemaElement } from "@jsonforms/core";
+import { JsonSchema } from "./jsonforms/JsonSchema";
+import { UISchemaElement } from "./jsonforms/UISchemaElement";
 
 /**
  * KeyValuePair input parameter type.

--- a/packages/spectral/src/types/jsonforms/JsonSchema.ts
+++ b/packages/spectral/src/types/jsonforms/JsonSchema.ts
@@ -1,0 +1,232 @@
+export type JsonSchema = JsonSchema4 | JsonSchema7;
+
+interface JsonSchema4 {
+  $ref?: string;
+  /**
+   * This is important because it tells refs where
+   * the root of the document is located
+   */
+  id?: string;
+  /**
+   * It is recommended that the meta-schema is
+   * included in the root of any JSON Schema
+   */
+  $schema?: string;
+  /**
+   * Title of the schema
+   */
+  title?: string;
+  /**
+   * Schema description
+   */
+  description?: string;
+  /**
+   * Default json for the object represented by
+   * this schema
+   */
+  default?: any;
+  /**
+   * The value must be a multiple of the number
+   * (e.g. 10 is a multiple of 5)
+   */
+  multipleOf?: number;
+  maximum?: number;
+  /**
+   * If true maximum must be > value, >= otherwise
+   */
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  /**
+   * If true minimum must be < value, <= otherwise
+   */
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  /**
+   * This is a regex string that the value must
+   * conform to
+   */
+  pattern?: string;
+  additionalItems?: boolean | JsonSchema4;
+  items?: JsonSchema4 | JsonSchema4[];
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  additionalProperties?: boolean | JsonSchema4;
+  /**
+   * Holds simple JSON Schema definitions for
+   * referencing from elsewhere.
+   */
+  definitions?: {
+    [key: string]: JsonSchema4;
+  };
+  /**
+   * The keys that can exist on the object with the
+   * json schema that should validate their value
+   */
+  properties?: {
+    [property: string]: JsonSchema4;
+  };
+  /**
+   * The key of this object is a regex for which
+   * properties the schema applies to
+   */
+  patternProperties?: {
+    [pattern: string]: JsonSchema4;
+  };
+  /**
+   * If the key is present as a property then the
+   * string of properties must also be present.
+   * If the value is a JSON Schema then it must
+   * also be valid for the object if the key is
+   * present.
+   */
+  dependencies?: {
+    [key: string]: JsonSchema4 | string[];
+  };
+  /**
+   * Enumerates the values that this schema can be
+   * e.g.
+   * {"type": "string",
+   *  "enum": ["red", "green", "blue"]}
+   */
+  enum?: any[];
+  /**
+   * The basic type of this schema, can be one of
+   * [string, number, object, array, boolean, null]
+   * or an array of the acceptable types
+   */
+  type?: string | string[];
+  allOf?: JsonSchema4[];
+  anyOf?: JsonSchema4[];
+  oneOf?: JsonSchema4[];
+  /**
+   * The entity being validated must not match this schema
+   */
+  not?: JsonSchema4;
+  format?: string;
+  const?: any;
+}
+
+interface JsonSchema7 {
+  $ref?: string;
+  /**
+   * This is important because it tells refs where
+   * the root of the document is located
+   */
+  $id?: string;
+  /**
+   * It is recommended that the meta-schema is
+   * included in the root of any JSON Schema
+   */
+  $schema?: string;
+  /**
+   * Title of the schema
+   */
+  title?: string;
+  /**
+   * Schema description
+   */
+  description?: string;
+  /**
+   * Default json for the object represented by
+   * this schema
+   */
+  default?: any;
+  /**
+   * The value must be a multiple of the number
+   * (e.g. 10 is a multiple of 5)
+   */
+  multipleOf?: number;
+  maximum?: number;
+  /**
+   * If true maximum must be > value, >= otherwise
+   */
+  exclusiveMaximum?: number;
+  minimum?: number;
+  /**
+   * If true minimum must be < value, <= otherwise
+   */
+  exclusiveMinimum?: number;
+  maxLength?: number;
+  minLength?: number;
+  /**
+   * This is a regex string that the value must
+   * conform to
+   */
+  pattern?: string;
+  additionalItems?: boolean | JsonSchema7;
+  items?: JsonSchema7 | JsonSchema7[];
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  additionalProperties?: boolean | JsonSchema7;
+  /**
+   * Holds simple JSON Schema definitions for
+   * referencing from elsewhere.
+   */
+  definitions?: {
+    [key: string]: JsonSchema7;
+  };
+  /**
+   * The keys that can exist on the object with the
+   * json schema that should validate their value
+   */
+  properties?: {
+    [property: string]: JsonSchema7;
+  };
+  /**
+   * The key of this object is a regex for which
+   * properties the schema applies to
+   */
+  patternProperties?: {
+    [pattern: string]: JsonSchema7;
+  };
+  /**
+   * If the key is present as a property then the
+   * string of properties must also be present.
+   * If the value is a JSON Schema then it must
+   * also be valid for the object if the key is
+   * present.
+   */
+  dependencies?: {
+    [key: string]: JsonSchema7 | string[];
+  };
+  /**
+   * Enumerates the values that this schema can be
+   * e.g.
+   * {"type": "string",
+   *  "enum": ["red", "green", "blue"]}
+   */
+  enum?: any[];
+  /**
+   * The basic type of this schema, can be one of
+   * [string, number, object, array, boolean, null]
+   * or an array of the acceptable types
+   */
+  type?: string | string[];
+  allOf?: JsonSchema7[];
+  anyOf?: JsonSchema7[];
+  oneOf?: JsonSchema7[];
+  /**
+   * The entity being validated must not match this schema
+   */
+  not?: JsonSchema7;
+  format?: string;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  examples?: any[];
+  contains?: JsonSchema7;
+  propertyNames?: JsonSchema7;
+  const?: any;
+  if?: JsonSchema7;
+  then?: JsonSchema7;
+  else?: JsonSchema7;
+  errorMessage?: any;
+}

--- a/packages/spectral/src/types/jsonforms/UISchemaElement.ts
+++ b/packages/spectral/src/types/jsonforms/UISchemaElement.ts
@@ -1,0 +1,66 @@
+/**
+ * Common base interface for any UI schema element.
+ */
+export interface UISchemaElement {
+  /**
+   * The type of this UI schema element.
+   */
+  type: string;
+  /**
+   * An optional rule.
+   */
+  rule?: Rule;
+  /**
+   * Any additional options.
+   */
+  options?: {
+    [key: string]: any;
+  };
+}
+
+/**
+ * A rule that may be attached to any UI schema element.
+ */
+interface Rule {
+  /**
+   * The effect of the rule
+   */
+  effect: RuleEffect;
+  /**
+   * The condition of the rule that must evaluate to true in order
+   * to trigger the effect.
+   */
+  condition: Condition;
+}
+
+/**
+ * The different rule effects.
+ */
+enum RuleEffect {
+  /**
+   * Effect that hides the associated element.
+   */
+  HIDE = "HIDE",
+  /**
+   * Effect that shows the associated element.
+   */
+  SHOW = "SHOW",
+  /**
+   * Effect that enables the associated element.
+   */
+  ENABLE = "ENABLE",
+  /**
+   * Effect that disables the associated element.
+   */
+  DISABLE = "DISABLE",
+}
+
+/**
+ * Represents a condition to be evaluated.
+ */
+interface Condition {
+  /**
+   * The type of condition.
+   */
+  readonly type?: string;
+}

--- a/packages/spectral/src/types/jsonforms/ValidationMode.ts
+++ b/packages/spectral/src/types/jsonforms/ValidationMode.ts
@@ -1,0 +1,1 @@
+export type ValidationMode = "ValidateAndShow" | "ValidateAndHide" | "NoValidation";

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,16 +672,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsonforms/core@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@jsonforms/core/-/core-3.0.0.tgz"
-  integrity sha512-DcUGLNaeAE411oA8d5dPuPEF2/nDmALAfQRsaA3GPAre2D76kJXyBb8TFMjLMRJCVIR0q5LsiRRdmLnuPVHKqA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    ajv "^8.6.1"
-    ajv-formats "^2.1.0"
-    lodash "^4.17.15"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -880,7 +870,7 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3":
+"@types/json-schema@*":
   version "7.0.11"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -1085,13 +1075,6 @@ acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
-ajv-formats@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz"
-  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
-  dependencies:
-    ajv "^8.0.0"
-
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -1100,16 +1083,6 @@ ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^8.0.0, ajv@^8.6.1:
-  version "8.11.2"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz"
-  integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ansi-escapes@^4.2.1:
@@ -3448,11 +3421,6 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
@@ -4196,11 +4164,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-alpn@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
This removes our dependency on `@jsonforms/core`. We require just a hand-full of types and interfaces from `@jsonforms/core` - this pulls those type definitions into this library. 