### PR TITLE
Fix converting component dataSources when registry and component key differ

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.4",
+  "version": "10.5.5",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -770,7 +770,8 @@ export const convertConfigVar = (
       componentRegistry,
       "dataSources",
     );
-    result.dataType = componentRegistry[ref.component.key].dataSources[ref.key].dataSourceType;
+    result.dataType =
+      componentRegistry[configVar.dataSource.component].dataSources[ref.key].dataSourceType;
     result.dataSource = ref;
     result.inputs = inputs;
 


### PR DESCRIPTION
This is similar to #261 .

## Issue

Suppose you use a component like `ms-sharepoint`, but you don't give the component manifest the key `ms-sharepoint` - you use `sharepoint` or `msSharepoint` instead.

```
import sharepoint from "@component-manifests/ms-sharepoint";

export const componentRegistry = componentManifests({
  sharepoint,
});
```

Typescript will allow you to reference a datasource from the Sharepoint component like this

```
  "Select Sharepoint Site": configPage({
    tagline: "Select a Slack channel from a dropdown menu",
    elements: {
      "Sharepoint Site": dataSourceConfigVar({
        stableKey: "select-slack-channel",
        dataSource: {
          component: "sharepoint",
          key: "listSites",
          values: {
            connection: { configVar: "Microsoft Sharepoint Connection" },
          },
        },
      }),
    },
  }),
```

BUT when you go to build and import your integration, you'll be met with an error 

```
prism integrations:import --open
    Error: Cannot read properties of undefined (reading 'dataSources')
```

That's because we're looking for a component in our `componentRegistry` named `ms-sharepoint` rather than our aliased `sharepoint`.

## Fix

This updates our reference, so we use the user's specified component key, rather than the programmatic key our API knows.

