### PR TITLE
Address various security notifications

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,7 +2863,7 @@ for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
-form-data@4.0.4:
+form-data@4.0.4, form-data@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
@@ -2872,15 +2872,6 @@ form-data@4.0.4:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
-    mime-types "^2.1.12"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 fs-extra@^11.2.0:


### PR DESCRIPTION
This PR:
1. Relocks `yarn.lock` after #343 
2. Bumps `@babel/helpers` to `7.27.6` to address https://github.com/advisories/GHSA-968p-4wvh-cqc8
3. Bumps `brace-expansion` to `2.0.2` to address https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
4. Bumps `form-data` to `4.0.4` to address https://github.com/form-data/form-data/security/advisories/GHSA-fjxv-7rqg-78g4