### PR TITLE
context._components fallbacks for testing use cases

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.15",
+  "version": "10.5.16",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/context.ts
+++ b/packages/spectral/src/serverTypes/context.ts
@@ -32,8 +32,7 @@ export function createCNIContext(
   // They are added to the context via spectral, here.
 
   // @ts-expect-error _components isn't part of the public API
-  const { _components } = context;
-
+  const _components = context._components ?? { invoke: () => {} };
   const invoke = (_components as { invoke: ComponentActionInvokeFunction }).invoke;
 
   // Construct the component methods from the component registry

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -878,7 +878,7 @@ const generateTriggerPerformFn = (
     componentRef && typeof onTrigger !== "function"
       ? async (context, payload, params) => {
           // @ts-expect-error: _components isn't part of the public API
-          const { _components } = context;
+          const _components = context._components ?? { invokeTrigger: () => {} };
           const invokeTrigger: TriggerActionInvokeFunction = _components.invokeTrigger;
           const cniContext = createCNIContext(context, componentRegistry);
 
@@ -923,8 +923,7 @@ const generateOnInstanceWrapperFn = (
     componentRef && typeof onTrigger !== "function"
       ? async (context, params) => {
           // @ts-expect-error: _components isn't part of the public API
-          const { _components } = context;
-
+          const _components = context._components ?? { invokeTrigger: () => {} };
           const invokeTrigger: TriggerActionInvokeFunction = _components.invokeTrigger;
           const cniContext = createCNIContext(context, componentRegistry);
           const invokeResponse =


### PR DESCRIPTION
We came across issues where attempts to build context for triggers and actions wouldn't work in testing scenarios because `context._components` was undefined. This PR fills in the gaps with no-ops.

Verified on local environment that you should be able to properly test management triggers via test harness after this.