### PR TITLE
Remove clean function from ConnectionInput hinting

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.5.16",
+  "version": "10.5.17",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -38,7 +38,7 @@ export const convertInput = (
     label,
     collection,
     ...rest
-  }: InputFieldDefinition | OnPremConnectionInput,
+  }: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
   const keyLabel =
     collection === "keyvaluelist" && typeof label === "object" ? label.key : undefined;
@@ -286,7 +286,7 @@ export const convertConnection = ({
 
   const convertedInputs = Object.entries(inputs).map(([key, value]) => {
     if ("templateValue" in value) {
-      return convertTemplateInput(key, value, inputs);
+      return convertTemplateInput(key, value as ConnectionTemplateInputField, inputs);
     }
 
     return convertInput(key, value);

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -30,6 +30,7 @@ import {
   FlowSchema,
   DEFAULT_JSON_SCHEMA_VERSION,
   FlowDefinitionFlowSchema,
+  ConnectionTemplateInputField,
 } from "../types";
 import {
   Component as ServerComponent,
@@ -687,7 +688,7 @@ export const convertConfigVar = (
         }
 
         const defaultValue = input.collection
-          ? (input.default || []).map((defaultValue) => {
+          ? (Array.isArray(input.default) ? input.default : []).map((defaultValue) => {
               if (typeof defaultValue === "string") {
                 return {
                   type: "value",
@@ -1101,7 +1102,7 @@ const codeNativeIntegrationComponent = (
 
       const convertedInputs = Object.entries(configVar.inputs).map(([key, value]) => {
         if ("templateValue" in value) {
-          return convertTemplateInput(key, value, configVar.inputs);
+          return convertTemplateInput(key, value as ConnectionTemplateInputField, configVar.inputs);
         }
 
         return convertInput(key, value);

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -16,7 +16,6 @@ import { createDebugContext, createInvokeFlow, logDebugResults } from "./context
 
 export type PerformFn = (...args: any[]) => Promise<any>;
 export type CleanFn = (...args: any[]) => any;
-
 export type InputCleaners = Record<string, CleanFn | undefined>;
 
 interface CreatePerformProps {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -96,14 +96,15 @@ export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = 
 
 export type Inputs = Record<string, InputFieldDefinition>;
 
-export type ConnectionInput = (
+export type ConnectionInput = Omit<
   | StringInputField
   | DataInputField
   | TextInputField
   | PasswordInputField
   | BooleanInputField
-  | ConnectionTemplateInputField
-) & {
+  | ConnectionTemplateInputField,
+  "clean"
+> & {
   /** Determines if this input field should be shown in the UI. */
   shown?: boolean;
   /**


### PR DESCRIPTION
We do not currently support defining `clean` functions on connection inputs. While `clean` is fine for every other type of input, it's basically because all other cases involve a `perform` function that we can modify to run the clean functions at the convert step.

Connections do not have a `perform` step, and at component build time they're basically defined as objects. Because of this, we cannot run `clean` methods on their inputs without doing some significant investigation re: storing the `clean` functions somewhere and deciding where they'll be executed (the runner?).

That said, we still show an optional `clean?` key in connection input hinting, which has caused confusion. This PR removes the incorrect hinting.