### PR TITLE
Add structuredObject input type and structuredObjectInput wrapper

### DIFF
--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { action, input, pollingTrigger, trigger } from ".";
+import { action, component, input, pollingTrigger, structuredObjectInput, trigger } from ".";
 import { convertTrigger } from "./serverTypes/convertComponent";
 import { PerformFn } from "./serverTypes/perform";
 
@@ -199,5 +199,69 @@ describe("test convert trigger", () => {
         throw e;
       }
     }
+  });
+});
+
+describe("structuredObject inputs in a published component", () => {
+  const createContact = action({
+    display: {
+      label: "Create Contact",
+      description: "Create a new contact",
+    },
+    inputs: {
+      name: structuredObjectInput({
+        label: "Name",
+        inputs: {
+          first: input({ type: "string", label: "First Name", required: true }),
+          last: input({ type: "string", label: "Last Name", required: true }),
+          prefix: input({ type: "string", label: "Prefix" }),
+        },
+      }),
+      email: input({ type: "string", label: "Email", required: true }),
+    },
+    perform: async (_context, _params) => Promise.resolve({ data: null }),
+  });
+
+  it("publishes the action with a structuredObject parent and nested children", () => {
+    const converted = component({
+      key: "crm",
+      public: false,
+      display: { label: "CRM", description: "Test CRM component", iconPath: "icon.png" },
+      actions: { createContact },
+    });
+
+    const action = converted.actions.createContact;
+    expect(action.inputs).toHaveLength(2);
+
+    const nameInput = action.inputs.find((i: { key: string }) => i.key === "name");
+    expect(nameInput).toMatchObject({
+      key: "name",
+      type: "structuredObject",
+      label: "Name",
+    });
+    expect(nameInput?.inputs).toHaveLength(3);
+    expect(nameInput?.inputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "first", type: "string", required: true }),
+        expect.objectContaining({ key: "last", type: "string", required: true }),
+        expect.objectContaining({ key: "prefix", type: "string" }),
+      ]),
+    );
+
+    const emailInput = action.inputs.find((i: { key: string }) => i.key === "email");
+    expect(emailInput).toMatchObject({ key: "email", type: "string", required: true });
+    expect(emailInput?.inputs).toBeUndefined();
+  });
+
+  it("structuredObjectInput factory forces type to 'structuredObject'", () => {
+    const fromFactory = structuredObjectInput({
+      label: "Address",
+      inputs: {
+        line1: input({ type: "string", label: "Line 1" }),
+      },
+    });
+    expect(fromFactory.type).toBe("structuredObject");
+    expect(fromFactory.label).toBe("Address");
+    expect(Object.keys(fromFactory.inputs)).toEqual(["line1"]);
   });
 });

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -264,4 +264,24 @@ describe("structuredObject inputs in a published component", () => {
     expect(fromFactory.label).toBe("Address");
     expect(Object.keys(fromFactory.inputs)).toEqual(["line1"]);
   });
+
+  it("rejects a stray `type` key and nested structuredObject children at compile time", () => {
+    structuredObjectInput({
+      label: "Bad",
+      // @ts-expect-error -- factory disallows callers from setting `type`.
+      type: "string",
+      inputs: { line1: input({ type: "string", label: "Line 1" }) },
+    });
+
+    structuredObjectInput({
+      label: "Outer",
+      inputs: {
+        // @ts-expect-error -- nesting is capped at one level by LeafInputFieldDefinition.
+        inner: structuredObjectInput({
+          label: "Inner",
+          inputs: { x: input({ type: "string", label: "X" }) },
+        }),
+      },
+    });
+  });
 });

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -98,10 +98,8 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   timestamp: "string",
   flow: "string",
   template: "string",
-  // TODO: emit a typed record matching the structuredObject's declared
-  // children. `unknown` is the safe fallback until the code-native
-  // action-calling type generator is taught to recurse into nested
-  // children and emit a precise per-field record type.
+  // TODO: emit a typed record matching the declared children once the
+  // code-native action-calling type generator handles structuredObject.
   structuredObject: "unknown",
 };
 

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -98,6 +98,11 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   timestamp: "string",
   flow: "string",
   template: "string",
