### PR TITLE
Support wrapper functions for triggers in component manifests

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.6.7",
+  "version": "10.7.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -142,7 +142,7 @@ export const fetchComponentDataForManifest = async ({
   });
 
   return {
-    key: componentKey,
+    key: component.key,
     signature: component.signature,
     public: !isPrivate,
     display: {

--- a/packages/spectral/src/generators/componentManifest/createTriggers.ts
+++ b/packages/spectral/src/generators/componentManifest/createTriggers.ts
@@ -55,6 +55,7 @@ export const createTriggers = async ({
           label: trigger.display.description,
           description: trigger.display.description,
           inputs,
+          componentKey: component.key,
         },
         dryRun,
         imports,
@@ -111,6 +112,7 @@ interface RenderTriggerProps {
     label: string;
     description: string;
     inputs: Input[];
+    componentKey: string;
   };
   dryRun: boolean;
   imports: Imports;

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -10,6 +10,7 @@ export interface <%= connection.typeInterface %>Values {
  * <%= connection.label %>
  *
  * @comments <%- connection.comments %>
+ * This object is used to support type hinting.
  */
 export const <%= connection.import %> = {
   key: "<%= connection.key %>",
@@ -27,7 +28,7 @@ export const <%= connection.import %> = {
 /**
  * <%= connection.label %> Connection Helper
  *
- * @comments Helper for direct usage in config wizard definitions.
+ * @comments This wrapper function can be used directly in config wizard definitions.
  */
 export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capitalizeFirstLetter(helpers.camelCase(connection.key)) %> = (
   stableKey: string,

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -10,6 +10,7 @@ export interface <%= dataSource.typeInterface %>Values {
  * <%= dataSource.label %>
  *
  * @description <%- dataSource.description %>
+ * This object is used to support type hinting.
  */
 export const <%= dataSource.import %> = {
   key: "<%= dataSource.key %>",
@@ -25,7 +26,7 @@ export const <%= dataSource.import %> = {
 /**
  * <%= dataSource.label %> DataSource Helper
  *
- * @comments Helper for direct usage in config wizard definitions.
+ * @comments This wrapper function can be used directly in config wizard definitions.
  */
 export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capitalizeFirstLetter(helpers.camelCase(dataSource.key)) %> = (
   stableKey: string,

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -1,5 +1,6 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
+import { ConfigVarExpression } from "@prismatic-io/spectral";
 
 export interface <%= trigger.typeInterface %>Values {
 <%- include('../partials/performArgs.ejs', { inputs: trigger.inputs, helpers }) -%>
@@ -9,6 +10,7 @@ export interface <%= trigger.typeInterface %>Values {
  * <%= trigger.label %>
  *
  * @description <%- trigger.description %>
+ * This object is used to support type hinting.
  */
 export const <%= trigger.import %> = {
   key: "<%= trigger.key %>",
@@ -19,3 +21,22 @@ export const <%= trigger.import %> = {
     <%- include('../partials/inputs.ejs', { inputs: trigger.inputs, helpers }) -%>
   }
 } as const;
+
+/**
+ * <%= trigger.label %> Trigger Helper
+ *
+ * @comments This wrapper function can be used directly in flow definitions.
+ */
+export const <%= helpers.camelCase(trigger.componentKey) %><%= helpers.capitalizeFirstLetter(trigger.import) %> = (values: {
+  <% trigger.inputs.forEach((input) => { -%>
+    <%- helpers.formatType(input.key) %><%= input.required ? "" : "?" %>: ({
+      value: <%- input.valueType.type ? input.valueType.type : input.valueType %>;
+    } | ConfigVarExpression);
+  <% }); -%>
+}) => {
+  return {
+    component: "<%= helpers.camelCase(trigger.componentKey) %>",
+    key: "<%= trigger.key %>",
+    values,
+  } as const;
+};


### PR DESCRIPTION
This PR:

* Fixes cni-component-manifest script to always return correctly formatted component keys
* Adds trigger wrapper functions to generated component manifests, to mirror what we did for actions, connections, and data sources
* Updates comments in manifest for clearer description of intended usage