### PR TITLE
Improve JSDoc for Spectral functions

### DIFF
--- a/packages/spectral/src/clients/http/index.ts
+++ b/packages/spectral/src/clients/http/index.ts
@@ -115,8 +115,31 @@ export const toAxiosRetryConfig = ({
 });
 
 /**
- * Creates a reusable Axios HTTP client. See
- * https://prismatic.io/docs/custom-connectors/connections/#using-the-built-in-createclient-http-client
+ * Creates a reusable Axios HTTP client pre-configured with a base URL,
+ * headers, timeout, and optional retry logic. This is the recommended
+ * way to make HTTP requests from custom component actions.
+ *
+ * @param props Configuration for the HTTP client.
+ * @returns An Axios instance configured with the provided options.
+ * @see {@link https://prismatic.io/docs/custom-connectors/connections/#using-the-built-in-createclient-http-client | Using the Built-in HTTP Client}
+ * @example
+ * import { createClient } from "@prismatic-io/spectral/dist/clients/http";
+ *
+ * const client = createClient({
+ *   baseUrl: "https://api.acme.com/v2",
+ *   headers: { Authorization: `Bearer ${accessToken}` },
+ *   responseType: "json",
+ *   timeout: 30000,
+ *   debug: false,
+ *   retryConfig: {
+ *     retries: 3,
+ *     retryDelay: 1000,
+ *     useExponentialBackoff: true,
+ *     retryAllErrors: false,
+ *   },
+ * });
+ *
+ * const { data } = await client.get("/items");
  */
 export const createClient = ({
   baseUrl,
@@ -191,13 +214,25 @@ export const createClient = ({
 
 /**
  * A global error handler that examines a thrown error and yields additional
- * information if the error was produced by Spectral's HTTP client. See
- * https://prismatic.io/docs/custom-connectors/error-handling/
- * and
- * https://prismatic.io/docs/custom-connectors/connections/#using-the-built-in-createclient-http-client
+ * information if the error was produced by Spectral's HTTP client. If the
+ * error is an Axios error, returns a structured object with the response
+ * `data`, `status`, and `headers`. Otherwise, returns the error as-is.
  *
- * @param error A JavaScript error to handle
- * @returns An error with data, status and headers if it was an Axios error, or the error otherwise
+ * Commonly used as a component-level `hooks.error` handler.
+ *
+ * @param error A JavaScript error to handle.
+ * @returns An error with data, status and headers if it was an Axios error, or the error otherwise.
+ * @see {@link https://prismatic.io/docs/custom-connectors/error-handling/ | Error Handling}
+ * @example
+ * import { component } from "@prismatic-io/spectral";
+ * import { handleErrors } from "@prismatic-io/spectral/dist/clients/http";
+ *
+ * export default component({
+ *   key: "acme",
+ *   display: { label: "Acme", description: "Acme connector", iconPath: "icon.png" },
+ *   hooks: { error: handleErrors },
+ *   actions: { ... },
+ * });
  */
 export const handleErrors = (error: unknown): unknown => {
   if (axios.isAxiosError(error)) {
@@ -215,14 +250,28 @@ export const handleErrors = (error: unknown): unknown => {
 type SendRawRequestValues = ActionInputParameters<typeof inputs>;
 
 /**
- * This function allows you to build a generic "Raw Request" action
- * for a custom connector. See
- * https://prismatic.io/docs/integrations/low-code-integration-designer/raw-request-actions/#building-an-http-raw-request-action-in-your-custom-component
+ * This function sends a raw HTTP request with full control over method, URL,
+ * headers, query parameters, and body. Used internally by `buildRawRequestAction`.
  *
- * @param baseUrl The base URL of the API you're integrating with
- * @param values An object comprising the HTTP request you'd like to make
- * @param authorizationHeaders Auth headers to apply to the request
- * @returns The response to the request
+ * @param baseUrl The base URL of the API you're integrating with.
+ * @param values An object comprising the HTTP request you'd like to make.
+ * @param authorizationHeaders Auth headers to apply to the request.
+ * @returns The Axios response to the request.
+ * @see {@link https://prismatic.io/docs/integrations/low-code-integration-designer/raw-request-actions/#building-an-http-raw-request-action-in-your-custom-component | Raw Request Actions}
+ * @example
+ * import { sendRawRequest } from "@prismatic-io/spectral/dist/clients/http";
+ *
+ * const response = await sendRawRequest(
+ *   "https://api.acme.com/v2",
+ *   {
+ *     method: "GET",
+ *     url: "/items",
+ *     headers: [],
+ *     queryParams: [{ key: "limit", value: "10" }],
+ *     responseType: "json",
+ *   },
+ *   { Authorization: "Bearer my-token" },
+ * );
  */
 export const sendRawRequest = async (
   baseUrl: string,
@@ -264,6 +313,25 @@ export const sendRawRequest = async (
   });
 };
 
+/**
+ * Builds a pre-configured "Raw Request" action for a custom connector.
+ * This action exposes a full HTTP interface (method, URL, headers, query
+ * params, body) so integration builders can make arbitrary API calls.
+ *
+ * @param baseUrl The base URL of the API you're integrating with.
+ * @param label The display label for the action. Defaults to `"Raw Request"`.
+ * @param description The display description for the action. Defaults to `"Issue a raw HTTP request"`.
+ * @returns An action definition for the raw request action.
+ * @see {@link https://prismatic.io/docs/integrations/low-code-integration-designer/raw-request-actions/#building-an-http-raw-request-action-in-your-custom-component | Raw Request Actions}
+ * @example
+ * import { buildRawRequestAction } from "@prismatic-io/spectral/dist/clients/http";
+ *
+ * // Add a raw request action to your component
+ * const actions = {
+ *   listItems: action({ ... }),
+ *   rawRequest: buildRawRequestAction("https://api.acme.com/v2"),
+ * };
+ */
 export const buildRawRequestAction = (
   baseUrl: string,
   label = "Raw Request",

--- a/packages/spectral/src/errors.ts
+++ b/packages/spectral/src/errors.ts
@@ -1,5 +1,16 @@
 import { Connection } from ".";
 
+/**
+ * Base error class for Spectral-specific errors. Extends the standard
+ * `Error` class with an `isSpectralError` flag for easy identification
+ * when handling errors in component hooks.
+ *
+ * @see {@link https://prismatic.io/docs/custom-connectors/error-handling/ | Error Handling}
+ * @example
+ * import { SpectralError } from "@prismatic-io/spectral";
+ *
+ * throw new SpectralError("Something went wrong during data processing");
+ */
 export class SpectralError extends Error {
   isSpectralError: boolean;
 
@@ -11,6 +22,30 @@ export class SpectralError extends Error {
   }
 }
 
+/**
+ * An error class for connection-related failures. Includes a reference to
+ * the `Connection` object that caused the error, so error handlers can
+ * inspect connection details.
+ *
+ * When thrown, the Prismatic platform will display a "Configuration Error"
+ * badge on the instance, signaling that the connection needs attention.
+ *
+ * @see {@link https://prismatic.io/docs/custom-connectors/error-handling/ | Error Handling}
+ * @example
+ * import { ConnectionError } from "@prismatic-io/spectral";
+ *
+ * // Inside an action perform function
+ * const myAction = action({
+ *   // ...
+ *   perform: async (context, { connection }) => {
+ *     try {
+ *       // Call external API...
+ *     } catch (err) {
+ *       throw new ConnectionError(connection, "Invalid API credentials");
+ *     }
+ *   },
+ * });
+ */
 export class ConnectionError extends SpectralError {
   connection: Connection;
 
@@ -20,6 +55,22 @@ export class ConnectionError extends SpectralError {
   }
 }
 
+/**
+ * Type guard to check if an error is a `SpectralError`.
+ *
+ * @param payload The error to test.
+ * @returns True if `payload` is a `SpectralError`, false otherwise.
+ * @example
+ * import { isSpectralError } from "@prismatic-io/spectral";
+ *
+ * try {
+ *   // ...
+ * } catch (err) {
+ *   if (isSpectralError(err)) {
+ *     console.log("Caught a Spectral error:", err.message);
+ *   }
+ * }
+ */
 export const isSpectralError = (payload: unknown): payload is SpectralError =>
   Boolean(
     payload &&
@@ -28,5 +79,21 @@ export const isSpectralError = (payload: unknown): payload is SpectralError =>
       (payload as SpectralError).isSpectralError === true,
   );
 
+/**
+ * Type guard to check if an error is a `ConnectionError`.
+ *
+ * @param payload The error to test.
+ * @returns True if `payload` is a `ConnectionError`, false otherwise.
+ * @example
+ * import { isConnectionError } from "@prismatic-io/spectral";
+ *
+ * try {
+ *   // ...
+ * } catch (err) {
+ *   if (isConnectionError(err)) {
+ *     console.log("Connection failed:", err.connection.key, err.message);
+ *   }
+ * }
+ */
 export const isConnectionError = (payload: unknown): payload is ConnectionError =>
   isSpectralError(payload) && "connection" in payload;

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -36,12 +36,28 @@ import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition"
 
 /**
  * This function creates a code-native integration object that can be
- * imported into Prismatic. For information on using this function to
- * write code-native integrations, see
- * https://prismatic.io/docs/integrations/code-native/.
+ * imported into Prismatic.
  *
  * @param definition An IntegrationDefinition type object.
  * @returns This function returns an integration object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/ | Code-Native Integrations}
+ * @example
+ * import { integration } from "@prismatic-io/spectral";
+ * import flows from "./flows";
+ * import { configPages } from "./configPages";
+ * import { componentRegistry } from "./componentRegistry";
+ *
+ * export default integration({
+ *   name: "Acme Integration",
+ *   description: "Syncs data between Acme and your system",
+ *   category: "Communication",
+ *   labels: ["chat", "beta"],
+ *   iconPath: "icon.png",
+ *   version: "1.0.0",
+ *   flows,
+ *   configPages,
+ *   componentRegistry,
+ * });
  */
 export const integration = <
   TInputs extends Inputs,
@@ -87,11 +103,43 @@ export const integration = <
 
 /**
  * This function creates a flow object for use in code-native integrations.
- * For information on writing code-native flows, see
- * https://prismatic.io/docs/integrations/code-native/flows/.
  *
  * @param definition A Flow type object.
  * @returns This function returns a flow object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
+ * @example
+ * // A webhook-triggered flow
+ * import { flow } from "@prismatic-io/spectral";
+ *
+ * export const myFlow = flow({
+ *   name: "Process Webhook",
+ *   stableKey: "process-webhook",
+ *   description: "Receives and processes incoming webhooks",
+ *   onTrigger: async (context, payload, params) => {
+ *     return Promise.resolve({ payload });
+ *   },
+ *   onExecution: async (context, params) => {
+ *     const { logger, configVars } = context;
+ *     const triggerData = params.onTrigger.results;
+ *     logger.info("Processing webhook payload");
+ *     return Promise.resolve({ data: triggerData });
+ *   },
+ * });
+ *
+ * @example
+ * // A scheduled flow with cron expression
+ * import { flow } from "@prismatic-io/spectral";
+ *
+ * export const scheduledSync = flow({
+ *   name: "Nightly Sync",
+ *   stableKey: "nightly-sync",
+ *   description: "Syncs data every night at midnight",
+ *   schedule: { value: "0 0 * * *", timezone: "America/Chicago" },
+ *   onExecution: async (context, params) => {
+ *     context.logger.info(`Sync started at ${new Date().toISOString()}`);
+ *     return Promise.resolve({ data: null });
+ *   },
+ * });
  */
 export const flow = <
   TInputs extends Inputs,
@@ -117,31 +165,115 @@ export const flow = <
 
 /**
  * This function creates a config wizard page object for use in code-native
- * integrations. For information on code-native config wizards, see
- * https://prismatic.io/docs/integrations/code-native/config-wizard/.
+ * integrations.
  *
  * @param definition A Config Page type object.
  * @returns This function returns a config page object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/ | Code-Native Config Wizard}
+ * @example
+ * import { configPage, connectionConfigVar, configVar } from "@prismatic-io/spectral";
+ *
+ * export const configPages = {
+ *   Connections: configPage({
+ *     tagline: "Set up your API connections",
+ *     elements: {
+ *       "Acme Connection": connectionConfigVar({
+ *         stableKey: "acme-connection",
+ *         dataType: "connection",
+ *         inputs: {
+ *           apiKey: { label: "API Key", type: "password", required: true },
+ *           baseUrl: { label: "Base URL", type: "string", required: true },
+ *         },
+ *       }),
+ *     },
+ *   }),
+ *   Configuration: configPage({
+ *     tagline: "Configure sync settings",
+ *     elements: {
+ *       "Sync Interval": configVar({
+ *         stableKey: "sync-interval",
+ *         dataType: "picklist",
+ *         pickList: ["hourly", "daily", "weekly"],
+ *         defaultValue: "daily",
+ *       }),
+ *     },
+ *   }),
+ * };
  */
 export const configPage = <T extends ConfigPage = ConfigPage>(definition: T): T => definition;
 
 /**
  * This function creates a config variable object for code-native integrations.
- * For information on writing code-native integrations, see
- * https://prismatic.io/docs/integrations/code-native/config-wizard/#other-config-variable-types-in-code-native-integrations.
  *
  * @param definition A Config Var type object.
  * @returns This function returns a standard config var object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#other-config-variable-types-in-code-native-integrations | Config Variable Types}
+ * @example
+ * import { configVar } from "@prismatic-io/spectral";
+ *
+ * // String config variable
+ * const endpoint = configVar({
+ *   stableKey: "api-endpoint",
+ *   dataType: "string",
+ *   defaultValue: "https://api.example.com",
+ *   description: "The base URL of the API",
+ * });
+ *
+ * @example
+ * import { configVar } from "@prismatic-io/spectral";
+ *
+ * // Picklist config variable
+ * const region = configVar({
+ *   stableKey: "region",
+ *   dataType: "picklist",
+ *   pickList: ["us-east-1", "us-west-2", "eu-west-1"],
+ *   defaultValue: "us-east-1",
+ *   description: "AWS region to use",
+ * });
+ *
+ * @example
+ * import { configVar } from "@prismatic-io/spectral";
+ *
+ * // Boolean config variable
+ * const enableDebug = configVar({
+ *   stableKey: "enable-debug",
+ *   dataType: "boolean",
+ *   defaultValue: false,
+ *   description: "Enable debug logging",
+ * });
+ *
+ * @example
+ * import { configVar } from "@prismatic-io/spectral";
+ *
+ * // Schedule config variable
+ * const syncSchedule = configVar({
+ *   stableKey: "sync-schedule",
+ *   dataType: "schedule",
+ *   description: "When to run the sync",
+ *   timeZone: "America/Chicago",
+ * });
  */
 export const configVar = <T extends StandardConfigVar>(definition: T): T => definition;
 
 /**
  * This function creates a data source-backed config variable for code-native
- * integrations. For information on code-native data sources, see
- * https://prismatic.io/docs/integrations/code-native/config-wizard/#data-sources-is-code-native-integrations.
+ * integrations.
  *
  * @param definition A Data Source Config Var type object.
  * @returns This function returns a data source config var object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#data-sources-is-code-native-integrations | Data Sources in Code-Native}
+ * @example
+ * import { dataSourceConfigVar } from "@prismatic-io/spectral";
+ *
+ * const selectRepository = dataSourceConfigVar({
+ *   stableKey: "select-repo",
+ *   dataSourceType: "picklist",
+ *   description: "Choose a repository from GitHub",
+ *   perform: async (context, params) => {
+ *     // Fetch repos from an API and return them as picklist options
+ *     return { result: ["repo-1", "repo-2", "repo-3"] };
+ *   },
+ * });
  */
 export const dataSourceConfigVar = <TDataSourceConfigVar extends DataSourceConfigVar>(
   definition: TDataSourceConfigVar,
@@ -149,11 +281,37 @@ export const dataSourceConfigVar = <TDataSourceConfigVar extends DataSourceConfi
 
 /**
  * This function creates a connection config variable for code-native
- * integrations. For information on writing code-native integrations, see
- * https://prismatic.io/docs/integrations/code-native/config-wizard/#connections-in-code-native-integrations.
+ * integrations.
  *
  * @param definition A Connection Config Var type object.
  * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#connections-in-code-native-integrations | Connections in Code-Native}
+ * @example
+ * import { connectionConfigVar } from "@prismatic-io/spectral";
+ * import { acmeConnection } from "./connections";
+ *
+ * const myConnection = connectionConfigVar({
+ *   stableKey: "acme-connection",
+ *   ...acmeConnection,
+ * });
+ *
+ * @example
+ * import { connectionConfigVar } from "@prismatic-io/spectral";
+ *
+ * // Inline connection definition
+ * const myApiConnection = connectionConfigVar({
+ *   stableKey: "my-api-connection",
+ *   dataType: "connection",
+ *   inputs: {
+ *     apiKey: { label: "API Key", type: "password", required: true },
+ *     baseUrl: {
+ *       label: "Base URL",
+ *       type: "string",
+ *       required: true,
+ *       default: "https://api.example.com",
+ *     },
+ *   },
+ * });
  */
 export const connectionConfigVar = <T extends ConnectionConfigVar = ConnectionConfigVar>(
   definition: T,
@@ -161,13 +319,18 @@ export const connectionConfigVar = <T extends ConnectionConfigVar = ConnectionCo
 
 /**
  * This function creates a customer-activated connection for code-native
- * integrations. For information on writing code-native integrations, see
- * https://prismatic.io/docs/integrations/code-native/.
- * For information on customer-activated connections, see
- * https://prismatic.io/docs/integrations/connections/integration-agnostic-connections/customer-activated/.
+ * integrations. Customer-activated connections are configured by end-users
+ * and can be shared across multiple integrations.
  *
  * @param definition A Customer-Activated Connection Config Var type object.
  * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/connections/integration-agnostic-connections/customer-activated/ | Customer-Activated Connections}
+ * @example
+ * import { customerActivatedConnection } from "@prismatic-io/spectral";
+ *
+ * const sharedSlackConnection = customerActivatedConnection({
+ *   stableKey: "shared-slack-connection",
+ * });
  */
 export const customerActivatedConnection = <T extends { stableKey: string }>(
   definition: T,
@@ -177,13 +340,18 @@ export const customerActivatedConnection = <T extends { stableKey: string }>(
 
 /**
  * This function creates an org-activated connection for code-native
- * integrations. For information on writing code-native integrations, see
- * https://prismatic.io/docs/integrations/code-native/.
- * For information on customer-activated connections, see
- * https://prismatic.io/docs/integrations/connections/integration-agnostic-connections/org-activated-customer/.
+ * integrations. Org-activated connections are configured once by the
+ * organization and shared across all customer instances.
  *
  * @param definition An Organization-Activated Connection Config Var type object.
  * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/connections/integration-agnostic-connections/org-activated-customer/ | Org-Activated Connections}
+ * @example
+ * import { organizationActivatedConnection } from "@prismatic-io/spectral";
+ *
+ * const orgSlackConnection = organizationActivatedConnection({
+ *   stableKey: "org-slack-connection",
+ * });
  */
 export const organizationActivatedConnection = <T extends { stableKey: string }>(
   definition: T,
@@ -192,22 +360,55 @@ export const organizationActivatedConnection = <T extends { stableKey: string }>
 };
 
 /**
- * Generate a manifest of components that this code-native integration relies on. See
- * https://prismatic.io/docs/integrations/code-native/existing-components/
+ * Generate a manifest of components that this code-native integration relies on.
+ * Component manifests allow your code-native integration to reference actions,
+ * triggers, connections, and data sources from published Prismatic components.
  *
  * @param definition A Component Manifest type object.
  * @returns This function returns a component manifest object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/existing-components/ | Using Existing Components}
+ * @example
+ * import { componentManifest } from "@prismatic-io/spectral";
+ *
+ * const slack = componentManifest({
+ *   key: "slack",
+ *   public: true,
+ *   actions: {
+ *     postMessage: {
+ *       inputs: {
+ *         message: { label: "Message" },
+ *         channelName: { label: "Channel Name" },
+ *       },
+ *     },
+ *   },
+ * });
  */
 export const componentManifest = <T extends ComponentManifest>(definition: T): T => definition;
 
 /**
  * This function creates a component object that can be
- * imported into the Prismatic API. For information on using
- * this function to write custom components, see
- * https://prismatic.io/docs/custom-connectors/.
+ * imported into the Prismatic API.
  *
  * @param definition A ComponentDefinition type object, including display information, unique key, and a set of actions the component implements.
  * @returns This function returns a component object that has the shape the Prismatic API expects.
+ * @see {@link https://prismatic.io/docs/custom-connectors/ | Custom Connectors}
+ * @example
+ * import { component } from "@prismatic-io/spectral";
+ * import actions from "./actions";
+ * import triggers from "./triggers";
+ * import connections from "./connections";
+ *
+ * export default component({
+ *   key: "acme-connector",
+ *   display: {
+ *     label: "Acme",
+ *     description: "Interact with Acme's API",
+ *     iconPath: "icon.png",
+ *   },
+ *   actions,
+ *   triggers,
+ *   connections,
+ * });
  */
 export const component = <TPublic extends boolean, TKey extends string>(
   definition: ComponentDefinition<TPublic, TKey>,
@@ -217,11 +418,35 @@ export const component = <TPublic extends boolean, TKey extends string>(
  * This function creates an action object that can be referenced
  * by a custom component. It helps ensure that the shape of the
  * action object conforms to what the Prismatic API expects.
- * For information on writing custom component actions, see
- * https://prismatic.io/docs/custom-connectors/actions/.
  *
- * @param definition An ActionDefinition type object that includes UI display information, a function to perform when the action is invoked, and a an object containing inputs for the perform function.
+ * @param definition An ActionDefinition type object that includes UI display information, a function to perform when the action is invoked, and an object containing inputs for the perform function.
  * @returns This function validates the shape of the `definition` object provided, and returns the same action object.
+ * @see {@link https://prismatic.io/docs/custom-connectors/actions/ | Writing Custom Actions}
+ * @example
+ * import { action, input, util } from "@prismatic-io/spectral";
+ *
+ * const listItems = action({
+ *   display: {
+ *     label: "List Items",
+ *     description: "Retrieve a list of items from Acme",
+ *   },
+ *   inputs: {
+ *     connection: input({ label: "Connection", type: "connection", required: true }),
+ *     limit: input({
+ *       label: "Limit",
+ *       type: "string",
+ *       required: false,
+ *       default: "100",
+ *       comments: "Maximum number of items to return",
+ *     }),
+ *   },
+ *   perform: async (context, { connection, limit }) => {
+ *     const maxItems = util.types.toInt(limit, 100);
+ *     context.logger.info(`Fetching up to ${maxItems} items`);
+ *     // Make API call using connection...
+ *     return { data: { items: [] } };
+ *   },
+ * });
  */
 export const action = <
   TInputs extends Inputs,
@@ -236,11 +461,42 @@ export const action = <
  * This function creates a trigger object that can be referenced
  * by a custom component. It helps ensure that the shape of the
  * trigger object conforms to what the Prismatic API expects.
- * For information on writing custom component triggers, see
- * https://prismatic.io/docs/custom-connectors/triggers/.
  *
- * @param definition A TriggerDefinition type object that includes UI display information, a function to perform when the trigger is invoked, and a an object containing inputs for the perform function.
+ * @param definition A TriggerDefinition type object that includes UI display information, a function to perform when the trigger is invoked, and an object containing inputs for the perform function.
  * @returns This function validates the shape of the `definition` object provided, and returns the same trigger object.
+ * @see {@link https://prismatic.io/docs/custom-connectors/triggers/ | Writing Custom Triggers}
+ * @example
+ * import { trigger, input } from "@prismatic-io/spectral";
+ * import { HttpResponse } from "@prismatic-io/spectral";
+ *
+ * const webhookTrigger = trigger({
+ *   display: {
+ *     label: "Acme Webhook",
+ *     description: "Receives webhooks from Acme",
+ *   },
+ *   inputs: {
+ *     secret: input({
+ *       label: "Signing Secret",
+ *       type: "password",
+ *       required: true,
+ *       comments: "Used to verify webhook signatures",
+ *     }),
+ *   },
+ *   scheduleSupport: "invalid",
+ *   synchronousResponseSupport: "valid",
+ *   perform: async (context, payload, { secret }) => {
+ *     // Validate and process the incoming webhook
+ *     const response: HttpResponse = {
+ *       statusCode: 200,
+ *       contentType: "application/json",
+ *       body: JSON.stringify({ received: true }),
+ *     };
+ *     return Promise.resolve({
+ *       payload,
+ *       response,
+ *     });
+ *   },
+ * });
  */
 export const trigger = <
   TInputs extends Inputs,
@@ -253,11 +509,37 @@ export const trigger = <
 
 /**
  * This function creates a polling trigger object that can be referenced
- * by a custom component. See
- * https://prismatic.io/docs/custom-connectors/triggers/#app-event-polling-triggers
+ * by a custom component. A polling trigger runs on a schedule and uses
+ * `context.polling` to track state between invocations, enabling detection
+ * of new or changed records.
  *
- * @param definition A PollingTriggerDefinition is similar to a TriggerDefinition, except it requires a pollAction instead of a perform. The pollAction, which can be any action defined in the component, will be polled on the defined schedule.
+ * @param definition A PollingTriggerDefinition, similar to a TriggerDefinition, except it requires a pollAction instead of a perform. The pollAction, which can be any action defined in the component, will be polled on the defined schedule.
+ * @see {@link https://prismatic.io/docs/custom-connectors/triggers/#app-event-polling-triggers | Polling Triggers}
  * @returns This function validates the shape of the `definition` object provided, and returns the same polling trigger object.
+ * @example
+ * import { pollingTrigger, input } from "@prismatic-io/spectral";
+ *
+ * const newRecordsTrigger = pollingTrigger({
+ *   display: {
+ *     label: "New Records",
+ *     description: "Triggers when new records are detected",
+ *   },
+ *   inputs: {
+ *     connection: input({ label: "Connection", type: "connection", required: true }),
+ *   },
+ *   perform: async (context, payload, params) => {
+ *     const lastCursor = context.polling.getState()["cursor"] ?? "";
+ *     // Fetch records since lastCursor...
+ *     const newRecords = []; // results from API
+ *     context.polling.setState({ cursor: "new-cursor-value" });
+ *     return Promise.resolve({
+ *       payload: {
+ *         ...payload,
+ *         body: { data: newRecords },
+ *       },
+ *     });
+ *   },
+ * });
  */
 export const pollingTrigger = <
   TInputs extends Inputs,
@@ -290,11 +572,32 @@ export const pollingTrigger = <
  * This function creates a data source object that can be referenced
  * by a custom component. It helps ensure that the shape of the
  * data source object conforms to what the Prismatic API expects.
- * For information on writing custom component data sources, see
- * https://prismatic.io/docs/custom-connectors/data-sources/.
  *
- * @param definition A DataSourceDefinition type object that includes UI display information, a function to perform when the data source is invoked, and a an object containing inputs for the perform function.
+ * @param definition A DataSourceDefinition type object that includes UI display information, a function to perform when the data source is invoked, and an object containing inputs for the perform function.
  * @returns This function validates the shape of the `definition` object provided, and returns the same data source object.
+ * @see {@link https://prismatic.io/docs/custom-connectors/data-sources/ | Writing Custom Data Sources}
+ * @example
+ * import { dataSource, input } from "@prismatic-io/spectral";
+ *
+ * const selectChannel = dataSource({
+ *   display: {
+ *     label: "Select Channel",
+ *     description: "Fetches a list of channels from the API",
+ *   },
+ *   dataSourceType: "picklist",
+ *   inputs: {
+ *     connection: input({ label: "Connection", type: "connection", required: true }),
+ *   },
+ *   perform: async (context, { connection }) => {
+ *     // Fetch channels from API using the connection...
+ *     return {
+ *       result: [
+ *         { label: "General", value: "C123" },
+ *         { label: "Engineering", value: "C456" },
+ *       ],
+ *     };
+ *   },
+ * });
  */
 export const dataSource = <
   TInputs extends Inputs,
@@ -305,47 +608,234 @@ export const dataSource = <
 ): DataSourceDefinition<TInputs, TConfigVars, TDataSourceType> => definition;
 
 /**
- * For information and examples on how to write inputs
- * for custom component actions and triggers, see
- * https://prismatic.io/docs/custom-connectors/actions/#action-inputs.
+ * This function creates an input definition for a custom component action,
+ * trigger, or data source. Inputs define what information is collected from
+ * the user when configuring an integration step.
  *
  * @param definition An InputFieldDefinition object that describes the type of an input for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
+ * @see {@link https://prismatic.io/docs/custom-connectors/actions/#action-inputs | Action Inputs}
  * @returns This function validates the shape of the `definition` object provided, and returns the same input object.
+ * @example
+ * import { input } from "@prismatic-io/spectral";
+ *
+ * // A basic string input
+ * const itemName = input({
+ *   label: "Item Name",
+ *   type: "string",
+ *   required: true,
+ *   comments: "The name of the item to create",
+ *   example: "My New Item",
+ * });
+ *
+ * @example
+ * import { input } from "@prismatic-io/spectral";
+ *
+ * // A string input with a dropdown of preset choices
+ * const priority = input({
+ *   label: "Priority",
+ *   type: "string",
+ *   required: true,
+ *   model: [
+ *     { label: "Low", value: "low" },
+ *     { label: "Medium", value: "medium" },
+ *     { label: "High", value: "high" },
+ *   ],
+ *   default: "medium",
+ * });
+ *
+ * @example
+ * import { input } from "@prismatic-io/spectral";
+ *
+ * // A code input for JSON
+ * const requestBody = input({
+ *   label: "Request Body",
+ *   type: "code",
+ *   language: "json",
+ *   required: false,
+ *   comments: "JSON body to send with the request",
+ * });
+ *
+ * @example
+ * import { input } from "@prismatic-io/spectral";
+ *
+ * // A key-value list collection input
+ * const headers = input({
+ *   label: "HTTP Headers",
+ *   type: "string",
+ *   collection: "keyvaluelist",
+ *   required: false,
+ *   comments: "Additional headers to include in the request",
+ * });
  */
 export const input = <T extends InputFieldDefinition>(definition: T): T => definition;
 
 /**
  * This function creates a connection that can be used by a code-native integration
- * or custom component. For information on writing connections, see
- * https://prismatic.io/docs/custom-connectors/connections/.
+ * or custom component. Connections define the fields (API keys, tokens, etc.) needed
+ * to authenticate with a third-party service.
  *
  * @param definition A DefaultConnectionDefinition object that describes the type of a connection for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
- * @returns This functions validates the shape of the `definition` object provided and returns the same connection object.
+ * @see {@link https://prismatic.io/docs/custom-connectors/connections/ | Writing Custom Connections}
+ * @returns This function validates the shape of the `definition` object provided and returns the same connection object.
+ * @example
+ * import { connection } from "@prismatic-io/spectral";
+ *
+ * const apiKeyConnection = connection({
+ *   key: "apiKey",
+ *   display: {
+ *     label: "Acme API Key",
+ *     description: "Authenticate with Acme using an API key",
+ *   },
+ *   inputs: {
+ *     apiKey: {
+ *       label: "API Key",
+ *       type: "password",
+ *       required: true,
+ *       comments: "Generate an API key from your Acme dashboard",
+ *     },
+ *     baseUrl: {
+ *       label: "Base URL",
+ *       type: "string",
+ *       required: true,
+ *       default: "https://api.acme.com/v2",
+ *     },
+ *   },
+ * });
  */
 export const connection = <T extends DefaultConnectionDefinition>(definition: T): T => definition;
 
 /**
  * This function creates an on-prem connection for a code-native integration or custom component.
- * For information on writing custom component connections using on-prem resources, see
- * https://prismatic.io/docs/integrations/connections/on-prem-agent/#supporting-on-prem-connections-in-a-custom-connector.
+ * On-prem connections include `host` and `port` fields that are automatically overridden by the
+ * on-prem agent with local tunnel endpoints.
  *
  * @param definition An OnPremConnectionDefinition object that describes the type of a connection for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
+ * @see {@link https://prismatic.io/docs/integrations/connections/on-prem-agent/#supporting-on-prem-connections-in-a-custom-connector | On-Prem Connections}
  * @returns This function validates the shape of the `definition` object provided and returns the same connection object.
+ * @example
+ * import { onPremConnection } from "@prismatic-io/spectral";
+ *
+ * const databaseConnection = onPremConnection({
+ *   key: "onPremDatabase",
+ *   display: {
+ *     label: "On-Prem Database",
+ *     description: "Connect to an on-premise database through the Prismatic agent",
+ *   },
+ *   inputs: {
+ *     host: {
+ *       label: "Host",
+ *       type: "string",
+ *       required: true,
+ *       onPremControlled: true,
+ *       comments: "Overridden when on-prem is enabled",
+ *     },
+ *     port: {
+ *       label: "Port",
+ *       type: "string",
+ *       required: true,
+ *       onPremControlled: true,
+ *       default: "5432",
+ *     },
+ *     username: {
+ *       label: "Username",
+ *       type: "string",
+ *       required: true,
+ *     },
+ *     password: {
+ *       label: "Password",
+ *       type: "password",
+ *       required: true,
+ *     },
+ *   },
+ * });
  */
 export const onPremConnection = <T extends OnPremConnectionDefinition>(definition: T): T =>
   definition;
 
 /**
  * This function creates an OAuth 2.0 connection for a code-native integration or custom component.
- * For information on writing an OAuth 2.0 connection, see
- * https://prismatic.io/docs/custom-connectors/connections/#writing-oauth-20-connections.
+ * Supports both Authorization Code and Client Credentials grant types.
  *
  * @param definition An OAuth2ConnectionDefinition object that describes the type of a connection for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
- * @returns This functions validates the shape of the `definition` object provided and returns the same connection object.
+ * @see {@link https://prismatic.io/docs/custom-connectors/connections/#writing-oauth-20-connections | OAuth 2.0 Connections}
+ * @returns This function validates the shape of the `definition` object provided and returns the same connection object.
+ * @example
+ * import { oauth2Connection, OAuth2Type } from "@prismatic-io/spectral";
+ *
+ * // Authorization Code OAuth 2.0 connection
+ * const acmeOAuth = oauth2Connection({
+ *   key: "acmeOAuth",
+ *   display: {
+ *     label: "Acme OAuth 2.0",
+ *     description: "Authenticate with Acme using OAuth 2.0",
+ *   },
+ *   oauth2Type: OAuth2Type.AuthorizationCode,
+ *   inputs: {
+ *     authorizeUrl: {
+ *       label: "Authorize URL",
+ *       type: "string",
+ *       required: true,
+ *       default: "https://app.acme.com/oauth2/authorize",
+ *       shown: false,
+ *     },
+ *     tokenUrl: {
+ *       label: "Token URL",
+ *       type: "string",
+ *       required: true,
+ *       default: "https://app.acme.com/oauth2/token",
+ *       shown: false,
+ *     },
+ *     scopes: {
+ *       label: "Scopes",
+ *       type: "string",
+ *       required: true,
+ *       default: "read write",
+ *       comments: "Space-delimited OAuth 2.0 permission scopes",
+ *     },
+ *     clientId: {
+ *       label: "Client ID",
+ *       type: "string",
+ *       required: true,
+ *     },
+ *     clientSecret: {
+ *       label: "Client Secret",
+ *       type: "password",
+ *       required: true,
+ *     },
+ *   },
+ * });
  */
 export const oauth2Connection = <T extends OAuth2ConnectionDefinition>(definition: T): T =>
   definition;
 
+/**
+ * Register multiple component manifests for a code-native integration.
+ * Each manifest declares a published Prismatic component and the specific
+ * actions, triggers, connections, and data sources your integration uses.
+ *
+ * @param definition A record of Component Manifest objects keyed by component name.
+ * @returns This function returns the same record of component manifests.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/existing-components/ | Using Existing Components}
+ * @example
+ * import { componentManifests } from "@prismatic-io/spectral";
+ *
+ * export const componentRegistry = componentManifests({
+ *   slack: {
+ *     key: "slack",
+ *     public: true,
+ *     actions: {
+ *       postMessage: { inputs: { message: { label: "Message" } } },
+ *     },
+ *   },
+ *   dropbox: {
+ *     key: "dropbox",
+ *     public: true,
+ *     actions: {
+ *       uploadFile: { inputs: { filePath: { label: "File Path" } } },
+ *     },
+ *   },
+ * });
+ */
 export const componentManifests = <T extends Record<string, ComponentManifest>>(definition: T): T =>
   definition;
 

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -38,8 +38,29 @@ import type {
 } from "./types";
 
 /**
- * Create a test connection to use when testing your custom component locally. See
- * https://prismatic.io/docs/custom-connectors/unit-testing/#providing-test-connection-inputs-to-an-action-test
+ * Create a test connection to use when testing your custom component locally.
+ * This builds a `ConnectionValue` from your connection definition and
+ * test credential values.
+ *
+ * @param connectionDef The connection definition (only `key` is used).
+ * @param values A record of field values for the connection (e.g. `apiKey`, `baseUrl`).
+ * @param tokenValues Optional OAuth 2.0 token values (e.g. `access_token`, `refresh_token`).
+ * @param displayName Optional display name for the connection config variable.
+ * @returns A `ConnectionValue` object suitable for use in test invocations.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/#providing-test-connection-inputs-to-an-action-test | Test Connection Inputs}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ * import { apiKeyConnection } from "./connections";
+ *
+ * const testConnection = testing.createConnection(apiKeyConnection, {
+ *   apiKey: "test-api-key-123",
+ *   baseUrl: "https://api.acme.com/v2",
+ * });
+ *
+ * // Use with testing.invoke()
+ * const { result } = await testing.invoke(myAction, {
+ *   connection: testConnection,
+ * });
  */
 export const createConnection = <T extends ConnectionDefinition>(
   { key }: T,
@@ -56,8 +77,21 @@ export const createConnection = <T extends ConnectionDefinition>(
 export const defaultConnectionValueEnvironmentVariable = "PRISMATIC_CONNECTION_VALUE";
 
 /**
- * Source a test connection from an environment variable for local testing. See
- * https://prismatic.io/docs/custom-connectors/unit-testing/#access-connections-for-local-testing
+ * Source a test connection from an environment variable for local testing.
+ * The environment variable should contain a JSON-serialized connection value.
+ * Defaults to reading from `PRISMATIC_CONNECTION_VALUE`.
+ *
+ * @param envVarKey The name of the environment variable to read. Defaults to `"PRISMATIC_CONNECTION_VALUE"`.
+ * @returns A `ConnectionValue` parsed from the environment variable.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/#access-connections-for-local-testing | Access Connections for Local Testing}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ *
+ * // Reads from PRISMATIC_CONNECTION_VALUE env var (default)
+ * const conn = testing.connectionValue();
+ *
+ * // Or specify a custom env var
+ * const conn = testing.connectionValue("MY_ACME_CONNECTION");
  */
 export const connectionValue = (
   envVarKey = defaultConnectionValueEnvironmentVariable,
@@ -74,9 +108,17 @@ export const connectionValue = (
 };
 
 /**
- * Pre-built mock of ActionLogger. Suitable for asserting logs are created as expected. See
- * https://prismatic.io/docs/custom-connectors/unit-testing/#verifying-correct-logging-in-action-tests
- * for information on testing correct logging behavior in your custom component.
+ * Pre-built mock of ActionLogger. All log methods (`info`, `warn`, `error`, etc.)
+ * are Jest spies, so you can assert that your actions log the expected messages.
+ *
+ * @returns A mock `ActionLogger` with Jest spy methods.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/#verifying-correct-logging-in-action-tests | Verifying Logging}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ *
+ * const logger = testing.loggerMock();
+ * // Pass logger in context, then assert:
+ * expect(logger.info).toHaveBeenCalledWith("Processing started");
  */
 export const loggerMock = (): ActionLogger => ({
   metric: console.log as ActionLoggerFunction,
@@ -97,14 +139,27 @@ async function invokeFlowTest(
 }
 
 /**
- * Creates basic component mocks based on the CNI's component registry.
- * You may pass mock overrides in the second argument, e.g.:
+ * Creates basic component action mocks based on a code-native integration's
+ * component registry. Each action mock returns the action's `examplePayload`
+ * by default. Pass overrides in the second argument to customize specific mocks.
  *
- * createMockContextComponents(myManifest, {
+ * @param registry The component registry (or subset) to mock.
+ * @param mocks Optional overrides for specific component actions.
+ * @returns An object of mocked component actions, suitable for use in test context.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { createMockContextComponents } from "@prismatic-io/spectral/dist/testing";
+ * import { componentRegistry } from "./componentRegistry";
+ *
+ * // Default mocks (uses examplePayload from the manifest)
+ * const components = createMockContextComponents(componentRegistry);
+ *
+ * // With custom overrides
+ * const components = createMockContextComponents(componentRegistry, {
  *   actions: {
- *     myComponentName: {
- *        myComponentAction: () => Promise.resolve({ data: "my test data "}),
- *     }
+ *     slack: {
+ *       postMessage: () => Promise.resolve({ data: { ok: true } }),
+ *     },
  *   },
  * });
  */
@@ -255,10 +310,27 @@ interface InvokeReturn<ReturnData> {
 }
 
 /**
- * Invokes specified ActionDefinition perform function using supplied params
- * and optional context. Accepts a generic type matching ActionPerformReturn as a convenience
- * to avoid extra casting within test methods. Returns an InvokeResult containing both the
- * action result and a mock logger for asserting logging.
+ * Invokes a custom component action's `perform` function within a test harness.
+ * Returns both the action result and a mock logger for asserting logging behavior.
+ *
+ * @param actionDef The action definition to test (only `perform` is used).
+ * @param params Input parameter values to pass to the action's `perform` function.
+ * @param context Optional partial context overrides (e.g. custom `configVars` or `instanceState`).
+ * @returns An object with `result` (the action's return value) and `loggerMock` (for asserting logs).
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ * import { myAction } from "./actions";
+ *
+ * it("should return items", async () => {
+ *   const { result, loggerMock } = await testing.invoke(myAction, {
+ *     connection: testConnection,
+ *     limit: "10",
+ *   });
+ *
+ *   expect(result.data).toHaveProperty("items");
+ *   expect(loggerMock.info).toHaveBeenCalled();
+ * });
  */
 export const invoke = async <
   TInputs extends Inputs,
@@ -336,10 +408,33 @@ export const defaultTriggerPayload = (): TriggerPayload => {
 };
 
 /**
- * Invokes specified TriggerDefinition perform function using supplied params
- * and optional context. Accepts a generic type matching TriggerResult as a convenience
- * to avoid extra casting within test methods. Returns an InvokeResult containing both the
- * trigger result and a mock logger for asserting logging.
+ * Invokes a custom component trigger's `perform` function within a test harness.
+ * Provides a default trigger payload that can be overridden. Returns both the
+ * trigger result and a mock logger for asserting logging behavior.
+ *
+ * @param triggerDef The trigger definition to test (only `perform` is used).
+ * @param context Optional partial context overrides.
+ * @param payload Optional partial trigger payload overrides (merged with defaults).
+ * @param params Optional input parameter values for the trigger.
+ * @returns An object with `result` (the trigger's return value) and `loggerMock`.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ * import { webhookTrigger } from "./triggers";
+ *
+ * it("should process the webhook payload", async () => {
+ *   const { result } = await testing.invokeTrigger(
+ *     webhookTrigger,
+ *     undefined, // use default context
+ *     {
+ *       body: { data: JSON.stringify({ event: "created" }) },
+ *       headers: { "x-webhook-secret": "test-secret" },
+ *     },
+ *     { secret: "test-secret" },
+ *   );
+ *
+ *   expect(result.payload).toBeDefined();
+ * });
  */
 export const invokeTrigger = async <
   TInputs extends Inputs,
@@ -365,9 +460,27 @@ export const invokeTrigger = async <
 };
 
 /**
- * Invokes specified DataSourceDefinition perform function using supplied params.
- * Accepts a generic type matching DataSourceResult as a convenience to avoid extra
- * casting within test methods. Returns a DataSourceResult.
+ * Invokes a custom component data source's `perform` function within a test harness.
+ * Returns the data source result directly.
+ *
+ * @param dataSourceDef The data source definition to test (only `perform` is used).
+ * @param params Input parameter values to pass to the data source's `perform` function.
+ * @param context Optional partial context overrides.
+ * @returns The data source result (e.g. a picklist, JSON form, or other data source type).
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ * import { selectChannel } from "./dataSources";
+ *
+ * it("should return a list of channels", async () => {
+ *   const result = await testing.invokeDataSource(selectChannel, {
+ *     connection: testConnection,
+ *   });
+ *
+ *   expect(result.result).toContainEqual(
+ *     expect.objectContaining({ label: "General" }),
+ *   );
+ * });
  */
 export const invokeDataSource = async <
   TInputs extends Inputs,
@@ -416,9 +529,35 @@ const createConfigVars = <TConfigVarValues extends TestConfigVarValues>(
 };
 
 /**
- * Invokes specified Flow of a Code Native Integration using supplied params.
- * Runs the Trigger and then the Action function and returns the result of the Action. See
- * https://prismatic.io/docs/integrations/triggers/cross-flow/#using-cross-flow-triggers-in-code-native
+ * Invokes a code-native integration flow within a test harness. Runs the
+ * flow's `onTrigger` (if defined) followed by `onExecution`, and returns
+ * the execution result. Accepts optional config variables, context overrides,
+ * and a custom trigger payload.
+ *
+ * @param flow The flow definition to test.
+ * @param options Optional config variables, context overrides, and trigger payload.
+ * @returns An object with `result` (the flow execution return value) and `loggerMock`.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { invokeFlow } from "@prismatic-io/spectral/dist/testing";
+ * import { myFlow } from "./flows";
+ *
+ * it("should execute the flow end-to-end", async () => {
+ *   const { result } = await invokeFlow(myFlow, {
+ *     configVars: {
+ *       "Acme API Endpoint": "https://api.acme.com",
+ *       "Acme Connection": {
+ *         fields: { apiKey: "test-key" },
+ *         key: "apiKey",
+ *       },
+ *     },
+ *     payload: {
+ *       body: { data: JSON.stringify({ event: "created" }) },
+ *     },
+ *   });
+ *
+ *   expect(result.data).toBeDefined();
+ * });
  */
 export const invokeFlow = async <
   TInputs extends Inputs,
@@ -616,8 +755,33 @@ export class ComponentTestHarness<
 }
 
 /**
- * Create a testing harness to test a custom component's actions, triggers and data sources. See
- * https://prismatic.io/docs/custom-connectors/unit-testing/
+ * Create a testing harness to test a custom component's actions, triggers
+ * and data sources by key. The harness automatically provides default input
+ * values and mock context.
+ *
+ * @param component The compiled component object (the result of calling `component()`).
+ * @returns A `ComponentTestHarness` instance with `.action()`, `.trigger()`, and `.dataSource()` methods.
+ * @see {@link https://prismatic.io/docs/custom-connectors/unit-testing/ | Unit Testing}
+ * @example
+ * import { testing } from "@prismatic-io/spectral";
+ * import myComponent from ".";
+ *
+ * const harness = testing.createHarness(myComponent);
+ *
+ * it("should list items", async () => {
+ *   const result = await harness.action("listItems", {
+ *     connection: testConnection,
+ *     limit: "10",
+ *   });
+ *   expect(result.data).toHaveProperty("items");
+ * });
+ *
+ * it("should handle a webhook trigger", async () => {
+ *   const result = await harness.trigger("webhook", {
+ *     body: { data: '{"event":"created"}' },
+ *   });
+ *   expect(result.payload).toBeDefined();
+ * });
  */
 export const createHarness = <
   TInputs extends Inputs,

--- a/packages/spectral/src/util.ts
+++ b/packages/spectral/src/util.ts
@@ -39,15 +39,29 @@ export const isObjectWithTruthyKeys = (value: unknown, keys: string[]): boolean 
 
 /**
  * This function checks if value is an Element.
- * `util.types.isElement({key: "foo"})` and `util.types.isElement({key: "foo", label: "Foo"})` return true.
+ *
  * @param value The variable to test.
  * @returns This function returns true or false, depending on if `value` is an Element.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isElement({ key: "foo" }); // true
+ * util.types.isElement({ key: "foo", label: "Foo" }); // true
+ * util.types.isElement("foo"); // false
+ * util.types.isElement({}); // false
  */
 const isElement = (value: unknown): value is Element => isObjectWithTruthyKeys(value, ["key"]);
 
 /**
+ * Checks if a value is a valid ObjectSelection (an array of objects each with an `object` property).
+ *
  * @param value The value to test
  * @returns This function returns true if the type of `value` is an ObjectSelection, or false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isObjectSelection([{ object: { key: "account" } }]); // true
+ * util.types.isObjectSelection("not an object selection"); // false
  */
 const isObjectSelection = (value: unknown): value is ObjectSelection => {
   if (typeof value === "string" && isJSON(value)) {
@@ -59,8 +73,22 @@ const isObjectSelection = (value: unknown): value is ObjectSelection => {
 
 /**
  * This function coerces a provided value into an ObjectSelection if possible.
+ * If the value is a JSON string it will be parsed first. Throws an error if
+ * the value cannot be coerced.
+ *
  * @param value The value to coerce to ObjectSelection.
- * @returns This function returns the the value as an ObjectSelection if possible.
+ * @returns This function returns the value as an ObjectSelection if possible.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * const selection = util.types.toObjectSelection([
+ *   { object: { key: "account", label: "Account" }, fields: [{ key: "name" }] },
+ * ]);
+ *
+ * // Also accepts a JSON string representation
+ * const fromString = util.types.toObjectSelection(
+ *   '[{"object":{"key":"account"}}]'
+ * );
  */
 const toObjectSelection = (value: unknown): ObjectSelection => {
   if (typeof value === "string" && isJSON(value)) {
@@ -79,8 +107,18 @@ const toObjectSelection = (value: unknown): ObjectSelection => {
 };
 
 /**
+ * Checks if a value is a valid ObjectFieldMap (an object with a `fields` array,
+ * where each field has a `field` property that is an Element).
+ *
  * @param value The value to test
  * @returns This function returns true if the type of `value` is an ObjectFieldMap, or false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isObjectFieldMap({
+ *   fields: [{ field: { key: "name", label: "Name" } }],
+ * }); // true
+ * util.types.isObjectFieldMap("not a field map"); // false
  */
 const isObjectFieldMap = (value: unknown): value is ObjectFieldMap => {
   if (typeof value === "string" && isJSON(value)) {
@@ -104,8 +142,19 @@ const isObjectFieldMap = (value: unknown): value is ObjectFieldMap => {
 
 /**
  * This function coerces a provided value into an ObjectFieldMap if possible.
+ * If the value is a JSON string it will be parsed first. Throws an error if
+ * the value cannot be coerced.
+ *
  * @param value The value to coerce to ObjectFieldMap.
- * @returns This function returns the the value as an ObjectFieldMap if possible.
+ * @returns This function returns the value as an ObjectFieldMap if possible.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * const fieldMap = util.types.toObjectFieldMap({
+ *   fields: [
+ *     { field: { key: "email", label: "Email" }, mappedField: { key: "contact_email" } },
+ *   ],
+ * });
  */
 const toObjectFieldMap = (value: unknown): ObjectFieldMap => {
   if (typeof value === "string" && isJSON(value)) {
@@ -124,8 +173,19 @@ const toObjectFieldMap = (value: unknown): ObjectFieldMap => {
 };
 
 /**
+ * Checks if a value is a valid JSONForm (an object with `schema`, `uiSchema`, and `data` properties).
+ *
  * @param value The value to test
  * @returns This function returns true if the type of `value` is a JSONForm, or false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isJSONForm({
+ *   schema: { type: "object", properties: { name: { type: "string" } } },
+ *   uiSchema: { type: "VerticalLayout", elements: [] },
+ *   data: { name: "Example" },
+ * }); // true
+ * util.types.isJSONForm({ schema: {} }); // false (missing uiSchema and data)
  */
 const isJSONForm = (value: unknown): value is JSONForm => {
   if (typeof value === "string" && isJSON(value)) {
@@ -137,8 +197,19 @@ const isJSONForm = (value: unknown): value is JSONForm => {
 
 /**
  * This function coerces a provided value into a JSONForm if possible.
+ * If the value is a JSON string it will be parsed first. Throws an error if
+ * the value cannot be coerced.
+ *
  * @param value The value to coerce to JSONForm.
- * @returns This function returns the the value as a JSONForm if possible.
+ * @returns This function returns the value as a JSONForm if possible.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * const form = util.types.toJSONForm({
+ *   schema: { type: "object", properties: { name: { type: "string" } } },
+ *   uiSchema: { type: "VerticalLayout", elements: [] },
+ *   data: { name: "Default Name" },
+ * });
  */
 const toJSONForm = (value: unknown): JSONForm => {
   if (typeof value === "string" && isJSON(value)) {
@@ -159,11 +230,15 @@ const toJSONForm = (value: unknown): JSONForm => {
 /**
  * Determine if a variable is a boolean (true or false).
  *
- * - `util.types.isBool(false)` will return `true`, since `false` is a boolean.
- * - `util.types.isBool("Hello")` will return `false`, since `"Hello"` is not a boolean.
- *
  * @param value The variable to test.
  * @returns True if the value is a boolean, or false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isBool(false); // true
+ * util.types.isBool(true); // true
+ * util.types.isBool("Hello"); // false
+ * util.types.isBool(0); // false
  */
 const isBool = (value: unknown): value is boolean => value === true || value === false;
 
@@ -173,11 +248,19 @@ const isBool = (value: unknown): value is boolean => value === true || value ===
  * Truthy/falsy checks are case-insensitive.
  *
  * In the event that `value` is undefined or an empty string, a default value can be provided.
- * For example, `util.types.toBool('', true)` will return `true`.
  *
  * @param value The value to convert to a boolean.
  * @param defaultValue The value to return if `value` is undefined or an empty string.
  * @returns The boolean equivalent of the truthy or falsy `value`.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.toBool("true"); // true
+ * util.types.toBool("YES"); // true
+ * util.types.toBool("f"); // false
+ * util.types.toBool("no"); // false
+ * util.types.toBool("", true); // true (uses default)
+ * util.types.toBool(undefined, false); // false (uses default)
  */
 const toBool = (value: unknown, defaultValue?: boolean): boolean => {
   if (isBool(value)) {
@@ -198,23 +281,35 @@ const toBool = (value: unknown, defaultValue?: boolean): boolean => {
 
 /**
  * This function checks if value is an integer.
- * `util.types.isInt(5)` returns true, while `util.types.isInt("5")` or `util.types.isInt(5.5)` returns false.
+ *
  * @param value The variable to test.
  * @returns This function returns true or false, depending on if `value` is an integer.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isInt(5); // true
+ * util.types.isInt(-3); // true
+ * util.types.isInt("5"); // false (string, not a number)
+ * util.types.isInt(5.5); // false (float, not an integer)
  */
 const isInt = (value: unknown): value is number => Number.isInteger(value);
 
 /**
  * This function converts a variable to an integer if possible.
- * `util.types.toInt(5.5)` will return `5`.  `util.types.toInt("20.3")` will return `20`.
+ * Floats are truncated (not rounded). Throws an error if `value`
+ * cannot be coerced and no `defaultValue` is provided.
  *
- * In the event that `value` is undefined or an empty string, a default value can be provided.
- * For example, `util.types.toInt('', 1)` will return `1`.
- *
- * This function will throw an exception if `value` cannot be coerced to an integer.
  * @param value The value to convert to an integer.
  * @param defaultValue The value to return if `value` is undefined, an empty string, or not able to be coerced.
  * @returns This function returns an integer if possible.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.toInt(5.5); // 5
+ * util.types.toInt("20.3"); // 20
+ * util.types.toInt("", 1); // 1 (uses default)
+ * util.types.toInt(undefined, 42); // 42 (uses default)
+ * util.types.toInt("abc"); // throws Error
  */
 const toInt = (value: unknown, defaultValue?: number): number => {
   if (isInt(value)) return value;
@@ -245,28 +340,33 @@ const toInt = (value: unknown, defaultValue?: number): number => {
 /**
  * Determine if a variable is a number, or can easily be coerced into a number.
  *
- * - `util.types.isNumber(3.21)` will return `true`, since `3.21` is a number.
- * - `util.types.isBool("5.5")` will return `true`, since the string `"5.5"` can easily be coerced into a number.
- * - `util.types.isBool("Hello")` will return `false`, since `"Hello"` is not a number.
- *
  * @param value The variable to test.
  * @returns This function returns true if `value` can easily be coerced into a number, and false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isNumber(3.21); // true
+ * util.types.isNumber("5.5"); // true (string is numeric)
+ * util.types.isNumber("Hello"); // false
  */
 const isNumber = (value: unknown): boolean => !Number.isNaN(Number(value));
 
 /**
  * This function coerces a value (number or string) into a number.
- * In the event that `value` is undefined or an empty string, a `defaultValue` can be provided, or zero will be returned.
+ * In the event that `value` is undefined, null, or an empty string, a `defaultValue` can be provided, or zero will be returned.
  * If `value` is not able to be coerced into a number but is defined, an error will be thrown.
  *
- * - `util.types.toNumber("3.22")` will return the number `3.22`.
- * - `util.types.toNumber("", 5.5)` will return the default value `5.5`, since `value` was an empty string.
- * - `util.types.toNumber(null, 5.5)` will return the default value `5.5`, since `value` was `null`.
- * - `util.types.toNumber(undefined)` will return `0`, since `value` was undefined and no `defaultValue` was given.
- * - `util.types.toNumber("Hello")` will throw an error, since the string `"Hello"` cannot be coerced into a number.
  * @param value The value to turn into a number.
- * @param defaultValue The value to return if `value` is undefined or an empty string.
+ * @param defaultValue The value to return if `value` is undefined, null, or an empty string.
  * @returns This function returns the numerical version of `value` if possible, or the `defaultValue` if `value` is undefined or an empty string.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.toNumber("3.22"); // 3.22
+ * util.types.toNumber("", 5.5); // 5.5 (uses default)
+ * util.types.toNumber(null, 5.5); // 5.5 (uses default)
+ * util.types.toNumber(undefined); // 0 (no default given)
+ * util.types.toNumber("Hello"); // throws Error
  */
 const toNumber = (value: unknown, defaultValue?: number): number => {
   if (typeof value === "undefined" || value === "" || value === null) {
@@ -281,21 +381,34 @@ const toNumber = (value: unknown, defaultValue?: number): number => {
 };
 
 /**
+ * Checks if a value is a bigint.
+ *
  * @param value The value to test
  * @returns This function returns true if the type of `value` is a bigint, or false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isBigInt(3n); // true
+ * util.types.isBigInt(3); // false (number, not bigint)
+ * util.types.isBigInt("3"); // false
  */
 const isBigInt = (value: unknown): value is bigint => typeof value === "bigint";
 
 /**
  * This function coerces a provided value into a bigint if possible.
  * The provided `value` must be a bigint, integer, string representing an integer, or a boolean.
+ * Throws an error if the value cannot be coerced.
  *
- * - `util.types.toBigInt(3)` will return `3n`.
- * - `util.types.toBigInt("-5")` will return `-5n`.
- * - `util.types.toBigInt(true)` will return `1n` (and `false` will return `0n`).
- * - `util.types.toBigInt("5.5")` will throw an error, as `5.5` is not an integer.
  * @param value The value to coerce to bigint.
  * @returns This function returns the bigint representation of `value`.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.toBigInt(3); // 3n
+ * util.types.toBigInt("-5"); // -5n
+ * util.types.toBigInt(true); // 1n
+ * util.types.toBigInt(false); // 0n
+ * util.types.toBigInt("5.5"); // throws Error (not an integer)
  */
 const toBigInt = (value: unknown): bigint => {
   if (isBigInt(value)) {
@@ -309,19 +422,40 @@ const toBigInt = (value: unknown): bigint => {
   }
 };
 
-/** This function returns true if `value` is a variable of type `Date`, and false otherwise. */
+/**
+ * This function returns true if `value` is a variable of type `Date`, and false otherwise.
+ *
+ * @param value The variable to test.
+ * @returns True if value is a Date object, false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isDate(new Date()); // true
+ * util.types.isDate("2021-03-20"); // false (string, not Date)
+ * util.types.isDate(1616198400); // false (number, not Date)
+ */
 const isDate = (value: unknown): value is Date => dateIsDate(value);
 
 /**
- * This function parses an ISO date or UNIX epoch timestamp if possible, or throws an error if the value provided
- * cannot be coerced into a Date object.
+ * This function parses an ISO date string or UNIX epoch timestamp if possible,
+ * or throws an error if the value provided cannot be coerced into a Date object.
  *
- * - `util.types.toDate(new Date('1995-12-17T03:24:00'))` will return `Date('1995-12-17T09:24:00.000Z')` since a `Date` object was passed in.
- * - `util.types.toDate('2021-03-20')` will return `Date('2021-03-20T05:00:00.000Z')` since a valid ISO date was passed in.
- * - `util.types.toDate(1616198400) will return `Date('2021-03-20T00:00:00.000Z')` since a UNIX epoch timestamp was passed in.
- * - `parseISODate('2021-03-20-05')` will throw an error since `value` was not a valid ISO date.
- * @param value The value to turn into a date.
+ * @param value The value to turn into a date. Accepts a Date object, ISO date string, or UNIX epoch timestamp (seconds).
  * @returns The date equivalent of `value`.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * // Pass through an existing Date object
+ * util.types.toDate(new Date("1995-12-17T03:24:00"));
+ *
+ * // Parse an ISO date string
+ * util.types.toDate("2021-03-20"); // Date object for 2021-03-20
+ *
+ * // Parse a UNIX epoch timestamp (in seconds)
+ * util.types.toDate(1616198400); // Date object for 2021-03-20
+ *
+ * // Invalid input throws an error
+ * util.types.toDate("not-a-date"); // throws Error
  */
 const toDate = (value: unknown): Date => {
   if (isDate(value)) {
@@ -347,44 +481,81 @@ const toDate = (value: unknown): Date => {
  * Note: this function only tests that the string is a syntactically correct URL; it does not check
  * if the URL is web accessible.
  *
- * - `util.types.isUrl('https://prismatic.io')` will return true.
- * - `util.types.isUrl('https:://prismatic.io')` will return false due to the extraneous `:` symbol.
  * @param value The URL to test.
  * @returns This function returns true if `value` is a valid URL, and false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isUrl("https://prismatic.io"); // true
+ * util.types.isUrl("http://example.com/path?q=1"); // true
+ * util.types.isUrl("https:://prismatic.io"); // false (malformed)
+ * util.types.isUrl("not a url"); // false
  */
 const isUrl = (value: string): boolean => isWebUri(value) !== undefined;
 
 /**
- * This function checks if value is a valid picklist.
- *
- * - `util.types.isPicklist(["value", new String("value")])` will return `true`.
+ * This function checks if value is a valid picklist. A picklist is an array
+ * of strings or an array of Element objects (objects with a `key` property).
  *
  * @param value The variable to test.
  * @returns This function returns true if `value` is a valid picklist.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isPicklist(["option1", "option2"]); // true
+ * util.types.isPicklist([{ key: "a", label: "Option A" }]); // true
+ * util.types.isPicklist("not a picklist"); // false
+ * util.types.isPicklist([1, 2, 3]); // false
  */
 const isPicklist = (value: unknown): boolean =>
   Array.isArray(value) && (value.every(isString) || value.every(isElement));
 
 /**
- * This function checks if value is a valid schedule.
- *
- * - `util.types.isSchedule({value: "00 00 * * 2,3"})` will return `true`.
- * - `util.types.isSchedule({value: "00 00 * * 2,3", scheduleType: "week", timeZone: "America/Chicago"})` will return `true`.
+ * This function checks if value is a valid schedule (an object with a truthy `value` property).
  *
  * @param value The variable to test.
  * @returns This function returns true if `value` is a valid schedule.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isSchedule({ value: "00 00 * * 2,3" }); // true
+ * util.types.isSchedule({
+ *   value: "00 00 * * 2,3",
+ *   schedule_type: "week",
+ *   time_zone: "America/Chicago",
+ * }); // true
+ * util.types.isSchedule("not a schedule"); // false
  */
 const isSchedule = (value: unknown): boolean => isObjectWithTruthyKeys(value, ["value"]);
 
 /**
  * This function helps to transform key-value lists to objects.
- * This is useful for transforming inputs that are key-value collections into objects.
+ * This is useful for transforming inputs that use the `keyvaluelist` collection type
+ * into plain objects.
  *
- * For example, an input that is a collection might return `[{key: "foo", value: "bar"},{key: "baz", value: 5}]`.
- * If that array were passed into `util.types.keyValPairListToObject()`, an object would be returned of the form
- * `{foo: "bar", baz: 5}`.
  * @param kvpList An array of objects with `key` and `value` properties.
  * @param valueConverter Optional function to call for each `value`.
+ * @returns A plain object with keys and values from the input array.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * const headers = [
+ *   { key: "Content-Type", value: "application/json" },
+ *   { key: "Authorization", value: "Bearer abc123" },
+ * ];
+ * util.types.keyValPairListToObject(headers);
+ * // { "Content-Type": "application/json", "Authorization": "Bearer abc123" }
+ *
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * // With a value converter
+ * const params = [
+ *   { key: "limit", value: "10" },
+ *   { key: "offset", value: "0" },
+ * ];
+ * util.types.keyValPairListToObject(params, (v) => Number(v));
+ * // { limit: 10, offset: 0 }
  */
 const keyValPairListToObject = <TValue = unknown>(
   kvpList: KeyValuePair<unknown>[],
@@ -405,21 +576,42 @@ const keyValPairListToObject = <TValue = unknown>(
  *
  * @param value The value to test
  * @returns This function returns true if `value` is a DataPayload object, and false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isBufferDataPayload({
+ *   data: Buffer.from("hello"),
+ *   contentType: "text/plain",
+ * }); // true
+ * util.types.isBufferDataPayload("hello"); // false
+ * util.types.isBufferDataPayload({ data: "not a buffer" }); // false
  */
 const isBufferDataPayload = (value: unknown): value is DataPayload =>
   value instanceof Object && "data" in value && Buffer.isBuffer(value.data);
 
 /**
- * Many libraries for third-party API that handle binary files expect `Buffer` objects.
- * This function helps to convert strings, Uint8Arrays, and Arrays to a data structure
- * that has a Buffer and a string representing `contentType`.
+ * Many libraries for third-party APIs that handle binary files expect `Buffer` objects.
+ * This function helps to convert strings, Uint8Arrays, objects, and arrays to a
+ * `DataPayload` structure that has a Buffer and a string representing `contentType`.
  *
- * You can access the buffer like this:
- *  `const { data, contentType } = util.types.toBufferDataPayload(someData);`
+ * Throws an error if `value` cannot be converted to a Buffer.
  *
- * If `value` cannot be converted to a Buffer, an error will be thrown.
- * @param value The string, Buffer, Uint8Array, or Array to convert to a Buffer.
- * @returns This function returns an object with two keys: `data`, which is a `Buffer`, and `contentType`, which is a string.
+ * @param value The string, Buffer, Uint8Array, object, or Array to convert to a Buffer.
+ * @returns An object with two keys: `data` (a `Buffer`) and `contentType` (a string).
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * // Convert a string (becomes text/plain)
+ * const { data, contentType } = util.types.toBufferDataPayload("Hello, world!");
+ * // data: Buffer, contentType: "text/plain"
+ *
+ * // Convert an object (becomes application/json)
+ * const jsonPayload = util.types.toBufferDataPayload({ key: "value" });
+ * // jsonPayload.contentType === "application/json"
+ *
+ * // Pass through an existing DataPayload
+ * const existing = { data: Buffer.from("binary"), contentType: "application/octet-stream" };
+ * util.types.toBufferDataPayload(existing); // returns as-is
  */
 const toBufferDataPayload = (value: unknown): DataPayload => {
   if (isBufferDataPayload(value)) {
@@ -483,31 +675,54 @@ const toData = (value: unknown): DataPayload => toBufferDataPayload(value);
 
 /**
  * This function checks if value is a string.
- * `util.types.isString("value")` and `util.types.isString(new String("value"))` return true.
+ *
  * @param value The variable to test.
  * @returns This function returns true or false, depending on if `value` is a string.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isString("value"); // true
+ * util.types.isString(new String("value")); // true
+ * util.types.isString(123); // false
+ * util.types.isString(null); // false
  */
 const isString = (value: unknown): value is string =>
   typeof value === "string" || value instanceof String;
 
 /**
  * This function converts a `value` to a string.
- * If `value` is undefined or an empty string, an optional `defaultValue` can be returned.
+ * If `value` is undefined or null, an optional `defaultValue` is returned (defaults to `""`).
  *
- * - `util.types.toString("Hello")` will return `"Hello"`.
- * - `util.types.toString(5.5)` will return `"5.5"`.
- * - `util.types.toString("", "Some default")` will return `"Some Default"`.
- * - `util.types.toString(undefined)` will return `""`.
  * @param value The value to convert to a string.
- * @param defaultValue A default value to return if `value` is undefined or an empty string.
- * @returns This function returns the stringified version fo `value`, or `defaultValue` in the case that `value` is undefined or an empty string.
+ * @param defaultValue A default value to return if `value` is undefined or null. Defaults to `""`.
+ * @returns The stringified version of `value`, or `defaultValue` if `value` is undefined or null.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.toString("Hello"); // "Hello"
+ * util.types.toString(5.5); // "5.5"
+ * util.types.toString("", "Some default"); // ""
+ * util.types.toString(undefined); // ""
+ * util.types.toString(null, "fallback"); // "fallback"
  */
 const toString = (value: unknown, defaultValue = ""): string => `${value ?? defaultValue}`;
 
 /**
- * This function checks if value is a valid connection.
+ * This function checks if value is a valid connection object (has `key`, `label`,
+ * and `inputs` properties, with appropriate OAuth 2.0 fields if applicable).
+ *
  * @param value The variable to test.
  * @returns This function returns true or false, depending on if `value` is a valid connection.
+ * @see {@link https://prismatic.io/docs/custom-connectors/connections/ | Writing Custom Connections}
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isConnection({
+ *   key: "apiKey",
+ *   label: "API Key",
+ *   inputs: { apiKey: { type: "password" } },
+ * }); // true
+ * util.types.isConnection("not a connection"); // false
  */
 const isConnection = (value: unknown): value is ConnectionDefinition => {
   if (typeof value === "string" && isJSON(value)) {
@@ -531,14 +746,19 @@ const isConnection = (value: unknown): value is ConnectionDefinition => {
 };
 
 /**
- * This function returns true if `value` resembles the shape of JSON, and false otherwise.
+ * This function returns true if `value` can be parsed as JSON, and false otherwise.
  *
- * - `isJSON("") will return `false`
- * - `isJSON(5) will return `true`
- * - `isJSON('{"name":"John", "age":30, "car":null}') will return `true`
- * @param value The value to test against
- * @returns This function returns a boolean, dependant on whether `value` can be parsed to JSON.
- * */
+ * @param value The value to test against.
+ * @returns True if `value` can be parsed by `JSON.parse()`, false otherwise.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.isJSON('{"name":"John","age":30}'); // true
+ * util.types.isJSON("5"); // true
+ * util.types.isJSON("true"); // true
+ * util.types.isJSON(""); // false
+ * util.types.isJSON("not json"); // false
+ */
 const isJSON = (value: string): boolean => {
   try {
     JSON.parse(value);
@@ -549,12 +769,27 @@ const isJSON = (value: string): boolean => {
 };
 
 /**
- * This function accepts an arbitrary object/value and safely serializes it (handles cyclic references).
+ * This function accepts an arbitrary object/value and safely serializes it to JSON.
+ * Unlike `JSON.stringify`, it handles cyclic references without throwing.
  *
  * @param value Arbitrary object/value to serialize.
- * @param prettyPrint When true, convert to pretty printed JSON with 2 spaces and newlines. When false, JSON is compact.
- * @param retainKeyOrder When true, the order of keys in the JSON output will be the same as the order in the input object.
+ * @param prettyPrint When true, convert to pretty printed JSON with 2 spaces and newlines. When false, JSON is compact. Defaults to `true`.
+ * @param retainKeyOrder When true, the order of keys in the JSON output will be the same as the order in the input object. Defaults to `false`.
  * @returns JSON serialized text that can be safely logged.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * // Pretty-printed (default)
+ * util.types.toJSON({ name: "Acme", count: 42 });
+ * // '{\n  "count": 42,\n  "name": "Acme"\n}'
+ *
+ * // Compact output
+ * util.types.toJSON({ name: "Acme", count: 42 }, false);
+ * // '{"count":42,"name":"Acme"}'
+ *
+ * // Retain original key order
+ * util.types.toJSON({ name: "Acme", count: 42 }, true, true);
+ * // '{\n  "name": "Acme",\n  "count": 42\n}'
  */
 const toJSON = (value: unknown, prettyPrint = true, retainKeyOrder = false): string => {
   const stringify = configure({
@@ -566,27 +801,42 @@ const toJSON = (value: unknown, prettyPrint = true, retainKeyOrder = false): str
 };
 
 /**
- * This function returns a lower cased version of the headers passed to it.
+ * This function returns a version of the headers object where all header
+ * names (keys) are lower-cased. Header values are left unchanged.
  *
- * - `lowerCaseHeaders({"Content-Type": "Application/JSON"})` will return `{"content-type": "Application/JSON"}`
- * - `lowerCaseHeaders({"Cache-Control": "max-age=604800"})` will return `{"cache-control": "max-age=604800"}`
- * - `lowerCaseHeaders({"Accept-Language": "en-us"})` will return `{"accept-language": "en-us"}`
- * @param headers The headers to convert to lower case
- * @returns This function returns a header object
- * */
+ * @param headers The headers to convert to lower case.
+ * @returns A new header object with lower-cased keys.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
+ *
+ * util.types.lowerCaseHeaders({ "Content-Type": "application/json" });
+ * // { "content-type": "application/json" }
+ *
+ * util.types.lowerCaseHeaders({
+ *   "Cache-Control": "max-age=604800",
+ *   "Accept-Language": "en-us",
+ * });
+ * // { "cache-control": "max-age=604800", "accept-language": "en-us" }
+ */
 export const lowerCaseHeaders = (headers: Record<string, string>): Record<string, string> =>
   Object.entries(headers).reduce((result, [key, val]) => {
     return { ...result, [key.toLowerCase()]: val };
   }, {});
 
 /**
- * This function parses a JSON string (if JSON) and returns an object, or returns the object.
+ * This function parses a JSON string and returns the resulting object,
+ * or returns the value as-is if it is already an object.
  *
- * - `toObject('{"foo":"bar","baz":123}')` will return object `{foo: "bar", baz: 123}`
- * - `toObject({foo:"bar",baz:123})` will return object `{foo: "bar", baz: 123}`
+ * @param value The JSON string or object to convert.
+ * @returns An object, parsing JSON as necessary.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
  *
- * @param value The JSON string or object to convert
- * @returns This function returns an object, parsing JSON as necessary
+ * util.types.toObject('{"foo":"bar","baz":123}');
+ * // { foo: "bar", baz: 123 }
+ *
+ * util.types.toObject({ foo: "bar", baz: 123 });
+ * // { foo: "bar", baz: 123 } (returned as-is)
  */
 export const toObject = (value: unknown): object => {
   if (typeof value === "string" && isJSON(value)) {
@@ -598,14 +848,22 @@ export const toObject = (value: unknown): object => {
 
 /**
  * This function removes any properties of an object that match a certain predicate.
- * By default properties with values of undefined, null and "" are removed.
+ * By default, properties with values of `undefined`, `null`, and `""` are removed.
+ * Useful for cleaning up request bodies before sending to an API.
  *
- * - `cleanObject({foo: undefined, bar: "abc", baz: null, buz: ""})` will return `{bar: "abc"}`
- * - `cleanObject({foo: 1, bar: 2, baz: 3}, v => v % 2 === 0)` will filter even number values, returning `{foo: 1, baz: 3}`
+ * @param obj A key-value object to remove properties from.
+ * @param predicate A function that returns true for properties to remove. Defaults to removing properties with `undefined`, `null`, and `""` values.
+ * @returns A new object with matching properties removed.
+ * @example
+ * import { util } from "@prismatic-io/spectral";
  *
- * @param obj A key-value object to remove properties from
- * @param predicate A function that returns true for properties to remove. Defaults to removing properties with undefined, null and "" values.
- * @returns An object with certain properties removed
+ * // Remove undefined, null, and empty string values (default)
+ * util.types.cleanObject({ foo: undefined, bar: "abc", baz: null, buz: "" });
+ * // { bar: "abc" }
+ *
+ * // Custom predicate: remove even numbers
+ * util.types.cleanObject({ foo: 1, bar: 2, baz: 3 }, (v) => v % 2 === 0);
+ * // { foo: 1, baz: 3 }
  */
 const cleanObject = (
   obj: Record<string, unknown>,


### PR DESCRIPTION
Improves JSDoc for all common spectral functions and utilities, and adds examples and links to documentation. JSDoc is available to end user developers building custom connectors and code-native integrations within their IDE.

<img width="1356" height="418" alt="image" src="https://github.com/user-attachments/assets/7a38de5a-24bf-4958-bba9-dfe8db16bd97" />

No code changes - purely docs.