### PR TITLE
Standardize CNI `context.components` availability

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.9",
+  "version": "10.5.10",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/context.ts
+++ b/packages/spectral/src/serverTypes/context.ts
@@ -1,9 +1,107 @@
 import { memoryUsage } from "node:process";
 import { ActionContext as ServerActionContext } from ".";
-import { ActionContext, DebugContext, MemoryUsage } from "../types";
+import {
+  ActionContext,
+  ComponentManifestAction,
+  ComponentRegistry,
+  DebugContext,
+  ExecutionFrame,
+  FlowInvoker,
+  MemoryUsage,
+} from "../types";
 import { performance } from "node:perf_hooks";
+import { ComponentReference as ServerComponentReference } from "./integration";
+import { convertInputValue } from "./convertIntegration";
+import axios, { AxiosRequestConfig } from "axios";
 
 const MEMORY_USAGE_CONVERSION = 1024 * 1024;
+
+type ComponentActionInvokeFunction = <TValues extends Record<string, any>>(
+  ref: ServerComponentReference,
+  context: ActionContext,
+  values: TValues,
+) => Promise<unknown>;
+
+type ComponentMethods = Record<string, Record<string, ComponentManifestAction["perform"]>>;
+
+export function createCNIContext(
+  context: ActionContext,
+  componentRegistry: ComponentRegistry,
+): ActionContext {
+  // Component, debug, and invokeFlow methods are not provided as part of the server context.
+  // They are added to the context via spectral, here.
+
+  // @ts-expect-error _components isn't part of the public API
+  const { _components } = context;
+
+  const invoke = (_components as { invoke: ComponentActionInvokeFunction }).invoke;
+
+  // Construct the component methods from the component registry
+  const componentMethods = Object.entries(componentRegistry).reduce<ComponentMethods>(
+    (
+      accumulator,
+      [registryComponentKey, { key: componentKey, actions, public: isPublic, signature }],
+    ) => {
+      const componentActions = Object.entries(actions).reduce<
+        Record<string, ComponentManifestAction["perform"]>
+      >((actionsAccumulator, [registryActionKey, action]) => {
+        const manifestActions = componentRegistry[registryComponentKey].actions[registryActionKey];
+
+        // Define the method to be called for the action
+        const invokeAction: ComponentManifestAction["perform"] = async (values) => {
+          // Apply defaults directly within the transformation process
+          const transformedValues = Object.entries(manifestActions.inputs).reduce<
+            Record<string, any>
+          >((transformedAccumulator, [inputKey, inputValueBase]) => {
+            const inputValue = values[inputKey] ?? inputValueBase.default;
+
+            const { collection } = inputValueBase;
+
+            return {
+              ...transformedAccumulator,
+              [inputKey]: convertInputValue(inputValue, collection),
+            };
+          }, {});
+
+          // Invoke the action with the transformed values
+          return invoke(
+            {
+              component: {
+                key: componentKey,
+                signature: signature ?? "",
+                isPublic,
+              },
+              // older versions of manifests did not contain action.key so we fall back to the registry key
+              key: action.key ?? registryActionKey,
+            },
+            {
+              ...context,
+              debug: createDebugContext(context),
+            },
+            transformedValues,
+          );
+        };
+        return {
+          ...actionsAccumulator,
+          [registryActionKey]: invokeAction,
+        };
+      }, {});
+
+      return {
+        ...accumulator,
+        [registryComponentKey]: componentActions,
+      };
+    },
+    {},
+  );
+
+  return {
+    ...context,
+    debug: createDebugContext(context),
+    components: componentMethods,
+    invokeFlow: createInvokeFlow(context, { isCNI: true }),
+  };
+}
 
 export function createDebugContext(context: ServerActionContext): DebugContext {
   const globalDebug = Boolean(context.globalDebug);
@@ -75,3 +173,44 @@ function memoryUsageInMB() {
     },
   );
 }
+
+function formatExecutionFrameHeaders(frame: ExecutionFrame, source?: string) {
+  let frameToUse = frame;
+
+  if (source) {
+    frameToUse = {
+      ...frame,
+      customSource: source,
+    };
+  }
+
+  return JSON.stringify(frameToUse);
+}
+
+export const createInvokeFlow = <const TFlows extends Readonly<string[]>>(
+  context: ActionContext,
+  options: { isCNI?: boolean } = {},
+): FlowInvoker<TFlows> => {
+  return async (
+    flowName: TFlows[number],
+    data?: Record<string, unknown>,
+    config?: AxiosRequestConfig,
+    source?: string,
+  ) => {
+    const sourceToUse = options.isCNI ? source : undefined;
+    return await axios.post(context.webhookUrls[flowName], data, {
+      ...config,
+      headers: {
+        ...(config?.headers ?? {}),
+        ...(context.webhookApiKeys[flowName]?.length > 0
+          ? {
+              "Api-Key": context.webhookApiKeys[flowName][0],
+            }
+          : {}),
+        "prismatic-invoked-by": formatExecutionFrameHeaders(context.executionFrame, sourceToUse),
+        "prismatic-invoke-type": "Cross Flow",
+        "prismatic-executionid": context.executionId,
+      },
+    });
+  };
+};

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -20,7 +20,6 @@ import {
 } from "./serverTypes";
 import {
   ActionContext,
-  ActionPerformReturn,
   ConnectionDefinition,
   ActionDefinition,
   TriggerDefinition,


### PR DESCRIPTION
A bug was reported where, when defining `onInstanceDeploy` and `onInstanceDelete` methods for a CNI flow, `context.components` was unavailable.

This PR makes it so `context.components` is exposed in all CNI-related contexts. To achieve this I did a bit of refactoring, including:

* moving the logic for generating component invocation methods from `convertOnExecution` into a shared `createCNIContext` method, and
* moving `createInvokeFlow` from the component `perform` helper file into the `context` helper file.

