### PR TITLE
Config vars should have configurable scheduleType

### DIFF
--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -280,6 +280,116 @@ describe("convertConfigVar", () => {
       );
     });
   });
+
+  describe("schedule config var handling", () => {
+    // In low-code, schedule-typed config variables can have a default of
+    // "Never" (scheduleType "none"), "Minute", "Hour", "Day", "Week", or
+    // "Custom" (a CRON expression). CNI should support the same set of
+    // defaults rather than always forcing scheduleType to "custom".
+
+    it("should default to scheduleType 'none' when no defaultValue is provided (Never)", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("scheduleType" in result && result.scheduleType).toBe("none");
+      expect("defaultValue" in result && result.defaultValue).toBeUndefined();
+    });
+
+    it("should treat an empty-string defaultValue as the 'Never' schedule (scheduleType 'none')", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+        defaultValue: "",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("scheduleType" in result && result.scheduleType).toBe("none");
+    });
+
+    it("should set scheduleType to 'custom' when a CRON expression is provided as defaultValue", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+        defaultValue: "*/5 * * * *",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("scheduleType" in result && result.scheduleType).toBe("custom");
+      expect("defaultValue" in result && result.defaultValue).toBe("*/5 * * * *");
+    });
+
+    it("should respect a user-specified scheduleType (e.g. 'hour')", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+        scheduleType: "hour",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("scheduleType" in result && result.scheduleType).toBe("hour");
+    });
+
+    it("should respect a user-specified scheduleType of 'none' (Never)", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+        scheduleType: "none",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("scheduleType" in result && result.scheduleType).toBe("none");
+    });
+
+    it("should preserve timeZone on schedule config vars", () => {
+      const scheduleConfigVar = configVar({
+        stableKey: "test-schedule",
+        dataType: "schedule",
+        timeZone: "America/Chicago",
+      });
+
+      const result = convertConfigVar(
+        "TestSchedule",
+        scheduleConfigVar,
+        referenceKey,
+        componentRegistry,
+      );
+
+      expect("timeZone" in result && result.timeZone).toBe("America/Chicago");
+    });
+  });
 });
 
 describe("convertQueueConfig", () => {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -965,7 +965,17 @@ export const convertConfigVar = (
   ) as ServerDefaultRequiredConfigVariable;
 
   if (isScheduleConfigVar(configVar)) {
-    result.scheduleType = "custom";
+    // Mirror the low-code options: callers may supply `scheduleType`
+    // explicitly ("none" / "minute" / "hour" / "day" / "week" / "custom").
+    // Otherwise infer from defaultValue: a non-empty string is treated as a
+    // custom CRON expression; missing/empty means "never".
+    if (configVar.scheduleType) {
+      result.scheduleType = configVar.scheduleType;
+    } else if (typeof defaultValue === "string" && defaultValue.length > 0) {
+      result.scheduleType = "custom";
+    } else {
+      result.scheduleType = "none";
+    }
   }
 
   if (isJsonFormConfigVar(configVar) || isJsonFormDataSourceConfigVar(configVar)) {

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -197,9 +197,23 @@ type BooleanConfigVar = CreateStandardConfigVar<"boolean">;
 
 type NumberConfigVar = CreateStandardConfigVar<"number">;
 
+/**
+ * Schedule type for a schedule-typed config variable. Mirrors the options
+ * available in low-code:
+ * - `"none"` (Never) - no schedule is set; the default when no `defaultValue` is provided.
+ * - `"minute"` / `"hour"` / `"day"` / `"week"` - run on the corresponding interval.
+ * - `"custom"` - run on a custom CRON expression supplied via `defaultValue`.
+ */
+export type ScheduleType = "none" | "custom" | "minute" | "hour" | "day" | "week";
+
 type ScheduleConfigVar = CreateStandardConfigVar<"schedule"> & {
   /** Timezone for the schedule. */
   timeZone?: string;
+  /**
+   * Optional schedule type. If omitted, this is inferred from `defaultValue`
+   * (`"none"` when there is no/empty `defaultValue`, otherwise `"custom"`).
+   */
+  scheduleType?: ScheduleType;
 };
 
 type ObjectSelectionConfigVar = CreateStandardConfigVar<"objectSelection">;


### PR DESCRIPTION
CNI never exposed scheduleType to authors and hard-coded "custom" in the converter, even though the platform has always accepted the full `"none" | "custom" | "minute" | "hour" | "day" | "week"` set — so this fix just plumbs scheduleType through to the converter, with a fallback inferred from defaultValue.