### PR TITLE
Ensure flow.stableId is required

### DIFF
--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -242,6 +242,7 @@ const createActionContext = <
     flow: {
       id: "flowId",
       name: "Flow 1",
+      stableId: "flowStableId",
     },
     startedAt: new Date().toISOString(),
     invokeFlow: invokeFlowTest,
@@ -401,6 +402,7 @@ export const defaultTriggerPayload = (): TriggerPayload => {
     flow: {
       id: "flowId",
       name: "Flow 1",
+      stableId: "flowStableId",
     },
     startedAt: new Date().toISOString(),
     globalDebug: false,

--- a/packages/spectral/src/types/FlowAttributes.ts
+++ b/packages/spectral/src/types/FlowAttributes.ts
@@ -5,5 +5,5 @@ export interface FlowAttributes {
   /** The name of the currently running flow. */
   name: string;
   /** The stable ID of the currently running flow. */
-  stableId?: string;
+  stableId: string;
 }


### PR DESCRIPTION
# Problem
`flow.stableId` has a type of optional while in practice it is always present and required. Let's make it official in the types.

# Approach
Change `stableId` to required in `FlowAttributes`.