### PR TITLE
Make manifest wrapper functions compatible with user-defined component keys

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.8.1",
+  "version": "10.9.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/generators/cniComponentManifest/cli.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/cli.ts
@@ -115,7 +115,6 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose,
     sourceDir: templatesDir,
     destinationDir,
-    isCniManifest: true,
   });
 
   await createConnections({
@@ -124,7 +123,6 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose,
     sourceDir: templatesDir,
     destinationDir,
-    isCniManifest: true,
   });
 
   await createDataSources({
@@ -133,7 +131,6 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose: flags.verbose.value,
     sourceDir: templatesDir,
     destinationDir,
-    isCniManifest: true,
   });
 
   console.info(

--- a/packages/spectral/src/generators/cniComponentManifest/cli.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/cli.ts
@@ -134,6 +134,6 @@ export const runMain = async (process: NodeJS.Process) => {
   });
 
   console.info(
-    `Component manifest created successfully for ${component.display.label} in ${destinationDir}!`,
+    `Component manifest created successfully for ${component.display.label} in ${destinationDir}!\nEnsure that you update your componentRegistry file accordingly.`,
   );
 };

--- a/packages/spectral/src/generators/cniComponentManifest/cli.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/cli.ts
@@ -115,6 +115,7 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose,
     sourceDir: templatesDir,
     destinationDir,