+  // TODO: emit a typed record matching the structuredObject's declared
+  // children. `unknown` is the safe fallback until the code-native
+  // action-calling type generator is taught to recurse into nested
+  // children and emit a precise per-field record type.
+  structuredObject: "unknown",
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -28,6 +28,7 @@ import {
   OnPremConnectionDefinition,
   OrganizationActivatedConnectionConfigVar,
   StandardConfigVar,
+  StructuredObjectInputField,
   TriggerDefinition,
   TriggerPayload,
   TriggerResult,
@@ -668,6 +669,41 @@ export const dataSource = <
  * });
  */
 export const input = <T extends InputFieldDefinition>(definition: T): T => definition;
+
+/**
+ * This function creates a structured object input that groups a set of related
+ * primitive inputs under a single named container. Use it when an action
+ * input is a record with named properties (e.g. an `address` containing
+ * `line1`, `city`, `state`, `zip`).
+ *
+ * Children are restricted to non-structuredObject types — a structuredObject
+ * input may not contain another structuredObject. The TypeScript signature
+ * enforces this at compile time.
+ *
+ * The platform stores structuredObject inputs as a flat list with parent
+ * pointers; the conversion layer handles emitting the nested wire shape.
+ *
+ * @param definition A StructuredObjectInputField object that describes the
+ *   container and its child inputs.
+ * @returns The same definition object, typed as a StructuredObjectInputField.
+ * @example
+ * import { input, structuredObjectInput } from "@prismatic-io/spectral";
+ *
+ * const name = structuredObjectInput({
+ *   label: "Name",
+ *   inputs: {
+ *     first: input({ type: "string", label: "First Name", required: true }),
+ *     last: input({ type: "string", label: "Last Name", required: true }),
+ *     prefix: input({ type: "string", label: "Prefix" }),
+ *   },
+ * });
+ */
+export const structuredObjectInput = <T extends Omit<StructuredObjectInputField, "type">>(
+  definition: T,
+): T & { type: "structuredObject" } => ({
+  ...definition,
+  type: "structuredObject" as const,
+});
 
 /**
  * This function creates a connection that can be used by a code-native integration

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -671,21 +671,10 @@ export const dataSource = <
 export const input = <T extends InputFieldDefinition>(definition: T): T => definition;
 
 /**
- * This function creates a structured object input that groups a set of related
- * primitive inputs under a single named container. Use it when an action
- * input is a record with named properties (e.g. an `address` containing
- * `line1`, `city`, `state`, `zip`).
+ * Groups related primitive inputs under a single named container. Children
+ * may not themselves be structuredObject inputs (the type signature enforces
+ * this at compile time).
  *
- * Children are restricted to non-structuredObject types — a structuredObject
- * input may not contain another structuredObject. The TypeScript signature
- * enforces this at compile time.
- *
- * The platform stores structuredObject inputs as a flat list with parent
- * pointers; the conversion layer handles emitting the nested wire shape.
- *
- * @param definition A StructuredObjectInputField object that describes the
- *   container and its child inputs.
- * @returns The same definition object, typed as a StructuredObjectInputField.
  * @example
  * import { input, structuredObjectInput } from "@prismatic-io/spectral";
  *
@@ -694,7 +683,6 @@ export const input = <T extends InputFieldDefinition>(definition: T): T => defin
  *   inputs: {
  *     first: input({ type: "string", label: "First Name", required: true }),
  *     last: input({ type: "string", label: "Last Name", required: true }),
- *     prefix: input({ type: "string", label: "Prefix" }),
  *   },
  * });
  */

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -686,7 +686,9 @@ export const input = <T extends InputFieldDefinition>(definition: T): T => defin
  *   },
  * });
  */
