### PR TITLE
Add stableId to flow context

### DIFF
--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.16.5",
+  "version": "10.17.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/packages/spectral/src/types/FlowAttributes.ts
+++ b/packages/spectral/src/types/FlowAttributes.ts
@@ -4,4 +4,6 @@ export interface FlowAttributes {
   id: string;
   /** The name of the currently running flow. */
   name: string;
+  /** The stable ID of the currently running flow. */
+  stableId?: string;
 }


### PR DESCRIPTION
~~This won't be merged until the corresponding backend work is done.~~

Shipping now for the type support, will send out communications once the backend is shipped. Nothing should break in the meantime.