### PR TITLE
Bugfix: cni-component-manifest - Throw readable error if there is an API request failure

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",


### PR DESCRIPTION
Tested by setting the access token to an intentionally invalid string. Most of the diff here is just formatting changes from putting stuff into a try/catch block.