### PR TITLE
Bugfix - Component manifest generation: Add camelcase when needed

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/componentManifest/helpers.ts
+++ b/packages/spectral/src/generators/componentManifest/helpers.ts
@@ -1,3 +1,4 @@
+import { camelizeLowercaseType } from "../utils/camelizeLowercaseType";
 import { capitalizeFirstLetter } from "../utils/capitalizeFirstLetter";
 import { createDependencyImports } from "../utils/createDependencyImports";
 import { formatType } from "../utils/formatType";
@@ -10,4 +11,5 @@ export const helpers = {
   generatePackageJsonVersion,
   formatType,
   camelCase,
+  camelizeLowercaseType,
 };

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -17,7 +17,7 @@ export const <%= action.import %> = {
     values: <%= action.typeInterface %>Values
   ): Promise<TReturn> => {
     const context = requireContext();
-    return await context.components.<%= action.componentKey %>.<%= action.key %>({ ...values }) as TReturn;
+    return await context.components.<%= helpers.camelCase(action.componentKey) %>.<%= action.key %>({ ...values }) as TReturn;
   },
   inputs: {
     <%- include('../partials/inputs.ejs', { inputs: action.inputs, helpers }) -%>

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -29,7 +29,7 @@ export const <%= connection.import %> = {
  *
  * @comments Helper for direct usage in config wizard definitions.
  */
-export const <%= connection.componentKey %><%= helpers.capitalizeFirstLetter(helpers.camelCase(connection.key)) %> = (
+export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capitalizeFirstLetter(helpers.camelCase(connection.key)) %> = (
   stableKey: string,
   values: {
 <% connection.inputs.forEach((input) => { -%>

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -16,7 +16,7 @@ export const <%= dataSource.import %> = {
   perform: (
     _values: <%= dataSource.typeInterface %>Values
   ): Promise<void> => Promise.resolve(),
-  dataSourceType: "<%= dataSource.dataSourceType %>",
+  dataSourceType: "<%= helpers.camelizeLowercaseType(dataSource.dataSourceType) %>",
   inputs: {
     <%- include('../partials/inputs.ejs', { inputs: dataSource.inputs, helpers }) -%>
   }
@@ -27,7 +27,7 @@ export const <%= dataSource.import %> = {
  *
  * @comments Helper for direct usage in config wizard definitions.
  */
-export const <%= dataSource.componentKey %><%= helpers.capitalizeFirstLetter(helpers.camelCase(dataSource.key)) %> = (
+export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capitalizeFirstLetter(helpers.camelCase(dataSource.key)) %> = (
   stableKey: string,
   values: {
 <% dataSource.inputs.forEach((input) => { -%>

--- a/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/partials/inputs.ejs
@@ -1,6 +1,6 @@
 <% inputs.forEach((input) => { -%>
   <%- helpers.formatType(input.key) %>: {
-    inputType: "<%= input.inputType %>",
+    inputType: "<%= helpers.camelizeLowercaseType(input.inputType) %>",
     <%_ if (input.collection) { -%>
     collection: "<%= input.collection %>",
     <%_ } else { -%>

--- a/packages/spectral/src/generators/utils/camelizeLowercaseType.ts
+++ b/packages/spectral/src/generators/utils/camelizeLowercaseType.ts
@@ -1,0 +1,11 @@
+const LOWER_TO_CAMEL_MAP: Record<string, string> = {
+  objectfieldmap: "objectFieldMap",
+  objectselection: "objectSelection",
+  dynamicfieldselection: "dynamicFieldSelection",
+  dynamicobjectselection: "dynamicObjectSelection",
+  jsonform: "jsonForm",
+};
+
+export const camelizeLowercaseType = (type: string) => {
+  return LOWER_TO_CAMEL_MAP[type] ?? type;
+};


### PR DESCRIPTION
We were running into issues where:

1. Certain dataSourceTypes and input types were coming back from the API in all caps, and then not getting camelized properly in the generated manifest (e.g. `OBJECTSELECTION => objectselection`, when the typechecker wants `objectSelection`).
2. Some hyphenated component keys weren't getting camelized and resulting in bad constant names

Re: issue 1, Unfortunately we can't just toss `src/manifests` into generated tsconfig excludes, so we have to actually address this. Put in a manual map to re-camelize these types so manifests generated via API will actually build.

**Notes:**
* valuelist and keyvaluelist do not need treatment
* I am leaving the version bump off for now -- I see some other changes in flight and I'll just wait until the dust has settled to bump