### PR TITLE
Support templated inputs for referenced data sources

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.5",
+  "version": "10.5.6",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -435,6 +435,13 @@ const convertComponentReference = (
         };
       }
 
+      if ("template" in value) {
+        return {
+          ...result,
+          [key]: { type: "template", value: value.template },
+        };
+      }
+
       return result;
     },
     {},

--- a/packages/spectral/src/types/ComponentRegistry.ts
+++ b/packages/spectral/src/types/ComponentRegistry.ts
@@ -30,6 +30,15 @@ export type ComponentRegistry = keyof IntegrationDefinitionComponentRegistry ext
     >;
 
 export type ConfigVarExpression = { configVar: string };
+export type TemplateExpression = {
+  /**
+   * Use a template to concatenate strings and other config variables together.
+   * For example, if you have a config variable named "Sharepoint Site", you
+   * can provide a value `/sites/{{#Sharepoint Site}}/drives`, and your `{{#}}`
+   * config variable will be concatenated with `/sites/` and `/drives`.
+   */
+  template: string;
+};
 export type ValueExpression<TValueType = unknown> = {
   value: TValueType;
 };
@@ -44,7 +53,7 @@ type ComponentReferenceTypeValueMap<
   TMap extends Record<ComponentReferenceType, unknown> = {
     actions: ValueExpression<TValue>;
     triggers: ValueExpression<TValue> | ConfigVarExpression;
-    dataSources: ValueExpression<TValue> | ConfigVarExpression;
+    dataSources: ValueExpression<TValue> | ConfigVarExpression | TemplateExpression;
     connections: (ValueExpression<TValue> | ConfigVarExpression) &
       ConfigVarVisibility & { writeOnly?: true };
   },
@@ -55,14 +64,14 @@ export type ComponentReference<
     component: string;
     key: string;
     values?: {
-      [key: string]: ValueExpression | ConfigVarExpression;
+      [key: string]: ValueExpression | ConfigVarExpression | TemplateExpression;
     };
     template?: string;
   } = {
     component: string;
     key: string;
     values?: {
-      [key: string]: ValueExpression | ConfigVarExpression;
+      [key: string]: ValueExpression | ConfigVarExpression | TemplateExpression;
     };
     template?: string;
   },


### PR DESCRIPTION
Some data sources require you to concatenate strings together to form an input. For example, if you're building a Sharepoint integration you may first ask a customer to connect to Sharepoint, then ask them to select a Sharepoint Site from a dropdown menu, and finally ask them to select a drive within their selected sharepoint site.

In the low-code designer, you would concatenate your Sharepoint Site config variable between `/sites/` and `/drives` to form a directory, like this:

<img width="592" alt="image" src="https://github.com/user-attachments/assets/2850b9b4-6455-46a6-949a-15088754526f" />

Currently, code-native does not allow for such concatenation.

This PR extends reference data source input values, so that you can specify `template` instead of `value` or `configVar`, and can supply a template like `template: "/sites/{{#Sharepoint Site}}/drives"`.

This `configPages.ts` and video demo the template input functionality added to a Sharepoint code-native integration


https://github.com/user-attachments/assets/f133321d-177c-4ae5-a0b1-00b75d7b959e



```
export const configPages = {
  Connections: configPage({
    elements: {
      "Microsoft Sharepoint Connection": connectionConfigVar({
        stableKey: "Microsoft Sharepoint Connection",
        dataType: "connection",
        connection: {
          component: "sharepoint",
          key: "oauth",
          values: {
            authorizeUrl: {
              value:
                "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
              permissionAndVisibilityType: "organization",
              visibleToOrgDeployer: false,
            },
            tokenUrl: {
              value:
                "https://login.microsoftonline.com/common/oauth2/v2.0/token",
              permissionAndVisibilityType: "organization",
              visibleToOrgDeployer: false,
            },
            scopes: {
              value: "Sites.ReadWrite.All Sites.Manage.All offline_access",
              permissionAndVisibilityType: "organization",
              visibleToOrgDeployer: false,
            },
            clientId: {
              value: "REPLACE_ME",
              permissionAndVisibilityType: "organization",
              visibleToOrgDeployer: false,
            },
            clientSecret: {
              value: "REPLACE_ME",
              permissionAndVisibilityType: "organization",
              visibleToOrgDeployer: false,
            },
          },
        },
      }),
    },
  }),
  "Select Sharepoint Site": configPage({
    tagline: "Select a Slack channel from a dropdown menu",
    elements: {
      "Sharepoint Site": dataSourceConfigVar({
        stableKey: "sharepoint-site",
        dataSource: {
          component: "sharepoint",
          key: "listSites",
          values: {
            connection: { configVar: "Microsoft Sharepoint Connection" },
          },
        },
      }),
    },
  }),
  "Select Sharepoint Drive": configPage({
    elements: {
      "Sharepoint Drive": dataSourceConfigVar({
        stableKey: "sharepoint-drive",
        dataSource: {
          component: "sharepoint",
          key: "listDrives",
          values: {
            connection: {
              configVar: "Microsoft Sharepoint Connection",
            },
            dir: {
              template: "/sites/{{#Sharepoint Site}}/drives",
            },
          },
        },
      }),
    },
  }),
  "Select Sharepoint Folder": configPage({
    elements: {
      "Folder Selection": dataSourceConfigVar({
        stableKey: "sharepoint-folder",
        dataSource: {
          component: "sharepoint",
          key: "listFolders",
          values: {
            connection: {
              configVar: "Microsoft Sharepoint Connection",
            },
            dir: {
              template: "/drives/{{#Sharepoint Drive}}/root/children",
            },
          },
        },
      }),
    },
  }),
};
```