### PR TITLE
Fix scoped config variable visibility

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.8",
+  "version": "10.5.9",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -129,29 +129,31 @@ const convertConfigPages = (
     name,
     tagline,
     ...(userLevelConfigured ? { userLevelConfigured } : {}),
-    elements: Object.entries(elements).map(([key, value]) => {
-      if (typeof value === "string") {
+    elements: Object.entries(elements)
+      .filter(([key, value]) => !isConnectionScopedConfigVar(value as ConfigVar))
+      .map(([key, value]) => {
+        if (typeof value === "string") {
+          return {
+            type: "htmlElement",
+            value,
+          };
+        } else if (
+          value &&
+          typeof value === "object" &&
+          "dataType" in value &&
+          value.dataType === "htmlElement"
+        ) {
+          return {
+            type: "htmlElement",
+            value: key,
+          };
+        }
+
         return {
-          type: "htmlElement",
-          value,
-        };
-      } else if (
-        value &&
-        typeof value === "object" &&
-        "dataType" in value &&
-        value.dataType === "htmlElement"
-      ) {
-        return {
-          type: "htmlElement",
+          type: "configVar",
           value: key,
         };
-      }
-
-      return {
-        type: "configVar",
-        value: key,
-      };
-    }),
+      }),
   }));
 };
 
@@ -624,6 +626,10 @@ export const convertConfigVar = (
       stableKey,
       dataType: "connection",
       useScopedConfigVar: stableKey,
+      meta: {
+        visibleToCustomerDeployer: false,
+        visibleToOrgDeployer: false,
+      },
     };
   }
 

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -626,10 +626,6 @@ export const convertConfigVar = (
       stableKey,
       dataType: "connection",
       useScopedConfigVar: stableKey,
-      meta: {
-        visibleToCustomerDeployer: false,
-        visibleToOrgDeployer: false,
-      },
     };
   }
 


### PR DESCRIPTION
Scoped config variables are treated specially in the configuration wizard. In the low-code designer, YAML definitions (left) do _not_ contain SCVs within `configPages.*.elements`. In code-native (right), they currently do. That's a mistake.

![image](https://github.com/user-attachments/assets/459b2654-b231-4fba-a282-6304e630adc8)

Similarly, in low-code (left) SCVs have `meta.*` visibility settings. In code-native (right) they don't.

![image](https://github.com/user-attachments/assets/3cf3e2b8-d381-4ec6-bf93-444d539f3936)

This PR fixes both of those issues, so code-native integration adhere to the standard that low-code integrations use.

This resolves the issue where a user may see a red toaster `Inputs cannot be empty` alert when using scoped config variables in code native.

![image](https://github.com/user-attachments/assets/92ae6669-cb81-41f5-bcd9-26e5249537d8)
