### PR TITLE
Ignore biome in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       dev-dependencies:
         dependency-type: "development"
         update-types: ["minor", "patch"]
+    ignore:
+      # Biome bumps require updating the $schema URL in biome.json files,
+      # which dependabot doesn't do. Bump manually.
+      - dependency-name: "@biomejs/biome"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Unfortunately the referenced schema in config files must match even the patch version so we'll have to handle these manually - at least while we're on dependabot.