### PR TITLE
Bugfix: Update test harness connection keys

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.13",
+  "version": "10.5.14",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -380,7 +380,7 @@ export const invokeDataSource = async <
   return result;
 };
 
-type TestConnectionValue = Pick<ConnectionValue, "fields" | "context" | "token">;
+type TestConnectionValue = Pick<ConnectionValue, "fields" | "context" | "token" | "key">;
 
 type TestConfigVarValues = Record<string, string | TestConnectionValue>;
 
@@ -399,7 +399,7 @@ const createConfigVars = <TConfigVarValues extends TestConfigVarValues>(
         ...result,
         [key]: {
           ...value,
-          key,
+          key: value.key,
           configVarKey: "",
         },
       };

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -399,7 +399,6 @@ const createConfigVars = <TConfigVarValues extends TestConfigVarValues>(
         ...result,
         [key]: {
           ...value,
-          key: value.key,
           configVarKey: "",
         },
       };


### PR DESCRIPTION
A bug was reported where the `createConfigVars` testing method would not assign the correct keys to created connections. The issue was that `connection.key` was getting set to the connection's display key, rather than its actual key.