### PR TITLE
Fix HTML elements being handled improperly when processing configPages

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.10",
+  "version": "10.5.11",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "@jest/globals";
+import { configPage, configVar } from "..";
+import { convertConfigPages } from "./convertIntegration";
+
+describe("convertConfigPages", () => {
+  it("should handle HTML string elements correctly", () => {
+    const pages = {
+      Connections: configPage({
+        elements: {
+          Authentication: "<h1>Authentication</h1>",
+        },
+      }),
+    };
+
+    const result = convertConfigPages(pages, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Connections");
+    expect(result[0].elements).toHaveLength(1);
+    expect(result[0].elements[0]).toEqual({
+      type: "htmlElement",
+      value: "<h1>Authentication</h1>",
+    });
+  });
+
+  it("should handle mixed HTML and configVar elements", () => {
+    const pages = {
+      TestPage: configPage({
+        tagline: "Test configuration page",
+        elements: {
+          HeaderText: "<h2>Configuration Settings</h2>",
+          ApiKey: configVar({
+            stableKey: "api-key",
+            dataType: "string",
+            description: "Your API key",
+          }),
+          Instructions: "<p>Enter your details below</p>",
+        },
+      }),
+    };
+
+    const result = convertConfigPages(pages, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("TestPage");
+    expect(result[0].tagline).toBe("Test configuration page");
+    expect(result[0].elements).toHaveLength(3);
+
+    // Check HTML elements
+    const htmlElements = result[0].elements.filter((el) => el.type === "htmlElement");
+    expect(htmlElements).toHaveLength(2);
+    expect(htmlElements[0].value).toBe("<h2>Configuration Settings</h2>");
+    expect(htmlElements[1].value).toBe("<p>Enter your details below</p>");
+
+    // Check configVar element
+    const configVarElements = result[0].elements.filter((el) => el.type === "configVar");
+    expect(configVarElements).toHaveLength(1);
+    expect(configVarElements[0].value).toBe("ApiKey");
+  });
+
+  it("should handle configVar with htmlElement dataType", () => {
+    const pages = {
+      TestPage: configPage({
+        elements: {
+          CustomHTML: {
+            dataType: "htmlElement",
+            stableKey: "custom-html",
+          },
+        },
+      }),
+    };
+
+    const result = convertConfigPages(pages, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].elements).toHaveLength(1);
+    expect(result[0].elements[0]).toEqual({
+      type: "htmlElement",
+      value: "CustomHTML", // Uses the key as the value
+    });
+  });
+
+  it("should handle empty elements object", () => {
+    const pages = {
+      EmptyPage: configPage({
+        elements: {},
+      }),
+    };
+
+    const result = convertConfigPages(pages, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("EmptyPage");
+    expect(result[0].elements).toHaveLength(0);
+  });
+});

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -114,7 +114,7 @@ export const convertIntegration = (definition: IntegrationDefinition): ServerCom
   };
 };
 
-const convertConfigPages = (
+export const convertConfigPages = (
   pages: ConfigPages | undefined,
   userLevelConfigured: boolean,
 ): ServerConfigPage[] => {
@@ -127,7 +127,7 @@ const convertConfigPages = (
     tagline,
     ...(userLevelConfigured ? { userLevelConfigured } : {}),
     elements: Object.entries(elements)
-      .filter(([key, value]) => !isConnectionScopedConfigVar(value as ConfigVar))
+      .filter(([key, value]) => !isConnectionScopedConfigVar(value))
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -51,9 +51,18 @@ type CreateScopedConfigVars<TScopedConfigVarMap> = keyof TScopedConfigVarMap ext
 export type ScopedConfigVarMap = CreateScopedConfigVars<IntegrationDefinitionScopedConfigVars>;
 
 export const isConnectionScopedConfigVar = (
-  cv: ConfigVar,
-): cv is OrganizationActivatedConnectionConfigVar =>
-  "dataType" in cv &&
-  cv.dataType === "connection" &&
-  !isConnectionDefinitionConfigVar(cv) &&
-  !isConnectionReferenceConfigVar(cv);
+  cv: unknown,
+): cv is OrganizationActivatedConnectionConfigVar => {
+  if (!cv || typeof cv !== "object" || Array.isArray(cv)) {
+    return false;
+  }
+
+  if (!("dataType" in cv) || cv.dataType !== "connection") {
+    return false;
+  }
+
+  return (
+    !isConnectionDefinitionConfigVar(cv as ConfigVar) &&
+    !isConnectionReferenceConfigVar(cv as ConfigVar)
+  );
+};


### PR DESCRIPTION
The `isConnectionScopedConfigVariable` type guard needed enhancing as not all values passing through it are guaranteed to even be of the appropriate `ConfigVar` shape.