+    isCniManifest: true,
   });
 
   await createConnections({
@@ -123,6 +124,7 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose,
     sourceDir: templatesDir,
     destinationDir,
+    isCniManifest: true,
   });
 
   await createDataSources({
@@ -131,6 +133,7 @@ export const runMain = async (process: NodeJS.Process) => {
     verbose: flags.verbose.value,
     sourceDir: templatesDir,
     destinationDir,
+    isCniManifest: true,
   });
 
   console.info(

--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -156,11 +156,7 @@ export const fetchComponentDataForManifest = async ({
       connections,
     };
   } catch (error) {
-    throw new Error(
-      `There was an error accessing the Prismatic API. Check your login status via 'prism me' or 'prism login'.\n${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
+    throw new Error(error instanceof Error ? error.message : String(error));
   }
 };
 

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -6,6 +6,7 @@ export interface ComponentNode {
   description: string;
   signature: string;
   key: string;
+  public: boolean;
   actions: {
     nodes: ActionNode[];
   };

--- a/packages/spectral/src/generators/componentManifest/createConnections.ts
+++ b/packages/spectral/src/generators/componentManifest/createConnections.ts
@@ -14,6 +14,7 @@ interface CreateConnectionsProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest?: boolean;
 }
 
 export const createConnections = async ({
@@ -22,6 +23,7 @@ export const createConnections = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest = false,
 }: CreateConnectionsProps) => {
   if (verbose) {
     console.info("Creating connections...");
@@ -73,6 +75,7 @@ export const createConnections = async ({
         verbose,
         sourceDir,
         destinationDir,
+        isCniManifest,
       });
     }),
   );
@@ -132,6 +135,7 @@ interface RenderConnectionProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest: boolean;
 }
 
 const renderConnection = async ({
@@ -141,6 +145,7 @@ const renderConnection = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest,
 }: RenderConnectionProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "connections", "connection.ts.ejs"),
@@ -149,6 +154,7 @@ const renderConnection = async ({
       connection,
       helpers,
       imports,
+      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/createConnections.ts
+++ b/packages/spectral/src/generators/componentManifest/createConnections.ts
@@ -14,7 +14,6 @@ interface CreateConnectionsProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest?: boolean;
 }
 
 export const createConnections = async ({
@@ -23,7 +22,6 @@ export const createConnections = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest = false,
 }: CreateConnectionsProps) => {
   if (verbose) {
     console.info("Creating connections...");
@@ -75,7 +73,6 @@ export const createConnections = async ({
         verbose,
         sourceDir,
         destinationDir,
-        isCniManifest,
       });
     }),
   );
@@ -135,7 +132,6 @@ interface RenderConnectionProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest: boolean;
 }
 
 const renderConnection = async ({
@@ -145,7 +141,6 @@ const renderConnection = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest,
 }: RenderConnectionProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "connections", "connection.ts.ejs"),
@@ -154,7 +149,6 @@ const renderConnection = async ({
       connection,
       helpers,
       imports,
-      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/createConnections.ts
+++ b/packages/spectral/src/generators/componentManifest/createConnections.ts
@@ -66,6 +66,7 @@ export const createConnections = async ({
           inputs,
           onPremAvailable,
           componentKey: component.key,
+          componentIsPublic: Boolean(component.public),
         },
         imports,
         dryRun,
@@ -124,6 +125,7 @@ interface RenderConnectionProps {
     inputs: Input[];
     onPremAvailable: boolean;
     componentKey: string;
+    componentIsPublic: boolean;
   };
   dryRun: boolean;
   imports: Imports;

--- a/packages/spectral/src/generators/componentManifest/createDataSources.ts
+++ b/packages/spectral/src/generators/componentManifest/createDataSources.ts
@@ -15,7 +15,6 @@ interface CreateDataSourcesProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest?: boolean;
 }
 
 export const createDataSources = async ({
@@ -24,7 +23,6 @@ export const createDataSources = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest = false,
 }: CreateDataSourcesProps) => {
   if (verbose) {
     console.info("Creating data sources...");
@@ -72,7 +70,6 @@ export const createDataSources = async ({
         verbose,
         sourceDir,
         destinationDir,
-        isCniManifest,
       });
     }),
   );
@@ -132,7 +129,6 @@ interface RenderDataSourceProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest: boolean;
 }
 
 const renderDataSource = async ({
@@ -142,7 +138,6 @@ const renderDataSource = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest,
 }: RenderDataSourceProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "dataSources", "dataSource.ts.ejs"),
@@ -151,7 +146,6 @@ const renderDataSource = async ({
       dataSource,
       helpers,
       imports,
-      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/createDataSources.ts
+++ b/packages/spectral/src/generators/componentManifest/createDataSources.ts
@@ -63,6 +63,7 @@ export const createDataSources = async ({
           dataSourceType: dataSource.dataSourceType,
           inputs,
           componentKey: component.key,
+          componentIsPublic: Boolean(component.public),
         },
         imports,
         dryRun,
@@ -121,6 +122,7 @@ interface RenderDataSourceProps {
     dataSourceType: DataSourceType;
     inputs: Input[];
     componentKey: string;
+    componentIsPublic: boolean;
   };
   dryRun: boolean;
   imports: Imports;

--- a/packages/spectral/src/generators/componentManifest/createDataSources.ts
+++ b/packages/spectral/src/generators/componentManifest/createDataSources.ts
@@ -15,6 +15,7 @@ interface CreateDataSourcesProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest?: boolean;
 }
 
 export const createDataSources = async ({
@@ -23,6 +24,7 @@ export const createDataSources = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest = false,
 }: CreateDataSourcesProps) => {
   if (verbose) {
     console.info("Creating data sources...");
@@ -70,6 +72,7 @@ export const createDataSources = async ({
         verbose,
         sourceDir,
         destinationDir,
+        isCniManifest,
       });
     }),
   );
@@ -129,6 +132,7 @@ interface RenderDataSourceProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest: boolean;
 }
 
 const renderDataSource = async ({
@@ -138,6 +142,7 @@ const renderDataSource = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest,
 }: RenderDataSourceProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "dataSources", "dataSource.ts.ejs"),
@@ -146,6 +151,7 @@ const renderDataSource = async ({
       dataSource,
       helpers,
       imports,
+      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/createTriggers.ts
+++ b/packages/spectral/src/generators/componentManifest/createTriggers.ts
@@ -14,6 +14,7 @@ interface CreateTriggersProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest?: boolean;
 }
 
 export const createTriggers = async ({
@@ -22,6 +23,7 @@ export const createTriggers = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest = false,
 }: CreateTriggersProps) => {
   if (verbose) {
     console.info("Creating triggers...");
@@ -63,6 +65,7 @@ export const createTriggers = async ({
         verbose,
         sourceDir,
         destinationDir,
+        isCniManifest,
       });
     }),
   );
@@ -121,6 +124,7 @@ interface RenderTriggerProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
+  isCniManifest: boolean;
 }
 
 const renderTrigger = async ({
@@ -130,6 +134,7 @@ const renderTrigger = async ({
   verbose,
   sourceDir,
   destinationDir,
+  isCniManifest,
 }: RenderTriggerProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "triggers", "trigger.ts.ejs"),
@@ -138,6 +143,7 @@ const renderTrigger = async ({
       helpers,
       imports,
       trigger,
+      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/createTriggers.ts
+++ b/packages/spectral/src/generators/componentManifest/createTriggers.ts
@@ -56,6 +56,7 @@ export const createTriggers = async ({
           description: trigger.display.description,
           inputs,
           componentKey: component.key,
+          componentIsPublic: Boolean(component.public),
         },
         dryRun,
         imports,
@@ -113,6 +114,7 @@ interface RenderTriggerProps {
     description: string;
     inputs: Input[];
     componentKey: string;
+    componentIsPublic: boolean;
   };
   dryRun: boolean;
   imports: Imports;

--- a/packages/spectral/src/generators/componentManifest/createTriggers.ts
+++ b/packages/spectral/src/generators/componentManifest/createTriggers.ts
@@ -14,7 +14,6 @@ interface CreateTriggersProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest?: boolean;
 }
 
 export const createTriggers = async ({
@@ -23,7 +22,6 @@ export const createTriggers = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest = false,
 }: CreateTriggersProps) => {
   if (verbose) {
     console.info("Creating triggers...");
@@ -65,7 +63,6 @@ export const createTriggers = async ({
         verbose,
         sourceDir,
         destinationDir,
-        isCniManifest,
       });
     }),
   );
@@ -124,7 +121,6 @@ interface RenderTriggerProps {
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
-  isCniManifest: boolean;
 }
 
 const renderTrigger = async ({
@@ -134,7 +130,6 @@ const renderTrigger = async ({
   verbose,
   sourceDir,
   destinationDir,
-  isCniManifest,
 }: RenderTriggerProps) => {
   return await createTemplate({
     source: path.join(sourceDir, "triggers", "trigger.ts.ejs"),
@@ -143,7 +138,6 @@ const renderTrigger = async ({
       helpers,
       imports,
       trigger,
-      isCniManifest,
     },
     dryRun,
     verbose,

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -3,7 +3,6 @@ import { connectionConfigVar } from "@prismatic-io/spectral/dist/integration";
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
-  runWithIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
@@ -45,24 +44,20 @@ export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capita
 <% }); -%>
   },
 ) => {
-  const context = requireIntegrationContext();
-  return runWithIntegrationContext(context, () => {
-    const userKey = findUserDefinedComponentKey(
-      "<%= connection.componentKey %>",
-      context.componentRegistry,
-    );
-
-    return connectionConfigVar({
-      dataType: "connection",
-      stableKey,
-      connection: {
-        // @ts-expect-error: findUserDefinedComponentKey does not narrow a response to a specific user key.
-        component: userKey,
-        // @ts-expect-error: See above.
-        key: "<%= helpers.camelCase(connection.key) %>",
-        // @ts-expect-error: See above.
-        values,
+  return connectionConfigVar({
+    dataType: "connection",
+    stableKey,
+    connection: {
+      get component() {
+        const context = requireIntegrationContext();
+        return findUserDefinedComponentKey(
+          "<%= connection.componentKey %>",
+          <%= connection.componentIsPublic %>,
+          context.componentRegistry,
+        );
       },
-    });
+      key: "<%= helpers.camelCase(connection.key) %>",
+      values,
+    },
   });
 };

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -1,5 +1,10 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { connectionConfigVar } from "@prismatic-io/spectral/dist/integration";
+import {
+  findUserDefinedComponentKey,
+  requireIntegrationContext,
+  runWithIntegrationContext,
+} from "@prismatic-io/spectral/dist/serverTypes";
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= connection.typeInterface %>Values {
@@ -40,13 +45,24 @@ export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capita
 <% }); -%>
   },
 ) => {
-  return connectionConfigVar({
-    dataType: "connection",
-    stableKey,
-    connection: {
-      component: "<%= connection.componentKey %>",
-      key: "<%= helpers.camelCase(connection.key) %>",
-      values,
-    },
+  const context = requireIntegrationContext();
+  return runWithIntegrationContext(context, () => {
+    const userKey = findUserDefinedComponentKey(
+      "<%= connection.componentKey %>",
+      context.componentRegistry,
+    );
+
+    return connectionConfigVar({
+      dataType: "connection",
+      stableKey,
+      connection: {
+        // @ts-expect-error: findUserDefinedComponentKey does not narrow a response to a specific user key.
+        component: userKey,
+        // @ts-expect-error: See above.
+        key: "<%= helpers.camelCase(connection.key) %>",
+        // @ts-expect-error: See above.
+        values,
+      },
+    });
   });
 };

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -1,11 +1,9 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { connectionConfigVar } from "@prismatic-io/spectral/dist/integration";
-<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
-<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= connection.typeInterface %>Values {
@@ -31,7 +29,6 @@ export const <%= connection.import %> = {
   }
 } as const;
 
-<%_ if (isCniManifest) { -%>
 /**
  * <%= connection.label %> Connection Helper
  *
@@ -64,4 +61,3 @@ export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capita
     },
   });
 };
-<%_ } -%>

--- a/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/connection.ts.ejs
@@ -1,9 +1,11 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { connectionConfigVar } from "@prismatic-io/spectral/dist/integration";
+<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
+<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= connection.typeInterface %>Values {
@@ -29,6 +31,7 @@ export const <%= connection.import %> = {
   }
 } as const;
 
+<%_ if (isCniManifest) { -%>
 /**
  * <%= connection.label %> Connection Helper
  *
@@ -61,3 +64,4 @@ export const <%= helpers.camelCase(connection.componentKey) %><%= helpers.capita
     },
   });
 };
+<%_ } -%>

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -1,5 +1,10 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { dataSourceConfigVar } from "@prismatic-io/spectral/dist/integration";
+import {
+  findUserDefinedComponentKey,
+  requireIntegrationContext,
+  runWithIntegrationContext,
+} from "@prismatic-io/spectral/dist/serverTypes";
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= dataSource.typeInterface %>Values {
@@ -40,12 +45,21 @@ export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capita
 <% }); -%>
   },
 ) => {
-  return dataSourceConfigVar({
-    stableKey,
-    dataSource: {
-      component: "<%= dataSource.componentKey %>",
-      key: "<%= helpers.camelCase(dataSource.key) %>",
-      values,
-    },
+  const context = requireIntegrationContext();
+  return runWithIntegrationContext(context, () => {
+    const userKey = findUserDefinedComponentKey(
+      "<%= dataSource.componentKey %>",
+      context.componentRegistry,
+    );
+
+    return dataSourceConfigVar({
+      stableKey,
+      dataSource: {
+        // @ts-expect-error: findUserDefinedComponentKey does not narrow a response to a specific user key.
+        component: userKey,
+        key: "<%= helpers.camelCase(dataSource.key) %>",
+        values,
+      },
+    });
   });
 };

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -1,9 +1,11 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { dataSourceConfigVar } from "@prismatic-io/spectral/dist/integration";
+<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
+<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= dataSource.typeInterface %>Values {
@@ -27,6 +29,7 @@ export const <%= dataSource.import %> = {
   }
 } as const;
 
+<%_ if (isCniManifest) { -%>
 /**
  * <%= dataSource.label %> DataSource Helper
  *
@@ -60,3 +63,4 @@ export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capita
     },
   });
 };
+<%_ } -%>

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -3,7 +3,6 @@ import { dataSourceConfigVar } from "@prismatic-io/spectral/dist/integration";
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
-  runWithIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
@@ -45,21 +44,19 @@ export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capita
 <% }); -%>
   },
 ) => {
-  const context = requireIntegrationContext();
-  return runWithIntegrationContext(context, () => {
-    const userKey = findUserDefinedComponentKey(
-      "<%= dataSource.componentKey %>",
-      context.componentRegistry,
-    );
-
-    return dataSourceConfigVar({
-      stableKey,
-      dataSource: {
-        // @ts-expect-error: findUserDefinedComponentKey does not narrow a response to a specific user key.
-        component: userKey,
-        key: "<%= helpers.camelCase(dataSource.key) %>",
-        values,
+  return dataSourceConfigVar({
+    stableKey,
+    dataSource: {
+      get component() {
+        const context = requireIntegrationContext();
+        return findUserDefinedComponentKey(
+          "<%= dataSource.componentKey %>",
+          <%= dataSource.componentIsPublic %>,
+          context.componentRegistry,
+        );
       },
-    });
+      key: "<%= helpers.camelCase(dataSource.key) %>",
+      values,
+    },
   });
 };

--- a/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/dataSources/dataSource.ts.ejs
@@ -1,11 +1,9 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { dataSourceConfigVar } from "@prismatic-io/spectral/dist/integration";
-<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
-<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= dataSource.typeInterface %>Values {
@@ -29,7 +27,6 @@ export const <%= dataSource.import %> = {
   }
 } as const;
 
-<%_ if (isCniManifest) { -%>
 /**
  * <%= dataSource.label %> DataSource Helper
  *
@@ -63,4 +60,3 @@ export const <%= helpers.camelCase(dataSource.componentKey) %><%= helpers.capita
     },
   });
 };
-<%_ } -%>

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -3,7 +3,6 @@ import { ConfigVarExpression } from "@prismatic-io/spectral";
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
-  runWithIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
@@ -39,17 +38,16 @@ export const <%= helpers.camelCase(trigger.componentKey) %><%= helpers.capitaliz
     } | ConfigVarExpression);
   <% }); -%>
 }) => {
-  const context = requireIntegrationContext();
-  return runWithIntegrationContext(context, () => {
-    const userKey = findUserDefinedComponentKey(
-      "<%= trigger.componentKey %>",
-      context.componentRegistry,
-    );
-
-    return {
-      component: userKey,
-      key: "<%= trigger.key %>",
-      values,
-    } as const;
-  });
+  return {
+    get component() {
+      const context = requireIntegrationContext();
+      return findUserDefinedComponentKey(
+        "<%= trigger.componentKey %>",
+        <%= trigger.componentIsPublic %>,
+        context.componentRegistry,
+      );
+    },
+    key: "<%= trigger.key %>",
+    values,
+  } as const;
 };

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -1,6 +1,11 @@
 <%- include('../partials/generatedHeader.ejs') -%>
-<%- include('../partials/imports.ejs', { imports, helpers }) %>
 import { ConfigVarExpression } from "@prismatic-io/spectral";
+import {
+  findUserDefinedComponentKey,
+  requireIntegrationContext,
+  runWithIntegrationContext,
+} from "@prismatic-io/spectral/dist/serverTypes";
+<%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= trigger.typeInterface %>Values {
 <%- include('../partials/performArgs.ejs', { inputs: trigger.inputs, helpers }) -%>
@@ -34,9 +39,17 @@ export const <%= helpers.camelCase(trigger.componentKey) %><%= helpers.capitaliz
     } | ConfigVarExpression);
   <% }); -%>
 }) => {
-  return {
-    component: "<%= helpers.camelCase(trigger.componentKey) %>",
-    key: "<%= trigger.key %>",
-    values,
-  } as const;
+  const context = requireIntegrationContext();
+  return runWithIntegrationContext(context, () => {
+    const userKey = findUserDefinedComponentKey(
+      "<%= trigger.componentKey %>",
+      context.componentRegistry,
+    );
+
+    return {
+      component: userKey,
+      key: "<%= trigger.key %>",
+      values,
+    } as const;
+  });
 };

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -1,11 +1,9 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { ConfigVarExpression } from "@prismatic-io/spectral";
-<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
-<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= trigger.typeInterface %>Values {
@@ -28,7 +26,6 @@ export const <%= trigger.import %> = {
   }
 } as const;
 
-<%_ if (isCniManifest) { -%>
 /**
  * <%= trigger.label %> Trigger Helper
  *
@@ -54,4 +51,3 @@ export const <%= helpers.camelCase(trigger.componentKey) %><%= helpers.capitaliz
     values,
   } as const;
 };
-<%_ } -%>

--- a/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/triggers/trigger.ts.ejs
@@ -1,9 +1,11 @@
 <%- include('../partials/generatedHeader.ejs') -%>
 import { ConfigVarExpression } from "@prismatic-io/spectral";
+<%_ if (isCniManifest) { -%>
 import {
   findUserDefinedComponentKey,
   requireIntegrationContext,
 } from "@prismatic-io/spectral/dist/serverTypes";
+<%_ } -%>
 <%- include('../partials/imports.ejs', { imports, helpers }) %>
 
 export interface <%= trigger.typeInterface %>Values {
@@ -26,6 +28,7 @@ export const <%= trigger.import %> = {
   }
 } as const;
 
+<%_ if (isCniManifest) { -%>
 /**
  * <%= trigger.label %> Trigger Helper
  *
@@ -51,3 +54,4 @@ export const <%= helpers.camelCase(trigger.componentKey) %><%= helpers.capitaliz
     values,
   } as const;
 };
+<%_ } -%>

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { convertComponent } from "./serverTypes/convertComponent";
 import { convertIntegration } from "./serverTypes/convertIntegration";
 import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
+import { runWithIntegrationContext } from "./serverTypes";
 
 /**
  * This function creates a code-native integration object that can be
@@ -45,7 +46,9 @@ import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition"
 export const integration = <T extends IntegrationDefinition = IntegrationDefinition>(
   definition: T,
 ): ReturnType<typeof convertIntegration> => {
-  const integrationDefinition = convertIntegration(definition);
+  const integrationDefinition = runWithIntegrationContext(definition, () =>
+    convertIntegration(definition),
+  );
 
   if (process.env?.DEBUG === "true") {
     console.info(integrationDefinition.codeNativeIntegrationYAML);

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -46,9 +46,9 @@ import { runWithIntegrationContext } from "./serverTypes";
 export const integration = <T extends IntegrationDefinition = IntegrationDefinition>(
   definition: T,
 ): ReturnType<typeof convertIntegration> => {
-  const integrationDefinition = runWithIntegrationContext(definition, () =>
-    convertIntegration(definition),
-  );
+  const integrationDefinition = runWithIntegrationContext(definition, () => {
+    return convertIntegration(definition);
+  });
 
   if (process.env?.DEBUG === "true") {
     console.info(integrationDefinition.codeNativeIntegrationYAML);

--- a/packages/spectral/src/serverTypes/asyncContext.ts
+++ b/packages/spectral/src/serverTypes/asyncContext.ts
@@ -57,21 +57,26 @@ export function requireIntegrationContext<T extends IntegrationDefinition>(): T 
 type GetUserDefinedKeyByComponentKey<
   K extends string,
   T extends ComponentRegistry,
+  TPublic extends boolean,
 > = keyof T extends infer UserKey
   ? UserKey extends keyof T
-    ? T[UserKey] extends { key: string }
-      ? T[UserKey]["key"] extends K
+    ? T[UserKey]["key"] extends K
+      ? T[UserKey]["public"] extends TPublic
         ? UserKey
         : never
       : never
     : never
   : never;
 
-export const findUserDefinedComponentKey = <K extends string, T extends ComponentRegistry>(
+export const findUserDefinedComponentKey = <
+  K extends string,
+  T extends ComponentRegistry,
+  TPublic extends boolean,
+>(
   componentKey: K,
-  isPublic: boolean,
+  isPublic: TPublic,
   registry?: T,
-): GetUserDefinedKeyByComponentKey<K, T> => {
+): GetUserDefinedKeyByComponentKey<K, T, TPublic> => {
   if (!registry) {
     throw new Error(
       "Error locating component registry. Is there a component registry defined on your integration?",
@@ -88,5 +93,5 @@ export const findUserDefinedComponentKey = <K extends string, T extends Componen
     );
   }
 
-  return userKey as GetUserDefinedKeyByComponentKey<K, T>;
+  return userKey as GetUserDefinedKeyByComponentKey<K, T, TPublic>;
 };

--- a/packages/spectral/src/serverTypes/asyncContext.ts
+++ b/packages/spectral/src/serverTypes/asyncContext.ts
@@ -1,15 +1,16 @@
+import { ComponentRegistry, IntegrationDefinition } from "../types";
 import type { ActionContext } from "../types/ActionPerformFunction";
 
 // Only import async_hooks in Node.js environments
 const asyncHooks = typeof window === "undefined" ? require("node:async_hooks") : null;
 const actionContextStorage = asyncHooks ? new asyncHooks.AsyncLocalStorage() : null;
+const integrationContextStorage = asyncHooks ? new asyncHooks.AsyncLocalStorage() : null;
 
 export function runWithContext<T>(
   context: ActionContext,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
   if (!actionContextStorage) {
-    // This shouldn't be running in a browser environment anyway.
     return fn();
   }
   return actionContextStorage.run(context, fn);
@@ -24,3 +25,53 @@ export function requireContext(): ActionContext {
 
   return context;
 }
+
+export function runWithIntegrationContext<T extends IntegrationDefinition, U>(
+  context: T,
+  fn: () => U,
+): U {
+  if (!integrationContextStorage) {
+    console.warn(
+      "Creating integration without context. This may result in errors when generating component manifests.",
+    );
+
+    return fn();
+  }
+
+  return integrationContextStorage.run(context, fn);
+}
+
+export function requireIntegrationContext<T extends IntegrationDefinition>(): T {
+  const context = integrationContextStorage.getStore();
+
+  if (!context) {
+    throw new Error(
+      "IntegrationContext not found. Ensure this code is wrapped via runWithIntegrationContext.",
+    );
+  }
+
+  return context;
+}
+
+export const findUserDefinedComponentKey = <T extends ComponentRegistry>(
+  componentKey: string,
+  registry?: T,
+): keyof T => {
+  if (!registry) {
+    throw new Error(
+      "Error locating component registry. Do you have a component registry defined on your integration?",
+    );
+  }
+
+  const userKey = Object.keys(registry).find((userKey) => {
+    return registry[userKey].key === componentKey;
+  });
+
+  if (!userKey) {
+    throw new Error(
+      `Error locating component ${componentKey} in the component registry. Is this component properly installed?`,
+    );
+  }
+
+  return userKey;
+};

--- a/packages/spectral/src/serverTypes/asyncContext.ts
+++ b/packages/spectral/src/serverTypes/asyncContext.ts
@@ -60,9 +60,11 @@ type GetUserDefinedKeyByComponentKey<
   TPublic extends boolean,
 > = keyof T extends infer UserKey
   ? UserKey extends keyof T
-    ? T[UserKey]["key"] extends K
-      ? T[UserKey]["public"] extends TPublic
-        ? UserKey
+    ? T[UserKey] extends { key: string; public: boolean }
+      ? T[UserKey]["key"] extends K
+        ? T[UserKey]["public"] extends TPublic
+          ? UserKey
+          : never
         : never
       : never
     : never

--- a/packages/spectral/src/serverTypes/asyncContext.ts
+++ b/packages/spectral/src/serverTypes/asyncContext.ts
@@ -84,7 +84,7 @@ export const findUserDefinedComponentKey = <K extends string, T extends Componen
 
   if (!userKey) {
     throw new Error(
-      `Error locating component ${componentKey} in the component registry. Is this component properly installed with a correct public/private setting?`,
+      `Error locating component ${componentKey} with custom key ${userKey} in the component registry. Is this component properly installed with a correct public/private setting?`,
     );
   }
 


### PR DESCRIPTION
# Premise
Users can define their own custom component keys in their registries, for example:

```
  "custom-slack": slack,
  "ms-intune": msIntune,
```

Instead of:

```
  slack,
  msIntune,
```

Our wrapper functions were initially assuming that all component keys in the registry would just be camel-cased versions of the official key, which is not so.

# Resolution
No DX changes will be required of users, though anyone affected by this issue will need to regenerate their manifests.

* Introduced new `asyncLocalStorage` wrapper around `convertIntegration` to give access to full definition at key points in convert process
* Added utility for locating the user-defined component key in a component manifest (shout-out to Bryan for figuring out the types)
* Updated wrapper functions to lazily fetch component keys at convert time rather than module load time