### PR TITLE
Conditionally import async_hooks; component-manifest bugfixes

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -51,7 +51,9 @@ export const getInputs = ({ inputs, docBlock = DOC_BLOCK_DEFAULT }: GetInputsPro
         label: input.label,
         inputType: input.type,
         valueType: getInputValueType(input),
-        required: input.required && (input.default === undefined || input.default === ""),
+        required:
+          input.required &&
+          (input.default === undefined || input.default === null || input.default === ""),
         collection: input.collection,
         onPremControlled: input.onPremiseControlled || input.onPremControlled,
         docBlock: docBlock(input),

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -1,6 +1,6 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
-import { requireContext } from "@prismatic-io/spectral";
+import { requireContext } from "@prismatic-io/spectral/dist/serverTypes";
 
 export interface <%= action.typeInterface %>Values {
 <%- include('../partials/performArgs.ejs', { inputs: action.inputs, helpers }) -%>

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -307,4 +307,3 @@ export { default as util } from "./util";
 export * from "./types";
 export { default as testing } from "./testing";
 export * from "./errors";
-export * from "./serverTypes/asyncContext";

--- a/packages/spectral/src/serverTypes/asyncContext.ts
+++ b/packages/spectral/src/serverTypes/asyncContext.ts
@@ -1,12 +1,17 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { ActionContext } from "../types";
 
-const actionContextStorage = new AsyncLocalStorage<ActionContext>();
+// Only import async_hooks in Node.js environments
+const asyncHooks = typeof window === "undefined" ? require("node:async_hooks") : null;
+const actionContextStorage = asyncHooks ? new asyncHooks.AsyncLocalStorage() : null;
 
 export function runWithContext<T>(
   context: ActionContext,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
+  if (!actionContextStorage) {
+    // This shouldn't be running in a browser environment anyway.
+    return fn();
+  }
   return actionContextStorage.run(context, fn);
 }
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -313,3 +313,5 @@ export interface Input {
   dataSource?: string;
   shown?: boolean;
 }
+
+export * from "./asyncContext";


### PR DESCRIPTION
While testing some other changes I came across two issues:

* `AsyncLocalStorage` cannot be used in a browser context -- in reality it never should be (it is used to power CNI action invocations), but the way `asyncContext` was being exported from this package would cause failures in browser-based builds (e.g. frontend).
  * I also moved `asyncContext` out of the generic index export & updated the manifest generator accordingly.
* Caught a component-manifest generation bug where sometimes required inputs would come through as optional.