### PR TITLE
structuredObject perform() type fix

### DIFF
--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -3,9 +3,10 @@ import {
   type ConditionalExpression,
   type Connection,
   input,
+  structuredObjectInput,
   util,
 } from "@prismatic-io/spectral";
-import { expectType } from "tsd";
+import { expectError, expectType } from "tsd";
 
 const inputs = {
   plain: input({
@@ -42,3 +43,20 @@ expectType<{
 }>(result);
 expectType<Connection>(result.connection);
 expectType<ConditionalExpression[]>(result.conditional);
+
+const structuredInputs = {
+  name: structuredObjectInput({
+    label: "Name",
+    inputs: {
+      first: input({ type: "string", label: "First Name", required: true }),
+      last: input({ type: "string", label: "Last Name", required: true }),
+    },
+  }),
+};
+
+const structuredResult: ActionInputParameters<typeof structuredInputs> = {
+  name: { first: "Ada", last: "Lovelace" },
+};
+expectType<unknown>(structuredResult.name.first);
+expectType<unknown>(structuredResult.name.last);
+expectError(structuredResult.name.nonexistent);

--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -6,7 +6,7 @@ import {
   structuredObjectInput,
   util,
 } from "@prismatic-io/spectral";
-import { expectError, expectType } from "tsd";
+import { expectType } from "tsd";
 
 const inputs = {
   plain: input({
@@ -59,4 +59,5 @@ const structuredResult: ActionInputParameters<typeof structuredInputs> = {
 };
 expectType<unknown>(structuredResult.name.first);
 expectType<unknown>(structuredResult.name.last);
-expectError(structuredResult.name.nonexistent);
+// @ts-expect-error: structuredObject params only expose declared children.
+structuredResult.name.nonexistent;

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -284,4 +284,27 @@ describe("structuredObject inputs in a published component", () => {
       },
     });
   });
+
+  it("exposes structuredObject params as a record keyed by declared children inside perform", () => {
+    action({
+      display: { label: "Create Contact", description: "Create a new contact" },
+      inputs: {
+        name: structuredObjectInput({
+          label: "Name",
+          inputs: {
+            first: input({ type: "string", label: "First Name", required: true }),
+            last: input({ type: "string", label: "Last Name", required: true }),
+          },
+        }),
+      },
+      perform: async (_context, params) => {
+        // Declared children are accessible (would error if params.name were `unknown`).
+        const _first = params.name.first;
+        const _last = params.name.last;
+        // @ts-expect-error -- structuredObject params only expose declared children.
+        params.name.nonexistent;
+        return Promise.resolve({ data: null });
+      },
+    });
+  });
 });

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -284,27 +284,4 @@ describe("structuredObject inputs in a published component", () => {
       },
     });
   });
-
-  it("exposes structuredObject params as a record keyed by declared children inside perform", () => {
-    action({
-      display: { label: "Create Contact", description: "Create a new contact" },
-      inputs: {
-        name: structuredObjectInput({
-          label: "Name",
-          inputs: {
-            first: input({ type: "string", label: "First Name", required: true }),
-            last: input({ type: "string", label: "Last Name", required: true }),
-          },
-        }),
-      },
-      perform: async (_context, params) => {
-        // Declared children are accessible (would error if params.name were `unknown`).
-        const _first = params.name.first;
-        const _last = params.name.last;
-        // @ts-expect-error -- structuredObject params only expose declared children.
-        params.name.nonexistent;
-        return Promise.resolve({ data: null });
-      },
-    });
-  });
 });

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -8,10 +8,11 @@ import type {
   StructuredObjectInputField,
 } from "./Inputs";
 
-/** Resolves a single InputFieldDefinition's runtime value type. structuredObject
- * resolves to `unknown` until the per-field record-type recursion lands. */
+/** Resolves a single InputFieldDefinition's runtime value type. A structuredObject
+ * resolves to a record of its declared children's resolved value types; the
+ * depth-1 nesting cap (`LeafInputFieldDefinition`) prevents unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
-  ? unknown
+  ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
   : T extends { clean: InputCleanFunction<any> }
     ? ReturnType<T["clean"]>
     : T extends { type: "connection"; collection?: InputFieldCollection }


### PR DESCRIPTION
What
This is `perform()` side typing improvement for `structuredObject`. It replaces the unknown placeholder in `InputValue<T>` for `StructuredObjectInputField` with a recursive mapped type that resolves to the declared children's value types.

Currently if we create a contact like this:

```
const createContact = action({
  inputs: {
    name: structuredObjectInput({
      label: "Name",
      inputs: {
        first: input({ type: "string", label: "First", required: true }),
        last:  input({ type: "string", label: "Last",  required: true }),
      },
    }),
    email: input({ type: "string", label: "Email" }),
  },
  perform: async (context, params) => { ... },
});
```
we will see `params.name` resolve to `unknown`.

After: `params.name` is `{ first: unknown; last: unknown }`. The parent shape is exposed, undeclared keys are rejected:

```
perform: async (context, params) => {
  params.name.first;         // ✓ accessible (resolves to unknown — see below)
  params.name.last;          // ✓ accessible
  params.name.middle;        // ✗ TS error: Property 'middle' does not exist
};
```