### PR TITLE
Organize spectral exports

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",
@@ -20,6 +20,36 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./component": {
+      "types": "./dist/component.d.ts",
+      "default": "./dist/component.js"
+    },
+    "./integration": {
+      "types": "./dist/integration.d.ts",
+      "default": "./dist/integration.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
+    },
+    "./util": {
+      "types": "./dist/util.d.ts",
+      "default": "./dist/util.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/types/index.js"
+    },
+    "./types/server": {
+      "types": "./dist/serverTypes/index.d.ts",
+      "default": "./dist/serverTypes/index.js"
+    }
   },
   "license": "MIT",
   "scripts": {

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -617,6 +617,8 @@ const cleanObject = (
   return omitBy(obj, predicate || defaultPredicate);
 };
 
+export * from "./errors";
+
 export default {
   types: {
     isBool,


### PR DESCRIPTION
# Premise

**Open to feedback.**

We are currently working on an effort to break up spectral exports into categories that specifically serve the desired use case. These use cases are:

* CNI dev (e.g. `import { integration, flow } from '@prismatic-io/spectral/integration'`)
* Component dev  (e.g. `import { component, action } from '@prismatic-io/spectral/component'`)
* Testing components/CNI's
* Providing types
* Providing utils

This PR is a first pass at organizing these exports accordingly, so users may selectively only import what they need.

# Separate packages vs. organized exports

There was some discussion of breaking up packages according to integration development and component development use cases, all stored in the same monorepo. There was also discussion of the possibility of a third package for providing types and shared utilities.

While we may do a package break-up eventually, I don't necessarily see the benefit in investing the time/dev & enablement work to introduce the churn now. I'm not completely opposed to the work, but I think it'd require a larger effort and feedback from the product & customer success sides.

I think a break-up re-evaluation may also make more sense if we actually decide to invest in a shared library for consumption by prism-mcp, the VSCode extension, etc.

# Breaking changes

Because we are now being explicit about what paths users can import from, any existing references to `@prismatic-io/spectral/dist` will break (often used for serverTypes). These should be replaced with paths defined in the following package.json (e.g. `@prismatic-io/spectral/types/server`).

References to `@prismatic-io/spectral` generally will still continue to work; allowing users to incrementally adopt the more specific exports if desired.

Despite the breaking change, I do not think this merits going up to version 11 though.
