### PR TITLE
Add support for required key in invoke schemas

### DIFF
--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -515,6 +515,7 @@ const convertFlowSchemas = (
         $comment: value.$comment,
         properties: value.properties,
         $schema: value.$schema || DEFAULT_JSON_SCHEMA_VERSION,
+        ...(value.required?.length ? { required: value.required } : {}),
       };
       return acc;
     },

--- a/packages/spectral/src/types/FlowSchemas.ts
+++ b/packages/spectral/src/types/FlowSchemas.ts
@@ -1,6 +1,6 @@
 interface FlowSchemaProperty {
   description: string;
-  type: string;
+  type?: string;
 }
 
 export const DEFAULT_JSON_SCHEMA_VERSION = "https://json-schema.org/draft/2020-12/schema";
@@ -12,6 +12,7 @@ export type FlowDefinitionFlowSchema = {
   $comment?: string;
   $schema?: string;
   properties: Record<string, FlowSchemaProperty>;
+  required?: string[];
 };
 
 export interface FlowSchema {
@@ -20,6 +21,7 @@ export interface FlowSchema {
   $schema: string;
   type: string;
   properties: Record<string, FlowSchemaProperty>;
+  required?: string[];
 }
 
 export interface FlowSchemas {


### PR DESCRIPTION
Adds support to the conversion layer to pass along `required` key in JSON schema for the invoke schemas.

Example usage in CNI:
```
invoke: {
  type: "object",
  properties: {
    to: {
      type: "array",
      description: "Recipient email addresses",
      items: { type: "string", format: "email" },
    },
    subject: {
      type: "string",
      description: "Email subject line",
    },
    body: {
      type: "string",
      description: "Email message content",
    },
    cc: {
      type: "array",
      description: "CC recipients",
      items: { type: "string", format: "email" },
    },
    bcc: {
      type: "array",
      description: "BCC recipients",
      items: { type: "string", format: "email" },
    },
    isHtml: {
      type: "boolean",
      description: "Send as HTML email",
    },
    importance: {
      type: "string",
      description: "Email importance level (low, normal, high)",
      enum: ["low", "normal", "high"],
    },
  },
  required: ["to", "subject", "body"],
}
```