### PR TITLE
Add simulated test flag to action context

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.10.0",
+  "version": "10.11.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/types/ActionPerformFunction.ts
+++ b/packages/spectral/src/types/ActionPerformFunction.ts
@@ -166,4 +166,6 @@ export type ActionContext<
   debug: DebugContext;
   /** JSON schemas to enable using flows for AI function calls. */
   flowSchemas: FlowSchemas;
+  /** Whether the execution is being run with simulated data. */
+  isSimulatedTestExecution?: boolean;
 };


### PR DESCRIPTION
Adds `isSimulatedTestExecution` to the action context. Likely to be used to skip behavior that may not work with arbitrary payload/result data (eg. hmac validation) when running a test case.