### PR TITLE
Ensure we reference action by camel-cased key to handle actions with hyphens in their keys

### DIFF
--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -17,7 +17,7 @@ export const <%= action.import %> = {
     values: <%= action.typeInterface %>Values
   ): Promise<TReturn> => {
     const context = requireContext();
-    return await context.components.<%= helpers.camelCase(action.componentKey) %>.<%= action.key %>({ ...values }) as TReturn;
+    return await context.components.<%= helpers.camelCase(action.componentKey) %>.<%= action.import %>({ ...values }) as TReturn;
   },
   inputs: {
     <%- include('../partials/inputs.ejs', { inputs: action.inputs, helpers }) -%>


### PR DESCRIPTION
Almost every action has a key that is already camel-cased. `sendSlackMessage`, etc.

Keys do not need to be camel-cased, though. They can contain hyphens, like the [Compute MD5-SHA1 Hash](https://prismatic.io/docs/components/hash/#compute-md5-sha1-hash) action, which has a key of `computemd5-sha1`.

If you generate a manifest for the `hash` component, you get erronous TypeScript with hyphens that are interpreted as as minus signs.

```
export const computemd5Sha1 = {
  key: "computemd5-sha1",
  perform: async <TReturn>(values: Computemd5Sha1Values): Promise<TReturn> => {
    const context = requireContext();
    return ((await context.components.hash.computemd5) -
      sha1({ ...values })) as TReturn;
  },
```

You end up with TypeScript errors on build

```
ERROR in /Users/treece/src/tmp/toying-with-triggers/trigger-cni/src/manifests/hash/actions/computemd5Sha1.ts
./src/manifests/hash/actions/computemd5Sha1.ts 25:12-54
[tsl] ERROR in /Users/treece/src/tmp/toying-with-triggers/trigger-cni/src/manifests/hash/actions/computemd5Sha1.ts(25,13)
      TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 @ ./src/manifests/hash/actions/index.ts 19:0-50 41:4-18
 @ ./src/manifests/hash/index.ts 5:0-32 9:0-55 14:4-11
 @ ./src/componentRegistry.ts 9:0-36 13:4-8
 @ ./src/index.ts 12:0-56 14:0-56 14:0-56 21:4-21
```

In reality, we should be invoking `await context.components.hash.computemd5Sha1` instead.

This updates that action invocation so that the action's key is camel-cased. `action.import` is camel-cased.

To test, I verified that after this change when I generated a manifest for the Hash component, I could invoke both actions whose keys contain hyphens, and those that do not, in my flow.