-export const structuredObjectInput = <T extends Omit<StructuredObjectInputField, "type">>(
+export const structuredObjectInput = <
+  T extends Omit<StructuredObjectInputField, "type"> & { type?: never },
+>(
   definition: T,
 ): T & { type: "structuredObject" } => ({
   ...definition,

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connection, input } from "..";
+import { connection, input, structuredObjectInput } from "..";
 import { convertConnection, convertInput, convertTemplateInput } from "./convertComponent";
 
 describe("convertConnection", () => {
@@ -37,6 +37,40 @@ describe("convertInput", () => {
 
     expect(convertedInput.key).toBe(basicInputWithDataSourceKey);
     expect(convertedInput.dataSource).toBe(dataSourceKey);
+  });
+
+  it("converts a structuredObject input with nested children", () => {
+    const name = structuredObjectInput({
+      label: "Name",
+      inputs: {
+        first: input({ type: "string", label: "First Name", required: true }),
+        last: input({ type: "string", label: "Last Name", required: true }),
+        prefix: input({ type: "string", label: "Prefix" }),
+      },
+    });
+
+    const converted = convertInput("name", name);
+
+    expect(converted.key).toBe("name");
+    expect(converted.type).toBe("structuredObject");
+    expect(converted.inputs).toHaveLength(3);
+    expect(converted.inputs?.[0]).toMatchObject({
+      key: "first",
+      type: "string",
+      label: "First Name",
+      required: true,
+    });
+    expect(converted.inputs?.[2]).toMatchObject({
+      key: "prefix",
+      type: "string",
+      label: "Prefix",
+    });
+  });
+
+  it("does not emit `inputs` on a non-structuredObject input", () => {
+    const basicInput = input({ type: "string", label: "Basic" });
+    const converted = convertInput("basic", basicInput);
+    expect(converted.inputs).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -29,20 +29,48 @@ import {
   Input as ServerInput,
   Trigger as ServerTrigger,
 } from ".";
-import { createPerform, createPollingPerform, InputCleaners, PerformFn } from "./perform";
+import { CleanFn, createPerform, createPollingPerform, InputCleaners, PerformFn } from "./perform";
+
+/**
+ * StructuredObject inputs do not carry a `clean` function (they have no
+ * per-field value to clean — children carry their own). All other input
+ * variants of InputFieldDefinition optionally carry `clean`.
+ */
+const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined =>
+  "clean" in input ? (input.clean as CleanFn | undefined) : undefined;
 
 export const convertInput = (
   key: string,
-  {
+  definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
+): ServerInput => {
+  // Cast for destructure: TypeScript can't safely destructure properties
+  // that exist on only some members of the union (e.g. `default` is on
+  // leaves but not StructuredObjectInputField). The runtime checks below
+  // make this safe.
+  const {
     default: defaultValue,
     type,
     label,
     collection,
+    inputs: childInputs,
     ...rest
-  }: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
-): ServerInput => {
+  } = definition as {
+    default?: unknown;
+    type: InputFieldDefinition["type"] | "template";
+    label: string | { key: string; value: string };
+    collection?: "valuelist" | "keyvaluelist";
+    inputs?: Record<string, InputFieldDefinition>;
+    [key: string]: unknown;
+  };
   const keyLabel =
     collection === "keyvaluelist" && typeof label === "object" ? label.key : undefined;
+
+  const nestedInputs =
+    type === "structuredObject" && childInputs
+      ? Object.entries(childInputs).map(([childKey, childDef]) =>
+          convertInput(childKey, childDef as InputFieldDefinition),
+        )
+      : undefined;
 
   return {
     ...omit(rest, [
@@ -57,7 +85,8 @@ export const convertInput = (
     collection,
     label: typeof label === "string" ? label : label.value,
     keyLabel,
-    onPremiseControlled: ("onPremControlled" in rest && rest.onPremControlled) || undefined,
+    onPremiseControlled: rest.onPremControlled === true ? true : undefined,
+    inputs: nestedInputs,
   };
 };
 
@@ -131,7 +160,7 @@ const convertAction = (
 ): ServerAction => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
   const inputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 
@@ -175,7 +204,7 @@ export const convertTrigger = <
   });
 
   const triggerInputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 
@@ -185,8 +214,19 @@ export const convertTrigger = <
   let performToUse: PerformFn;
 
   if (isPollingTrigger) {
-    // Pull inputs up from the action and make them available on the trigger
-    const { pollAction: action } = trigger;
+    // Pull inputs up from the action and make them available on the trigger.
+    // The inline cast is needed because isPollingTriggerDefinition()'s type
+    // guard narrows on the call site only — assigning the result to the
+    // `isPollingTrigger` variable (used elsewhere in this function) doesn't
+    // carry the narrowing here.
+    const { pollAction: action } = trigger as PollingTriggerDefinition<
+      Inputs,
+      ConfigVarResultCollection,
+      TriggerPayload,
+      boolean,
+      any,
+      any
+    >;
     let actionInputCleaners: InputCleaners = {};
     scheduleSupport = "required";
 
@@ -199,14 +239,17 @@ export const convertTrigger = <
             );
           }
 
-          accum.push(convertInput(key, value));
+          accum.push(convertInput(key, value as InputFieldDefinition));
           return accum;
         },
         [],
       );
 
       actionInputCleaners = Object.entries(action.inputs).reduce<InputCleaners>(
-        (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+        (result, [key, value]) => ({
+          ...result,
+          [key]: cleanerFor(value as InputFieldDefinition),
+        }),
         {},
       );
     }
@@ -218,7 +261,7 @@ export const convertTrigger = <
       errorHandler: hooks?.error,
     });
   } else {
-    performToUse = createPerform(trigger.perform, {
+    performToUse = createPerform((trigger as TriggerDefinition<any>).perform, {
       inputCleaners: triggerInputCleaners,
       errorHandler: hooks?.error,
     });
@@ -293,7 +336,7 @@ const convertDataSource = (
 ): ServerDataSource => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
   const inputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -31,11 +31,6 @@ import {
 } from ".";
 import { CleanFn, createPerform, createPollingPerform, InputCleaners, PerformFn } from "./perform";
 
-/**
- * StructuredObject inputs do not carry a `clean` function (they have no
- * per-field value to clean — children carry their own). All other input
- * variants of InputFieldDefinition optionally carry `clean`.
- */
 const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined =>
   "clean" in input ? (input.clean as CleanFn | undefined) : undefined;
 
@@ -43,10 +38,8 @@ export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
-  // Cast for destructure: TypeScript can't safely destructure properties
-  // that exist on only some members of the union (e.g. `default` is on
-  // leaves but not StructuredObjectInputField). The runtime checks below
-  // make this safe.
+  // Cast: union members don't all carry `default`/`collection`/`inputs`;
+  // runtime guards below handle the differences.
   const {
     default: defaultValue,
     type,
@@ -214,11 +207,8 @@ export const convertTrigger = <
   let performToUse: PerformFn;
 
   if (isPollingTrigger) {
-    // Pull inputs up from the action and make them available on the trigger.
-    // The inline cast is needed because isPollingTriggerDefinition()'s type
-    // guard narrows on the call site only — assigning the result to the
-    // `isPollingTrigger` variable (used elsewhere in this function) doesn't
-    // carry the narrowing here.
+    // Cast: the type-guard call's narrowing doesn't survive being stored in
+    // `isPollingTrigger` and read here.
     const { pollAction: action } = trigger as PollingTriggerDefinition<
       Inputs,
       ConfigVarResultCollection,

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -32,7 +32,7 @@ import {
 import { CleanFn, createPerform, createPollingPerform, InputCleaners, PerformFn } from "./perform";
 
 const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined =>
-  "clean" in input ? (input.clean as CleanFn | undefined) : undefined;
+  "clean" in input ? (input.clean as CleanFn) : undefined;
 
 export const convertInput = (
   key: string,
@@ -189,7 +189,6 @@ export const convertTrigger = <
   const webhookLifecycleHandlers =
     "webhookLifecycleHandlers" in trigger ? trigger.webhookLifecycleHandlers : undefined;
   const inputs: Inputs = trigger.inputs ?? {};
-  const isPollingTrigger = isPollingTriggerDefinition(trigger);
 
   const triggerInputKeys = Object.keys(inputs);
   const convertedTriggerInputs = Object.entries(inputs).map(([key, value]) => {
@@ -206,17 +205,8 @@ export const convertTrigger = <
   let convertedActionInputs: Array<ServerInput> = [];
   let performToUse: PerformFn;
 
-  if (isPollingTrigger) {
-    // Cast: the type-guard call's narrowing doesn't survive being stored in
-    // `isPollingTrigger` and read here.
-    const { pollAction: action } = trigger as PollingTriggerDefinition<
-      Inputs,
-      ConfigVarResultCollection,
-      TriggerPayload,
-      boolean,
-      any,
-      any
-    >;
+  if (isPollingTriggerDefinition(trigger)) {
+    const { pollAction: action } = trigger;
     let actionInputCleaners: InputCleaners = {};
     scheduleSupport = "required";
 
@@ -251,7 +241,7 @@ export const convertTrigger = <
       errorHandler: hooks?.error,
     });
   } else {
-    performToUse = createPerform((trigger as TriggerDefinition<any>).perform, {
+    performToUse = createPerform(trigger.perform, {
       inputCleaners: triggerInputCleaners,
       errorHandler: hooks?.error,
     });
@@ -279,7 +269,7 @@ export const convertTrigger = <
         : scheduleSupport === "invalid"
           ? "valid"
           : "invalid",
-    ...(isPollingTrigger ? { isPollingTrigger: true } : {}),
+    ...(isPollingTriggerDefinition(trigger) ? { isPollingTrigger: true } : {}),
   };
 
   if (onInstanceDeploy) {

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,6 +364,13 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
+  /**
+   * Nested child inputs. Only populated when `type === "structuredObject"`.
+   * The platform's recursive InputFieldDefinition GraphQL input type accepts
+   * this shape and the publish pipeline walks the nested tree to write
+   * InputField rows with parent pointers.
+   */
+  inputs?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,12 +364,7 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  /**
-   * Nested child inputs. Only populated when `type === "structuredObject"`.
-   * The platform's recursive InputFieldDefinition GraphQL input type accepts
-   * this shape and the publish pipeline walks the nested tree to write
-   * InputField rows with parent pointers.
-   */
+  /** Nested child inputs; populated only when `type === "structuredObject"`. */
   inputs?: Input[];
 }
 

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -8,18 +8,8 @@ import type {
   StructuredObjectInputField,
 } from "./Inputs";
 
-/**
- * Resolves a single InputFieldDefinition's runtime value type.
- *
- * StructuredObject is dispatched first so the rest of the chain doesn't try
- * to index `clean`/`default`/`collection` against a member of the union that
- * lacks them. The runtime value for a structuredObject is a record of
- * resolved child values; emitting a precise typed record (matching the
- * declared children) is a follow-up to this work. Until that lands,
- * `unknown` is the safe fallback so the union of all per-field resolutions
- * still simplifies to `unknown` and doesn't break code that passes around a
- * generic `ActionInputParameters<Inputs>`.
- */
+/** Resolves a single InputFieldDefinition's runtime value type. structuredObject
+ * resolves to `unknown` until the per-field record-type recursion lands. */
 type InputValue<T> = T extends StructuredObjectInputField
   ? unknown
   : T extends { clean: InputCleanFunction<any> }

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -5,7 +5,35 @@ import type {
   InputFieldCollection,
   Inputs,
   KeyValuePair,
+  StructuredObjectInputField,
 } from "./Inputs";
+
+/**
+ * Resolves a single InputFieldDefinition's runtime value type.
+ *
+ * StructuredObject is dispatched first so the rest of the chain doesn't try
+ * to index `clean`/`default`/`collection` against a member of the union that
+ * lacks them. The runtime value for a structuredObject is a record of
+ * resolved child values; emitting a precise typed record (matching the
+ * declared children) is a follow-up to this work. Until that lands,
+ * `unknown` is the safe fallback so the union of all per-field resolutions
+ * still simplifies to `unknown` and doesn't break code that passes around a
+ * generic `ActionInputParameters<Inputs>`.
+ */
+type InputValue<T> = T extends StructuredObjectInputField
+  ? unknown
+  : T extends { clean: InputCleanFunction<any> }
+    ? ReturnType<T["clean"]>
+    : T extends { type: "connection"; collection?: infer C }
+      ? ExtractValue<Connection, C extends InputFieldCollection | undefined ? C : undefined>
+      : T extends { type: "conditional"; collection?: infer C }
+        ? ExtractValue<
+            ConditionalExpression,
+            C extends InputFieldCollection | undefined ? C : undefined
+          >
+        : T extends { default?: infer D; collection?: infer C }
+          ? ExtractValue<D, C extends InputFieldCollection | undefined ? C : undefined>
+          : unknown;
 
 /**
  * Collection of input parameters.
@@ -13,13 +41,7 @@ import type {
  * references to previous steps' outputs.
  */
 export type ActionInputParameters<TInputs extends Inputs> = {
-  [Property in keyof TInputs]: TInputs[Property]["clean"] extends InputCleanFunction<any>
-    ? ReturnType<TInputs[Property]["clean"]>
-    : TInputs[Property]["type"] extends "connection"
-      ? ExtractValue<Connection, TInputs[Property]["collection"]>
-      : TInputs[Property]["type"] extends "conditional"
-        ? ExtractValue<ConditionalExpression, TInputs[Property]["collection"]>
-        : ExtractValue<TInputs[Property]["default"], TInputs[Property]["collection"]>;
+  [Property in keyof TInputs]: InputValue<TInputs[Property]>;
 };
 
 export type ExtractValue<

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -14,15 +14,12 @@ type InputValue<T> = T extends StructuredObjectInputField
   ? unknown
   : T extends { clean: InputCleanFunction<any> }
     ? ReturnType<T["clean"]>
-    : T extends { type: "connection"; collection?: infer C }
-      ? ExtractValue<Connection, C extends InputFieldCollection | undefined ? C : undefined>
-      : T extends { type: "conditional"; collection?: infer C }
-        ? ExtractValue<
-            ConditionalExpression,
-            C extends InputFieldCollection | undefined ? C : undefined
-          >
-        : T extends { default?: infer D; collection?: infer C }
-          ? ExtractValue<D, C extends InputFieldCollection | undefined ? C : undefined>
+    : T extends { type: "connection"; collection?: InputFieldCollection }
+      ? ExtractValue<Connection, T["collection"]>
+      : T extends { type: "conditional"; collection?: InputFieldCollection }
+        ? ExtractValue<ConditionalExpression, T["collection"]>
+        : T extends { default?: unknown; collection?: InputFieldCollection }
+          ? ExtractValue<T["default"], T["collection"]>
           : unknown;
 
 /**

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -92,6 +92,7 @@ export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = 
   timestamp: "",
   flow: "",
   template: "",
+  structuredObject: undefined,
 };
 
 export type Inputs = Record<string, InputFieldDefinition>;
@@ -139,7 +140,8 @@ export type InputFieldDefinition =
   | DynamicFieldSelectionInputField
   | DateInputField
   | DateTimeInputField
-  | FlowInputField;
+  | FlowInputField
+  | StructuredObjectInputField;
 
 export type InputCleanFunction<TValue, TResult = TValue> = (value: TValue) => TResult;
 
@@ -379,6 +381,48 @@ export type DateTimeInputField = BaseInputField & {
   /** Clean function. */
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
+
+/**
+ * The non-structuredObject member of `InputFieldDefinition`. Used as the value
+ * type for `StructuredObjectInputField.inputs` to enforce the depth-1 cap at
+ * the type level — a structuredObject's children may not themselves be
+ * structuredObjects, which matches the platform-side validator.
+ */
+export type LeafInputFieldDefinition =
+  | StringInputField
+  | DataInputField
+  | TextInputField
+  | PasswordInputField
+  | BooleanInputField
+  | CodeInputField
+  | ConditionalInputField
+  | ConnectionInputField
+  | ConnectionTemplateInputField
+  | ObjectSelectionInputField
+  | ObjectFieldMapInputField
+  | JSONFormInputField
+  | DynamicObjectSelectionInputField
+  | DynamicFieldSelectionInputField
+  | DateInputField
+  | DateTimeInputField
+  | FlowInputField;
+
+/**
+ * Defines attributes of a StructuredObjectInputField. A structuredObject input
+ * groups a set of related primitive inputs under a single named container —
+ * the platform stores it as a flat list with a parent pointer; the FE
+ * reconstructs the tree for rendering. Children are restricted to
+ * non-structuredObject types (depth-1 cap).
+ */
+export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
+  /** Data type the input will collect. */
+  type: "structuredObject";
+  /**
+   * Nested input fields keyed by their local key. Children may not themselves
+   * be structuredObject inputs.
+   */
+  inputs: Record<string, LeafInputFieldDefinition>;
+};
 
 /** Defines a single Choice option for a InputField. */
 export interface InputFieldChoice {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -382,12 +382,8 @@ export type DateTimeInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/**
- * The non-structuredObject member of `InputFieldDefinition`. Used as the value
- * type for `StructuredObjectInputField.inputs` to enforce the depth-1 cap at
- * the type level — a structuredObject's children may not themselves be
- * structuredObjects, which matches the platform-side validator.
- */
+/** `InputFieldDefinition` minus `StructuredObjectInputField`; used to cap
+ * structuredObject nesting at one level. */
 export type LeafInputFieldDefinition =
   | StringInputField
   | DataInputField
@@ -407,20 +403,12 @@ export type LeafInputFieldDefinition =
   | DateTimeInputField
   | FlowInputField;
 
-/**
- * Defines attributes of a StructuredObjectInputField. A structuredObject input
- * groups a set of related primitive inputs under a single named container —
- * the platform stores it as a flat list with a parent pointer; the FE
- * reconstructs the tree for rendering. Children are restricted to
- * non-structuredObject types (depth-1 cap).
- */
+/** Groups related primitive inputs under a single named container.
+ * Nesting is capped at one level. */
 export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
   /** Data type the input will collect. */
   type: "structuredObject";
-  /**
-   * Nested input fields keyed by their local key. Children may not themselves
-   * be structuredObject inputs.
-   */
+  /** Nested input fields keyed by their local key. */
   inputs: Record<string, LeafInputFieldDefinition>;
 };
 

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -384,24 +384,7 @@ export type DateTimeInputField = BaseInputField & {
 
 /** `InputFieldDefinition` minus `StructuredObjectInputField`; used to cap
  * structuredObject nesting at one level. */
-export type LeafInputFieldDefinition =
-  | StringInputField
-  | DataInputField
-  | TextInputField
-  | PasswordInputField
-  | BooleanInputField
-  | CodeInputField
-  | ConditionalInputField
-  | ConnectionInputField
-  | ConnectionTemplateInputField
-  | ObjectSelectionInputField
-  | ObjectFieldMapInputField
-  | JSONFormInputField
-  | DynamicObjectSelectionInputField
-  | DynamicFieldSelectionInputField
-  | DateInputField
-  | DateTimeInputField
-  | FlowInputField;
+export type LeafInputFieldDefinition = Exclude<InputFieldDefinition, StructuredObjectInputField>;
 
 /** Groups related primitive inputs under a single named container.
  * Nesting is capped at one level. */


### PR DESCRIPTION
# Summary

Adds a new `structuredObject` input field type and a `structuredObjectInput()` factory function to the spectral SDK. Component authors can now group related primative inputs under a named container that the platform's component publishing accepts.

Example:
```
import { input, structuredObjectInput } from "@prismatic-io/spectral";

inputs: {
  name: structuredObjectInput({
    label: "Name",
    inputs: {
      first: input({ type: "string", label: "First Name", required: true }),
      last: input({ type: "string", label: "Last Name", required: true }),
      prefix: input({ type: "string", label: "Prefix" }),
    },
  }),
  email: input({ type: "string", label: "Email", required: true }),
}
```

# Changes

- New `StructuredObjectInputField` type added to `InputFieldDefinition` union. Has a `type` of `structuredObject` and a recursive `inputs: Record<string, LeafInputFieldDefinition>` member.
- New `LeafInputFieldDefinition` type alias is the union of all non-structuredObject members. Used as the children's allowed type to flag attempts to nest a structuredObject inside a structuredObject. This is due to a depth of 1 cap the api enforces.
- The `Input` interface gains an optional `inputs?: Input[]` field. Mirrors recursive `InputFieldDefinition` graphQL input type that the platform's `publishComponent` mutation accepts.
- `InputFieldDefaultMap` is extended with `structuredObject: unknown` to be circled back with in a later CNI update to add support for these nested objects.
- `ActionInputParameters` also maps `structuredObject` to `unknown` which will also be resolved in a later CNI update.  