### PR TITLE
Allow global error handlers to be async

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.11",
+  "version": "10.5.12",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -75,7 +75,7 @@ export const createPerform = (
 
       return result;
     } catch (error) {
-      throw errorHandler ? errorHandler(error) : error;
+      throw errorHandler ? await errorHandler(error) : error;
     }
   };
 };
@@ -106,7 +106,7 @@ const createInvokePollAction = <TInputs extends Inputs>(
         params,
       );
     } catch (error) {
-      throw errorHandler ? errorHandler(error) : error;
+      throw errorHandler ? await errorHandler(error) : error;
     }
   };
 };
@@ -164,7 +164,7 @@ export const createPollingPerform = (
         resultType: polledNoChanges ? "polled_no_changes" : "completed",
       };
     } catch (error) {
-      throw errorHandler ? errorHandler(error) : error;
+      throw errorHandler ? await errorHandler(error) : error;
     }
   };
 };

--- a/packages/spectral/src/types/ComponentDefinition.ts
+++ b/packages/spectral/src/types/ComponentDefinition.ts
@@ -7,7 +7,7 @@ import {
 } from ".";
 import { PollingTriggerDefinition } from "./PollingTriggerDefinition";
 
-export type ErrorHandler = (error: unknown) => unknown;
+export type ErrorHandler = (error: unknown) => unknown | Promise<unknown>;
 
 export interface ComponentHooks {
   /**


### PR DESCRIPTION
As a custom component developer, you can include a global error handler in your custom component that handles all errors thrown by all actions, data sources and triggers. https://prismatic.io/docs/custom-connectors/error-handling/#global-error-handlers

That function currently must be synchronous.

But, there are times when it would be handy to have an asynchronous function. For example, you may want to catch all errors and report them to a third-party app for analysis.

This updates perform invocations so that if an `errorHandler` is present, that handler is awaited. That way, you can make an error handler like

```
  hooks: {
    error: async (error) => {
      await fetch("https://api.example.com/error-reporting", {
        method: "POST",
        headers: {
          "Content-Type": "application/json",
        },
        body: JSON.stringify({
          error: (error as Error).message,
          stack: (error as Error).stack,
          timestamp: new Date().toISOString(),
        }),
      });
      return error;
    },
  },
```