### PR TITLE
Add CNI support for configuring triggers for batching

### DIFF
--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -155,7 +155,7 @@ export const flow = <
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
   T extends Flow<
     TInputs,
     TActionInputs,
@@ -164,7 +164,7 @@ export const flow = <
     TResult,
     TTriggerPayload,
     TItem,
-    TDiscoveryState
+    TPaginationState
   > = Flow<
     TInputs,
     TActionInputs,
@@ -173,15 +173,15 @@ export const flow = <
     TResult,
     TTriggerPayload,
     TItem,
-    TDiscoveryState
+    TPaginationState
   >,
 >(
-  // The intersection adds an explicit inference site for `TItem`/`TDiscoveryState` that the
+  // The intersection adds an explicit inference site for `TItem`/`TPaginationState` that the
   // `T extends Flow<...>` capture alone does not provide, while `T` still preserves the precise
   // literal type for the return value. They are inferred from a batched `trigger`'s
   // `items`/pagination-state types (see `batchFlowTrigger`).
   definition: T & {
-    trigger?: BatchTrigger<TItem, TDiscoveryState>;
+    trigger?: BatchTrigger<TItem, TPaginationState>;
   },
 ): T => definition;
 
@@ -189,17 +189,17 @@ export const flow = <
  * Builds a flow's batched `trigger` — the ergonomic way to define a batching flow. Instead of
  * writing `onTrigger`/`onDeployTrigger` (returning a full payload) plus `triggerResolver`/
  * `onDeployResolver` (to extract and paginate), each trigger fire returns `{ items,
- * discoveryState? }`: the records to dispatch and, when paginating, the cursor for the next
+ * paginationState? }`: the records to dispatch and, when paginating, the cursor for the next
  * page. spectral wraps the items into the wire payload and synthesizes the `resolveItems` and
- * `getNextDiscoveryState` that read them back — there is no separate pagination callback.
+ * `getNextPaginationState` that read them back — there is no separate pagination callback.
  *
  * Supply the item and pagination-state types explicitly —
  * `batchFlowTrigger<Order, { cursor: number }>({ ... })`. They flow through the whole flow:
- * the trigger fires return `Order[]`, `payload.discoveryState` reads back as `{ cursor: number }`,
+ * the trigger fires return `Order[]`, `payload.paginationState` reads back as `{ cursor: number }`,
  * and the flow's `onExecution` sees `params.onTrigger.results.body.data` typed as `Order | Order[]`.
  *
  * @typeParam TItem - the item type each batched execution receives.
- * @typeParam TPaginationState - the pagination state round-tripped via `payload.discoveryState`.
+ * @typeParam TPaginationState - the pagination state round-tripped via `payload.paginationState`.
  * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
  * @example
  * import { flow, batchFlowTrigger } from "@prismatic-io/spectral";
@@ -210,10 +210,10 @@ export const flow = <
  *   batchConfig: { batchSize: 50 },
  *   trigger: batchFlowTrigger<Order, { cursor: number }>({
  *     onTrigger: async (context, payload) => {
- *       const page = await fetchOrders(payload.discoveryState?.cursor);
+ *       const page = await fetchOrders(payload.paginationState?.cursor);
  *       return {
  *         items: page.orders,
- *         discoveryState: page.nextCursor ? { cursor: page.nextCursor } : null,
+ *         paginationState: page.nextCursor ? { cursor: page.nextCursor } : null,
  *       };
  *     },
  *   }),

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -14,6 +14,7 @@ import type {
   ComponentManifest,
   ConfigPage,
   ConfigVarResultCollection,
+  ConfigVars,
   ConnectionConfigVar,
   CustomerActivatedConnectionConfigVar,
   DataSourceConfigVar,
@@ -32,6 +33,7 @@ import type {
   StructuredObjectInputField,
   TriggerDefinition,
   TriggerPayload,
+  TriggerResolverBehavior,
   TriggerResult,
 } from "./types";
 import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
@@ -153,17 +155,91 @@ export const flow = <
     TPayload
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
   T extends Flow<
     TInputs,
     TActionInputs,
     TPayload,
     TAllowsBranching,
     TResult,
-    TTriggerPayload
-  > = Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, TTriggerPayload>,
+    TTriggerPayload,
+    TItem,
+    TDiscoveryState
+  > = Flow<
+    TInputs,
+    TActionInputs,
+    TPayload,
+    TAllowsBranching,
+    TResult,
+    TTriggerPayload,
+    TItem,
+    TDiscoveryState
+  >,
 >(
-  definition: T,
+  // The intersection adds an explicit inference site for `TItem`/`TDiscoveryState`
+  // (from the resolver's `resolveItems` / `getNextDiscoveryState` return types) that
+  // the `T extends Flow<...>` capture alone does not provide, while `T` still preserves
+  // the precise literal type for the return value.
+  definition: T & {
+    triggerResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
+    onDeployResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
+  },
 ): T => definition;
+
+/**
+ * Builds a flow's `triggerResolver` — the behavior that extracts the records a trigger
+ * returns into batched dispatches and (optionally) paginates. Batch *sizing* comes from
+ * the flow's `batch` config, not from here. Supply the item and pagination-cursor types
+ * explicitly — `triggerResolver<Order, { cursor: number }>({ ... })` — and they flow
+ * through the whole chain: `resolveItems` returns `Order[]`, `result.payload.discoveryState`
+ * reads back as `{ cursor: number }`, and the flow's `onExecution` sees
+ * `params.onTrigger.results.body.data` typed as `Order | Order[]`.
+ *
+ * @typeParam TItem - the item type each batched execution receives.
+ * @typeParam TDiscoveryState - the pagination cursor shape round-tripped via `payload.discoveryState`.
+ * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
+ * @example
+ * import { flow, triggerResolver } from "@prismatic-io/spectral";
+ *
+ * flow({
+ *   // ...
+ *   batch: { batchSize: 50 },
+ *   triggerResolver: triggerResolver<Order, { cursor: number }>({
+ *     resolveItems: (context, result) => result.payload.body.data as Order[],
+ *     getNextDiscoveryState: (context, result) => {
+ *       const next = result.payload.discoveryState?.cursor; // number | undefined
+ *       return next === undefined ? null : { cursor: next };
+ *     },
+ *   }),
+ * });
+ */
+export const triggerResolver = <
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TConfigVars extends ConfigVarResultCollection = ConfigVars,
+  TPayload extends TriggerPayload = TriggerPayload,
+>(
+  resolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>,
+): TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState> => resolver;
+
+/**
+ * Builds a flow's `onDeployResolver` — the resolver behavior for the `onDeployTrigger`
+ * fire that runs once when an instance is first deployed. Identical in shape to
+ * {@link triggerResolver} and shares the flow's `batch` config; named separately so the
+ * call site reads as the sibling of `onDeployTrigger`.
+ *
+ * @typeParam TItem - the item type each batched on-deploy execution receives.
+ * @typeParam TDiscoveryState - the pagination cursor shape round-tripped via `payload.discoveryState`.
+ */
+export const onDeployResolver = <
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TConfigVars extends ConfigVarResultCollection = ConfigVars,
+  TPayload extends TriggerPayload = TriggerPayload,
+>(
+  resolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>,
+): TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState> => resolver;
 
 /**
  * This function creates a config wizard page object for use in code-native

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -188,9 +188,10 @@ export const flow = <
 /**
  * Builds a flow's batched `trigger` — the ergonomic way to define a batching flow. Instead of
  * writing `onTrigger`/`onDeployTrigger` (returning a full payload) plus `triggerResolver`/
- * `onDeployResolver` (to extract and paginate), the trigger fires return just their `items` and
- * the pagination callbacks live alongside them. spectral wraps the items into the wire payload
- * and synthesizes the `resolveItems` that reads them back.
+ * `onDeployResolver` (to extract and paginate), each trigger fire returns `{ items,
+ * discoveryState? }`: the records to dispatch and, when paginating, the cursor for the next
+ * page. spectral wraps the items into the wire payload and synthesizes the `resolveItems` and
+ * `getNextDiscoveryState` that read them back — there is no separate pagination callback.
  *
  * Supply the item and pagination-state types explicitly —
  * `batchFlowTrigger<Order, { cursor: number }>({ ... })`. They flow through the whole flow:
@@ -210,11 +211,10 @@ export const flow = <
  *   trigger: batchFlowTrigger<Order, { cursor: number }>({
  *     onTrigger: async (context, payload) => {
  *       const page = await fetchOrders(payload.discoveryState?.cursor);
- *       return { items: page.orders };
- *     },
- *     getNextOnTriggerPaginationState: (context, result) => {
- *       const next = result.payload.discoveryState?.cursor;
- *       return next === undefined ? null : { cursor: next };
+ *       return {
+ *         items: page.orders,
+ *         discoveryState: page.nextCursor ? { cursor: page.nextCursor } : null,
+ *       };
  *     },
  *   }),
  *   onExecution: async (context, params) => {

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -10,11 +10,11 @@ import { convertIntegration } from "./serverTypes/convertIntegration";
 import type {
   ActionDefinition,
   ActionPerformReturn,
+  BatchTrigger,
   ComponentDefinition,
   ComponentManifest,
   ConfigPage,
   ConfigVarResultCollection,
-  ConfigVars,
   ConnectionConfigVar,
   CustomerActivatedConnectionConfigVar,
   DataSourceConfigVar,
@@ -33,7 +33,6 @@ import type {
   StructuredObjectInputField,
   TriggerDefinition,
   TriggerPayload,
-  TriggerResolverBehavior,
   TriggerResult,
 } from "./types";
 import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
@@ -177,69 +176,59 @@ export const flow = <
     TDiscoveryState
   >,
 >(
-  // The intersection adds an explicit inference site for `TItem`/`TDiscoveryState`
-  // (from the resolver's `resolveItems` / `getNextDiscoveryState` return types) that
-  // the `T extends Flow<...>` capture alone does not provide, while `T` still preserves
-  // the precise literal type for the return value.
+  // The intersection adds an explicit inference site for `TItem`/`TDiscoveryState` that the
+  // `T extends Flow<...>` capture alone does not provide, while `T` still preserves the precise
+  // literal type for the return value. They are inferred from a batched `trigger`'s
+  // `items`/pagination-state types (see `batchFlowTrigger`).
   definition: T & {
-    triggerResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
-    onDeployResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
+    trigger?: BatchTrigger<TItem, TDiscoveryState>;
   },
 ): T => definition;
 
 /**
- * Builds a flow's `triggerResolver` — the behavior that extracts the records a trigger
- * returns into batched dispatches and (optionally) paginates. Batch *sizing* comes from
- * the flow's `batch` config, not from here. Supply the item and pagination-cursor types
- * explicitly — `triggerResolver<Order, { cursor: number }>({ ... })` — and they flow
- * through the whole chain: `resolveItems` returns `Order[]`, `result.payload.discoveryState`
- * reads back as `{ cursor: number }`, and the flow's `onExecution` sees
- * `params.onTrigger.results.body.data` typed as `Order | Order[]`.
+ * Builds a flow's batched `trigger` — the ergonomic way to define a batching flow. Instead of
+ * writing `onTrigger`/`onDeployTrigger` (returning a full payload) plus `triggerResolver`/
+ * `onDeployResolver` (to extract and paginate), the trigger fires return just their `items` and
+ * the pagination callbacks live alongside them. spectral wraps the items into the wire payload
+ * and synthesizes the `resolveItems` that reads them back.
+ *
+ * Supply the item and pagination-state types explicitly —
+ * `batchFlowTrigger<Order, { cursor: number }>({ ... })`. They flow through the whole flow:
+ * the trigger fires return `Order[]`, `payload.discoveryState` reads back as `{ cursor: number }`,
+ * and the flow's `onExecution` sees `params.onTrigger.results.body.data` typed as `Order | Order[]`.
  *
  * @typeParam TItem - the item type each batched execution receives.
- * @typeParam TDiscoveryState - the pagination cursor shape round-tripped via `payload.discoveryState`.
+ * @typeParam TPaginationState - the pagination state round-tripped via `payload.discoveryState`.
  * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
  * @example
- * import { flow, triggerResolver } from "@prismatic-io/spectral";
+ * import { flow, batchFlowTrigger } from "@prismatic-io/spectral";
  *
  * flow({
- *   // ...
- *   batch: { batchSize: 50 },
- *   triggerResolver: triggerResolver<Order, { cursor: number }>({
- *     resolveItems: (context, result) => result.payload.body.data as Order[],
- *     getNextDiscoveryState: (context, result) => {
- *       const next = result.payload.discoveryState?.cursor; // number | undefined
+ *   name: "Sync Orders",
+ *   stableKey: "sync-orders",
+ *   batchConfig: { batchSize: 50 },
+ *   trigger: batchFlowTrigger<Order, { cursor: number }>({
+ *     onTrigger: async (context, payload) => {
+ *       const page = await fetchOrders(payload.discoveryState?.cursor);
+ *       return { items: page.orders };
+ *     },
+ *     getNextOnTriggerPaginationState: (context, result) => {
+ *       const next = result.payload.discoveryState?.cursor;
  *       return next === undefined ? null : { cursor: next };
  *     },
  *   }),
+ *   onExecution: async (context, params) => {
+ *     const orders = params.onTrigger.results.body.data; // Order | Order[]
+ *     return { data: orders };
+ *   },
  * });
  */
-export const triggerResolver = <
-  TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
-  TConfigVars extends ConfigVarResultCollection = ConfigVars,
-  TPayload extends TriggerPayload = TriggerPayload,
+export const batchFlowTrigger = <
+  TItem,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 >(
-  resolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>,
-): TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState> => resolver;
-
-/**
- * Builds a flow's `onDeployResolver` — the resolver behavior for the `onDeployTrigger`
- * fire that runs once when an instance is first deployed. Identical in shape to
- * {@link triggerResolver} and shares the flow's `batch` config; named separately so the
- * call site reads as the sibling of `onDeployTrigger`.
- *
- * @typeParam TItem - the item type each batched on-deploy execution receives.
- * @typeParam TDiscoveryState - the pagination cursor shape round-tripped via `payload.discoveryState`.
- */
-export const onDeployResolver = <
-  TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
-  TConfigVars extends ConfigVarResultCollection = ConfigVars,
-  TPayload extends TriggerPayload = TriggerPayload,
->(
-  resolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>,
-): TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState> => resolver;
+  trigger: BatchTrigger<TItem, TPaginationState>,
+): BatchTrigger<TItem, TPaginationState> => trigger;
 
 /**
  * This function creates a config wizard page object for use in code-native

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -470,12 +470,13 @@ const baseTrigger = {
 };
 
 describe("convertTrigger triggerResolver", () => {
-  it("defaults triggerResolverSupport to 'valid' when triggerResolver is declared without explicit support", () => {
+  it("defaults triggerResolverSupport to 'valid' when triggerResolver is declared, emitting the shared batch default", () => {
     const result = convertTrigger(
       "myTrigger",
       trigger({
         ...baseTrigger,
-        triggerResolver: { default: { batchSize: 50 } },
+        batchConfig: { batchSize: 50 },
+        triggerResolver: { resolveItems: () => [1, 2, 3] },
       }),
     );
     expect(result.triggerResolverSupport).toBe("valid");
@@ -489,7 +490,7 @@ describe("convertTrigger triggerResolver", () => {
     expect(result.hasResolveTriggerItems).toBeUndefined();
   });
 
-  it("emits default batchSize 1 when triggerResolverSupport is 'valid' without a triggerResolver", () => {
+  it("emits default batchSize 1 when triggerResolverSupport is 'valid' without a batch config", () => {
     const result = convertTrigger(
       "myTrigger",
       trigger({
@@ -520,31 +521,32 @@ describe("convertTrigger triggerResolver", () => {
         trigger({
           ...baseTrigger,
           triggerResolverSupport: "invalid",
-          triggerResolver: { default: { batchSize: 50 } },
+          triggerResolver: { resolveItems: () => [1, 2, 3] },
         }),
       ),
     ).toThrow(/triggerResolver but triggerResolverSupport is "invalid"/);
   });
 
-  it("rejects triggerResolver with batchSize < 1", () => {
+  it("rejects a batch config with batchSize < 1", () => {
     expect(() =>
       convertTrigger(
         "myTrigger",
         trigger({
           ...baseTrigger,
-          triggerResolver: { default: { batchSize: 0 } },
+          batchConfig: { batchSize: 0 },
+          triggerResolver: { resolveItems: () => [1, 2, 3] },
         }),
       ),
-    ).toThrow(/invalid triggerResolver\.default batchSize of 0/);
+    ).toThrow(/invalid batchConfig batchSize of 0/);
   });
 
-  it("preserves resolveItems on triggerResolver", () => {
+  it("preserves resolveItems on triggerResolver and shares the batch default", () => {
     const result = convertTrigger(
       "myTrigger",
       trigger({
         ...baseTrigger,
+        batchConfig: { batchSize: 25 },
         triggerResolver: {
-          default: { batchSize: 25 },
           resolveItems: () => [1, 2, 3],
         },
       }),
@@ -552,5 +554,87 @@ describe("convertTrigger triggerResolver", () => {
     expect(result.hasResolveTriggerItems).toBe(true);
     expect(result.triggerResolverDefaultBatchSize).toBe(25);
     expect(typeof result.resolveTriggerItems).toBe("function");
+  });
+});
+
+describe("convertTrigger on-deploy", () => {
+  it("fires on deploy when onDeployPerform is declared; no resolver means no batch default", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+      }),
+    );
+    expect(result.hasOnDeployPerform).toBe(true);
+    // No resolver to batch → no default batch size is emitted.
+    expect(result.triggerResolverDefaultBatchSize).toBeUndefined();
+  });
+
+  it("emits the shared batch default when an onDeployResolver is declared", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 50 },
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+        onDeployResolver: { resolveItems: () => [1, 2, 3] },
+      }),
+    );
+    expect(result.hasResolveOnDeployItems).toBe(true);
+    expect(result.hasOnDeployPerform).toBe(true);
+    expect(result.triggerResolverDefaultBatchSize).toBe(50);
+  });
+
+  it("emits no on-deploy fields when neither onDeployPerform nor onDeployResolver is declared", () => {
+    const result = convertTrigger("myTrigger", trigger(baseTrigger));
+    expect(result.hasOnDeployPerform).toBeUndefined();
+    expect(result.hasResolveOnDeployItems).toBeUndefined();
+    expect(result.triggerResolverDefaultBatchSize).toBeUndefined();
+  });
+
+  it("rejects an onDeployResolver.resolveItems without onDeployPerform", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          batchConfig: { batchSize: 10 },
+          // @ts-expect-error - onDeployResolver requires onDeployPerform
+          onDeployResolver: { resolveItems: () => [1, 2, 3] },
+        }),
+      ),
+    ).toThrow(/onDeployResolver\.resolveItems but is missing onDeployPerform/);
+  });
+
+  it("rejects a batchConfig with batchSize < 1 on the on-deploy path", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          batchConfig: { batchSize: 0 },
+          onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+          onDeployResolver: { resolveItems: () => [1, 2, 3] },
+        }),
+      ),
+    ).toThrow(/invalid batchConfig batchSize of 0/);
+  });
+
+  it("preserves resolveItems on onDeployResolver", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 25 },
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+        onDeployResolver: {
+          resolveItems: () => [1, 2, 3],
+        },
+      }),
+    );
+    expect(result.hasResolveOnDeployItems).toBe(true);
+    expect(result.triggerResolverDefaultBatchSize).toBe(25);
+    expect(typeof result.resolveOnDeployItems).toBe("function");
   });
 });

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -555,6 +555,43 @@ describe("convertTrigger triggerResolver", () => {
     expect(result.triggerResolverDefaultBatchSize).toBe(25);
     expect(typeof result.resolveTriggerItems).toBe("function");
   });
+
+  it("emits the shared concurrentBatchLimit when set on batchConfig", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 50, concurrentBatchLimit: 5 },
+        triggerResolver: { resolveItems: () => [1, 2, 3] },
+      }),
+    );
+    expect(result.triggerResolverDefaultConcurrentBatchLimit).toBe(5);
+  });
+
+  it("omits concurrentBatchLimit when not set on batchConfig", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 50 },
+        triggerResolver: { resolveItems: () => [1, 2, 3] },
+      }),
+    );
+    expect(result.triggerResolverDefaultConcurrentBatchLimit).toBeUndefined();
+  });
+
+  it("rejects a batch config with concurrentBatchLimit < 1", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          batchConfig: { batchSize: 50, concurrentBatchLimit: 0 },
+          triggerResolver: { resolveItems: () => [1, 2, 3] },
+        }),
+      ),
+    ).toThrow(/invalid batchConfig concurrentBatchLimit of 0/);
+  });
 });
 
 describe("convertTrigger on-deploy", () => {

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { connection, dynamicObjectInput, input, structuredObjectInput } from "..";
+import { connection, dynamicObjectInput, input, structuredObjectInput, trigger } from "..";
 import {
   cleanerFor,
   convertConnection,
   convertInput,
   convertTemplateInput,
+  convertTrigger,
 } from "./convertComponent";
 
 describe("convertConnection", () => {
@@ -457,5 +458,99 @@ describe("cleanerFor", () => {
       expect(cleaner?.(undefined)).toBeUndefined();
       expect(cleaner?.(null)).toBeNull();
     });
+  });
+});
+
+const baseTrigger = {
+  display: { label: "My Trigger", description: "" },
+  perform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+  inputs: {},
+  scheduleSupport: "invalid" as const,
+  synchronousResponseSupport: "invalid" as const,
+};
+
+describe("convertTrigger triggerResolver", () => {
+  it("defaults triggerResolverSupport to 'valid' when triggerResolver is declared without explicit support", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        triggerResolver: { default: { batchSize: 50 } },
+      }),
+    );
+    expect(result.triggerResolverSupport).toBe("valid");
+    expect(result.triggerResolverDefaultBatchSize).toBe(50);
+  });
+
+  it("defaults triggerResolverSupport to 'invalid' when no triggerResolver is declared", () => {
+    const result = convertTrigger("myTrigger", trigger(baseTrigger));
+    expect(result.triggerResolverSupport).toBe("invalid");
+    expect(result.triggerResolverDefaultBatchSize).toBeUndefined();
+    expect(result.hasResolveTriggerItems).toBeUndefined();
+  });
+
+  it("emits default batchSize 1 when triggerResolverSupport is 'valid' without a triggerResolver", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        triggerResolverSupport: "valid",
+      }),
+    );
+    expect(result.triggerResolverSupport).toBe("valid");
+    expect(result.triggerResolverDefaultBatchSize).toBe(1);
+  });
+
+  it("rejects triggerResolverSupport='required' without triggerResolver", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          triggerResolverSupport: "required",
+        }),
+      ),
+    ).toThrow(/triggerResolverSupport "required" but is missing triggerResolver/);
+  });
+
+  it("rejects triggerResolverSupport='invalid' when triggerResolver is set", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          triggerResolverSupport: "invalid",
+          triggerResolver: { default: { batchSize: 50 } },
+        }),
+      ),
+    ).toThrow(/triggerResolver but triggerResolverSupport is "invalid"/);
+  });
+
+  it("rejects triggerResolver with batchSize < 1", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          triggerResolver: { default: { batchSize: 0 } },
+        }),
+      ),
+    ).toThrow(/invalid triggerResolver\.default batchSize of 0/);
+  });
+
+  it("preserves resolveItems on triggerResolver", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        triggerResolver: {
+          default: { batchSize: 25 },
+          resolveItems: () => [1, 2, 3],
+        },
+      }),
+    );
+    expect(result.hasResolveTriggerItems).toBe(true);
+    expect(result.triggerResolverDefaultBatchSize).toBe(25);
+    expect(typeof result.resolveTriggerItems).toBe("function");
   });
 });

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -21,6 +21,7 @@ import {
   isPollingTriggerDefinition,
   type PollingTriggerDefinition,
 } from "../types/PollingTriggerDefinition";
+import type { TriggerResolver } from "../types/TriggerDefinition";
 import type {
   Action as ServerAction,
   Component as ServerComponent,
@@ -96,6 +97,56 @@ export const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined => 
   }
 
   return "clean" in input ? (input.clean as CleanFn) : undefined;
+};
+
+/**
+ * Throws if `batchSize` isn't a positive integer; otherwise returns it.
+ * Shared by both component-trigger (`TriggerResolver.default.batchSize`) and
+ * CNI flow (`TriggerResolverConfig.batchSize`) validation paths.
+ */
+export const validateBatchSize = (
+  ownerLabel: string,
+  fieldName: string,
+  batchSize: unknown,
+): number => {
+  if (typeof batchSize !== "number" || !Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error(
+      `${ownerLabel} has an invalid ${fieldName} batchSize of ${String(batchSize)}. batchSize must be an integer >= 1.`,
+    );
+  }
+  return batchSize;
+};
+
+const buildTriggerResolverFields = <
+  TConfigVars extends ConfigVarResultCollection,
+  TPayload extends TriggerPayload,
+>(
+  triggerLabel: string,
+  support: TriggerOptionChoice,
+  resolver: TriggerResolver<TConfigVars, TPayload> | undefined,
+) => {
+  if (!resolver) {
+    return support === "invalid" ? {} : { triggerResolverDefaultBatchSize: 1 };
+  }
+  return {
+    triggerResolverDefaultBatchSize: validateBatchSize(
+      `Trigger "${triggerLabel}"`,
+      "triggerResolver.default",
+      resolver.default.batchSize,
+    ),
+    ...(resolver.resolveItems
+      ? {
+          resolveTriggerItems: resolver.resolveItems,
+          hasResolveTriggerItems: true,
+        }
+      : {}),
+    ...(resolver.getNextDiscoveryState
+      ? {
+          getNextDiscoveryState: resolver.getNextDiscoveryState,
+          hasGetNextDiscoveryState: true,
+        }
+      : {}),
+  };
 };
 
 export const convertInput = (
@@ -284,6 +335,25 @@ export const convertTrigger = <
 
   let scheduleSupport: TriggerOptionChoice =
     "scheduleSupport" in trigger ? trigger.scheduleSupport : "invalid";
+
+  const triggerResolver = "triggerResolver" in trigger ? trigger.triggerResolver : undefined;
+  const triggerResolverSupport: TriggerOptionChoice =
+    "triggerResolverSupport" in trigger && trigger.triggerResolverSupport !== undefined
+      ? trigger.triggerResolverSupport
+      : triggerResolver
+        ? "valid"
+        : "invalid";
+  if (triggerResolverSupport === "required" && !triggerResolver) {
+    throw new Error(
+      `Trigger "${trigger.display.label}" declares triggerResolverSupport "required" but is missing triggerResolver.`,
+    );
+  }
+  if (triggerResolverSupport === "invalid" && triggerResolver) {
+    throw new Error(
+      `Trigger "${trigger.display.label}" declares triggerResolver but triggerResolverSupport is "invalid".`,
+    );
+  }
+
   let convertedActionInputs: Array<ServerInput> = [];
   let performToUse: PerformFn;
 
@@ -351,6 +421,8 @@ export const convertTrigger = <
         : scheduleSupport === "invalid"
           ? "valid"
           : "invalid",
+    triggerResolverSupport,
+    ...buildTriggerResolverFields(trigger.display.label, triggerResolverSupport, triggerResolver),
     ...(isPollingTriggerDefinition(trigger) ? { isPollingTrigger: true } : {}),
   };
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -118,6 +118,31 @@ export const validateBatchSize = (
 };
 
 /**
+ * Throws if `concurrentBatchLimit` is set but isn't a positive integer; returns it
+ * unchanged (including `undefined`, which the platform treats as unlimited). Shared by the
+ * component-trigger and CNI flow paths, both sourcing it from the single `batchConfig`.
+ */
+export const validateConcurrentBatchLimit = (
+  ownerLabel: string,
+  fieldName: string,
+  concurrentBatchLimit: unknown,
+): number | undefined => {
+  if (concurrentBatchLimit === undefined) {
+    return undefined;
+  }
+  if (
+    typeof concurrentBatchLimit !== "number" ||
+    !Number.isInteger(concurrentBatchLimit) ||
+    concurrentBatchLimit < 1
+  ) {
+    throw new Error(
+      `${ownerLabel} has an invalid ${fieldName} concurrentBatchLimit of ${String(concurrentBatchLimit)}. concurrentBatchLimit must be an integer >= 1.`,
+    );
+  }
+  return concurrentBatchLimit;
+};
+
+/**
  * Emits the trigger's single default batch size to the one wire field the platform reads
  * (`triggerResolverDefaultBatchSize`), shared by both the trigger and on-deploy resolution.
  * Emitted when the trigger declares a resolver — `triggerResolverSupport` `"valid"`/`"required"`
@@ -133,10 +158,20 @@ const buildBatchDefaultField = (
   if (triggerResolverSupport === "invalid" && !hasOnDeployResolver) {
     return {};
   }
+  const concurrentBatchLimit = batchConfig
+    ? validateConcurrentBatchLimit(
+        `Trigger "${triggerLabel}"`,
+        "batchConfig",
+        batchConfig.concurrentBatchLimit,
+      )
+    : undefined;
   return {
     triggerResolverDefaultBatchSize: batchConfig
       ? validateBatchSize(`Trigger "${triggerLabel}"`, "batchConfig", batchConfig.batchSize)
       : 1,
+    ...(concurrentBatchLimit !== undefined
+      ? { triggerResolverDefaultConcurrentBatchLimit: concurrentBatchLimit }
+      : {}),
   };
 };
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -32,7 +32,6 @@ import type {
 } from ".";
 import {
   type CleanFn,
-  aliasPaginationState,
   cleanParams,
   createPerform,
   createPollingPerform,
@@ -189,20 +188,13 @@ const buildTriggerResolverFields = <
   return {
     ...(resolveItems
       ? {
-          resolveTriggerItems: (...[context, result]: Parameters<typeof resolveItems>) =>
-            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
+          resolveTriggerItems: resolveItems,
           hasResolveTriggerItems: true,
         }
       : {}),
     ...(getNextPaginationState
       ? {
-          // Wire name stays `getNextDiscoveryState` (the backend contract); the author's
-          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
-          getNextDiscoveryState: (...[context, result]: Parameters<typeof getNextPaginationState>) =>
-            getNextPaginationState(context, {
-              ...result,
-              payload: aliasPaginationState(result.payload),
-            }),
+          getNextPaginationState,
           hasGetNextDiscoveryState: true,
         }
       : {}),
@@ -222,22 +214,13 @@ const buildOnDeployResolverFields = <
   return {
     ...(resolveItems
       ? {
-          resolveOnDeployItems: (...[context, result]: Parameters<typeof resolveItems>) =>
-            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
+          resolveOnDeployItems: resolveItems,
           hasResolveOnDeployItems: true,
         }
       : {}),
     ...(getNextPaginationState
       ? {
-          // Wire name stays `getOnDeployNextDiscoveryState` (the backend contract); the author's
-          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
-          getOnDeployNextDiscoveryState: (
-            ...[context, result]: Parameters<typeof getNextPaginationState>
-          ) =>
-            getNextPaginationState(context, {
-              ...result,
-              payload: aliasPaginationState(result.payload),
-            }),
+          getOnDeployNextPaginationState: getNextPaginationState,
           hasGetOnDeployNextDiscoveryState: true,
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -32,6 +32,7 @@ import type {
 } from ".";
 import {
   type CleanFn,
+  aliasPaginationState,
   cleanParams,
   createPerform,
   createPollingPerform,
@@ -184,16 +185,24 @@ const buildTriggerResolverFields = <
   if (!resolver) {
     return {};
   }
+  const { resolveItems, getNextPaginationState } = resolver;
   return {
-    ...(resolver.resolveItems
+    ...(resolveItems
       ? {
-          resolveTriggerItems: resolver.resolveItems,
+          resolveTriggerItems: (...[context, result]: Parameters<typeof resolveItems>) =>
+            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
           hasResolveTriggerItems: true,
         }
       : {}),
-    ...(resolver.getNextDiscoveryState
+    ...(getNextPaginationState
       ? {
-          getNextDiscoveryState: resolver.getNextDiscoveryState,
+          // Wire name stays `getNextDiscoveryState` (the backend contract); the author's
+          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
+          getNextDiscoveryState: (...[context, result]: Parameters<typeof getNextPaginationState>) =>
+            getNextPaginationState(context, {
+              ...result,
+              payload: aliasPaginationState(result.payload),
+            }),
           hasGetNextDiscoveryState: true,
         }
       : {}),
@@ -209,16 +218,26 @@ const buildOnDeployResolverFields = <
   if (!resolver) {
     return {};
   }
+  const { resolveItems, getNextPaginationState } = resolver;
   return {
-    ...(resolver.resolveItems
+    ...(resolveItems
       ? {
-          resolveOnDeployItems: resolver.resolveItems,
+          resolveOnDeployItems: (...[context, result]: Parameters<typeof resolveItems>) =>
+            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
           hasResolveOnDeployItems: true,
         }
       : {}),
-    ...(resolver.getNextDiscoveryState
+    ...(getNextPaginationState
       ? {
-          getOnDeployNextDiscoveryState: resolver.getNextDiscoveryState,
+          // Wire name stays `getOnDeployNextDiscoveryState` (the backend contract); the author's
+          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
+          getOnDeployNextDiscoveryState: (
+            ...[context, result]: Parameters<typeof getNextPaginationState>
+          ) =>
+            getNextPaginationState(context, {
+              ...result,
+              payload: aliasPaginationState(result.payload),
+            }),
           hasGetOnDeployNextDiscoveryState: true,
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -21,7 +21,7 @@ import {
   isPollingTriggerDefinition,
   type PollingTriggerDefinition,
 } from "../types/PollingTriggerDefinition";
-import type { TriggerResolver } from "../types/TriggerDefinition";
+import type { BatchConfig, TriggerResolverBehavior } from "../types/TriggerDefinition";
 import type {
   Action as ServerAction,
   Component as ServerComponent,
@@ -100,9 +100,9 @@ export const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined => 
 };
 
 /**
- * Throws if `batchSize` isn't a positive integer; otherwise returns it.
- * Shared by both component-trigger (`TriggerResolver.default.batchSize`) and
- * CNI flow (`TriggerResolverConfig.batchSize`) validation paths.
+ * Throws if `batchSize` isn't a positive integer; otherwise returns it. Shared by the
+ * component-trigger (`TriggerDefinition.batch.batchSize`) and CNI flow (`flow.batch.batchSize`)
+ * validation paths.
  */
 export const validateBatchSize = (
   ownerLabel: string,
@@ -117,23 +117,39 @@ export const validateBatchSize = (
   return batchSize;
 };
 
+/**
+ * Emits the trigger's single default batch size to the one wire field the platform reads
+ * (`triggerResolverDefaultBatchSize`), shared by both the trigger and on-deploy resolution.
+ * Emitted when the trigger declares a resolver — `triggerResolverSupport` `"valid"`/`"required"`
+ * for the normal path, or an `onDeployResolver` for the on-deploy path. Defaults to 1 when no
+ * `batchConfig` was declared.
+ */
+const buildBatchDefaultField = (
+  triggerLabel: string,
+  triggerResolverSupport: TriggerOptionChoice,
+  hasOnDeployResolver: boolean,
+  batchConfig: BatchConfig | undefined,
+) => {
+  if (triggerResolverSupport === "invalid" && !hasOnDeployResolver) {
+    return {};
+  }
+  return {
+    triggerResolverDefaultBatchSize: batchConfig
+      ? validateBatchSize(`Trigger "${triggerLabel}"`, "batchConfig", batchConfig.batchSize)
+      : 1,
+  };
+};
+
 const buildTriggerResolverFields = <
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
 >(
-  triggerLabel: string,
-  support: TriggerOptionChoice,
-  resolver: TriggerResolver<TConfigVars, TPayload> | undefined,
+  resolver: TriggerResolverBehavior<TConfigVars, TPayload> | undefined,
 ) => {
   if (!resolver) {
-    return support === "invalid" ? {} : { triggerResolverDefaultBatchSize: 1 };
+    return {};
   }
   return {
-    triggerResolverDefaultBatchSize: validateBatchSize(
-      `Trigger "${triggerLabel}"`,
-      "triggerResolver.default",
-      resolver.default.batchSize,
-    ),
     ...(resolver.resolveItems
       ? {
           resolveTriggerItems: resolver.resolveItems,
@@ -144,6 +160,31 @@ const buildTriggerResolverFields = <
       ? {
           getNextDiscoveryState: resolver.getNextDiscoveryState,
           hasGetNextDiscoveryState: true,
+        }
+      : {}),
+  };
+};
+
+const buildOnDeployResolverFields = <
+  TConfigVars extends ConfigVarResultCollection,
+  TPayload extends TriggerPayload,
+>(
+  resolver: TriggerResolverBehavior<TConfigVars, TPayload> | undefined,
+) => {
+  if (!resolver) {
+    return {};
+  }
+  return {
+    ...(resolver.resolveItems
+      ? {
+          resolveOnDeployItems: resolver.resolveItems,
+          hasResolveOnDeployItems: true,
+        }
+      : {}),
+    ...(resolver.getNextDiscoveryState
+      ? {
+          getOnDeployNextDiscoveryState: resolver.getNextDiscoveryState,
+          hasGetOnDeployNextDiscoveryState: true,
         }
       : {}),
   };
@@ -313,6 +354,12 @@ export const convertTrigger = <
   >,
 >(
   triggerKey: string,
+  // `any` is load-bearing: the user-facing TriggerDefinition / PollingTriggerDefinition
+  // type their event-function fields (onInstanceDeploy, webhookLifecycleHandlers, etc.) over
+  // TInputs/TConfigVars/TPayload, while the wire-format ServerTrigger drops those generics.
+  // The `...trigger` spread in the result construction below would surface variance errors
+  // without these `any`s. The user-typed handlers are immediately replaced with
+  // createPerform-wrapped versions, so the loose input typing is safe in practice.
   trigger:
     | TriggerDefinition<any>
     | PollingTriggerDefinition<any, ConfigVarResultCollection, TriggerPayload, boolean, any, any>,
@@ -336,6 +383,7 @@ export const convertTrigger = <
   let scheduleSupport: TriggerOptionChoice =
     "scheduleSupport" in trigger ? trigger.scheduleSupport : "invalid";
 
+  const batchConfig = "batchConfig" in trigger ? trigger.batchConfig : undefined;
   const triggerResolver = "triggerResolver" in trigger ? trigger.triggerResolver : undefined;
   const triggerResolverSupport: TriggerOptionChoice =
     "triggerResolverSupport" in trigger && trigger.triggerResolverSupport !== undefined
@@ -351,6 +399,16 @@ export const convertTrigger = <
   if (triggerResolverSupport === "invalid" && triggerResolver) {
     throw new Error(
       `Trigger "${trigger.display.label}" declares triggerResolver but triggerResolverSupport is "invalid".`,
+    );
+  }
+
+  const onDeployPerform = "onDeployPerform" in trigger ? trigger.onDeployPerform : undefined;
+  const onDeployResolver = "onDeployResolver" in trigger ? trigger.onDeployResolver : undefined;
+  // On-deploy is presence-driven (no support flag): a trigger that defines an
+  // `onDeployResolver` must also define the `onDeployPerform` fire it batches.
+  if (onDeployResolver?.resolveItems && !onDeployPerform) {
+    throw new Error(
+      `Trigger "${trigger.display.label}" declares onDeployResolver.resolveItems but is missing onDeployPerform.`,
     );
   }
 
@@ -410,7 +468,9 @@ export const convertTrigger = <
     pollAction?: PollingTriggerDefinition["pollAction"];
     triggerType?: string;
   } = {
-    ...trigger,
+    // `batchConfig` / `triggerResolver` / `onDeployResolver` are author-only inputs; the
+    // wire carries the serialized resolver behavior plus the single batch size instead.
+    ...omit(trigger, ["batchConfig", "triggerResolver", "onDeployResolver"]),
     key: triggerKey,
     inputs: convertedTriggerInputs.concat(convertedActionInputs),
     perform: performToUse,
@@ -422,7 +482,15 @@ export const convertTrigger = <
           ? "valid"
           : "invalid",
     triggerResolverSupport,
-    ...buildTriggerResolverFields(trigger.display.label, triggerResolverSupport, triggerResolver),
+    // The single shared default batch size → the one wire field the platform reads.
+    ...buildBatchDefaultField(
+      trigger.display.label,
+      triggerResolverSupport,
+      !!onDeployResolver?.resolveItems,
+      batchConfig,
+    ),
+    ...buildTriggerResolverFields(triggerResolver),
+    ...buildOnDeployResolverFields(onDeployResolver),
     ...(isPollingTriggerDefinition(trigger) ? { isPollingTrigger: true } : {}),
   };
 
@@ -432,6 +500,14 @@ export const convertTrigger = <
       errorHandler: hooks?.error,
     });
     result.hasOnInstanceDeploy = true;
+  }
+
+  if (onDeployPerform) {
+    result.onDeployPerform = createPerform(onDeployPerform, {
+      inputCleaners: triggerInputCleaners,
+      errorHandler: hooks?.error,
+    });
+    result.hasOnDeployPerform = true;
   }
 
   if (onInstanceDelete) {

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { configPage, configVar, flow, integration } from "..";
+import { batchFlowTrigger, configPage, configVar, flow, integration } from "..";
 import type { ConfigVar, TriggerReference } from "../types";
 import {
   convertConfigPages,
@@ -60,16 +60,15 @@ describe("convertFlow with polling triggers", () => {
   });
 
   it("emits the single flow-level batch config and strips resolver behavior from the flow result", () => {
-    const triggerResolverFlow = flow({
+    const batchedFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
       batchConfig: { batchSize: 25 },
-      triggerResolver: {
-        resolveItems: () => [1, 2, 3],
-      },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+      }),
     });
 
-    const result = convertFlow(triggerResolverFlow, {}, "test-ref");
+    const result = convertFlow(batchedFlow, {}, "test-ref");
 
     // The single batch config is written to the existing `triggerResolver` flow wire field
     // (→ trigger_resolver_batch_size / trigger_resolver_enabled), with enabled forced on.
@@ -77,16 +76,18 @@ describe("convertFlow with polling triggers", () => {
     // Author-only fields are stripped; resolver behavior goes on the synthesized trigger.
     expect(result.batchConfig).toBeUndefined();
     expect(result.onDeployResolver).toBeUndefined();
+    // The batched `trigger` is expanded; the field itself is not emitted on the flow wire.
+    expect(result.trigger).toBeUndefined();
   });
 
-  it("shares one batch config across triggerResolver and onDeployResolver", () => {
+  it("shares one batch config across the trigger and on-deploy fires", () => {
     const sharedBatchFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
-      onDeployTrigger: async (_context, payload) => ({ payload }),
       batchConfig: { batchSize: 50 },
-      triggerResolver: { resolveItems: () => [1, 2, 3] },
-      onDeployResolver: { resolveItems: () => [4, 5, 6] },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+        onDeploy: async () => ({ items: [4, 5, 6] }),
+      }),
     });
 
     const result = convertFlow(sharedBatchFlow, {}, "test-ref");
@@ -100,11 +101,11 @@ describe("convertFlow with polling triggers", () => {
   it("emits the shared concurrentBatchLimit on the flow wire when set on batchConfig", () => {
     const sharedBatchFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
-      onDeployTrigger: async (_context, payload) => ({ payload }),
       batchConfig: { batchSize: 50, concurrentBatchLimit: 5 },
-      triggerResolver: { resolveItems: () => [1, 2, 3] },
-      onDeployResolver: { resolveItems: () => [4, 5, 6] },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+        onDeploy: async () => ({ items: [4, 5, 6] }),
+      }),
     });
 
     const result = convertFlow(sharedBatchFlow, {}, "test-ref");
@@ -119,10 +120,11 @@ describe("convertFlow with polling triggers", () => {
   it("throws when the flow-level batch concurrentBatchLimit is invalid", () => {
     const invalidFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
       // @ts-expect-error - intentionally invalid concurrentBatchLimit for runtime validation
       batchConfig: { batchSize: 50, concurrentBatchLimit: 0 },
-      triggerResolver: { resolveItems: () => [1, 2, 3] },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+      }),
     });
 
     expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
@@ -130,23 +132,14 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("throws when a resolver is defined without a batch config", () => {
-    const invalidFlow = flow({
-      ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
-      triggerResolver: { resolveItems: () => [1, 2, 3] },
-    });
-
-    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(/no batchConfig/);
-  });
-
   it("throws when the flow-level batch batchSize is invalid", () => {
     const invalidFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
       // @ts-expect-error - intentionally invalid batchSize for runtime validation
       batchConfig: { batchSize: 0 },
-      triggerResolver: { resolveItems: () => [1, 2, 3] },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+      }),
     });
 
     expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
@@ -154,17 +147,83 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("throws when onDeployResolver is set without onDeployTrigger", () => {
-    const invalidFlow = flow({
+  it("synthesizes the default resolveItems (reads payload.body.data) on the trigger", () => {
+    const batchedFlow = flow({
       ...baseFlowInput,
-      onTrigger: async (_context, payload) => ({ payload }),
       batchConfig: { batchSize: 10 },
-      onDeployResolver: { resolveItems: () => [1, 2, 3] },
+      trigger: batchFlowTrigger<number>({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+        getNextOnTriggerPaginationState: () => null,
+      }),
     });
 
-    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
-      /declares onDeployResolver without onDeployTrigger/,
-    );
+    const result = integration({
+      name: "Test",
+      flows: [batchedFlow],
+      configPages: {},
+      componentRegistry: {},
+    });
+
+    const trigger = Object.values(result.triggers)[0] as Record<string, unknown>;
+    expect(trigger.hasResolveTriggerItems).toBe(true);
+    expect(trigger.hasGetNextDiscoveryState).toBe(true);
+    expect(trigger.triggerResolverSupport).toBe("valid");
+    expect(trigger.triggerResolverDefaultBatchSize).toBe(10);
+    // The synthesized resolveItems just reads the records back out of payload.body.data.
+    const resolveTriggerItems = trigger.resolveTriggerItems as (
+      ctx: unknown,
+      result: { payload: { body: { data: unknown } } },
+    ) => unknown[];
+    expect(resolveTriggerItems({}, { payload: { body: { data: [7, 8, 9] } } })).toEqual([7, 8, 9]);
+  });
+
+  it("maps the on-deploy fire and pagination onto the synthesized trigger", () => {
+    const batchedFlow = flow({
+      ...baseFlowInput,
+      batchConfig: { batchSize: 10 },
+      trigger: batchFlowTrigger<number, { cursor: number }>({
+        onTrigger: async () => ({ items: [1] }),
+        onDeploy: async () => ({ items: [2] }),
+        getNextOnDeployPaginationState: (_ctx, result) => {
+          const cursor = result.payload.discoveryState?.cursor ?? 0;
+          return cursor >= 2 ? null : { cursor: cursor + 1 };
+        },
+      }),
+    });
+
+    const result = integration({
+      name: "Test",
+      flows: [batchedFlow],
+      configPages: {},
+      componentRegistry: {},
+    });
+
+    const trigger = Object.values(result.triggers)[0] as Record<string, unknown>;
+    expect(trigger.hasOnDeployPerform).toBe(true);
+    expect(trigger.hasResolveOnDeployItems).toBe(true);
+    expect(trigger.hasGetOnDeployNextDiscoveryState).toBe(true);
+  });
+
+  it("does not synthesize on-deploy resolver fields when the trigger omits onDeploy", () => {
+    const batchedFlow = flow({
+      ...baseFlowInput,
+      batchConfig: { batchSize: 10 },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1] }),
+      }),
+    });
+
+    const result = integration({
+      name: "Test",
+      flows: [batchedFlow],
+      configPages: {},
+      componentRegistry: {},
+    });
+
+    const trigger = Object.values(result.triggers)[0] as Record<string, unknown>;
+    expect(trigger.hasOnDeployPerform).toBeUndefined();
+    expect(trigger.hasResolveOnDeployItems).toBeUndefined();
+    expect(trigger.hasGetOnDeployNextDiscoveryState).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -147,7 +147,7 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("synthesizes the default resolveItems and getNextDiscoveryState on the trigger", () => {
+  it("synthesizes the default resolveItems and getNextPaginationState on the trigger", () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
@@ -174,23 +174,22 @@ describe("convertFlow with polling triggers", () => {
       result: { payload: { body: { data: unknown } } },
     ) => unknown[];
     expect(resolveTriggerItems({}, { payload: { body: { data: [7, 8, 9] } } })).toEqual([7, 8, 9]);
-    const getNextDiscoveryState = trigger.getNextDiscoveryState as (
+    const getNextPaginationState = trigger.getNextPaginationState as (
       ctx: unknown,
-      result: { payload: { discoveryState?: unknown } },
+      result: { payload: { paginationState?: unknown } },
     ) => unknown;
-    expect(getNextDiscoveryState({}, { payload: { discoveryState: { cursor: 2 } } })).toEqual({
+    expect(getNextPaginationState({}, { payload: { paginationState: { cursor: 2 } } })).toEqual({
       cursor: 2,
     });
-    expect(getNextDiscoveryState({}, { payload: {} })).toBeNull();
+    expect(getNextPaginationState({}, { payload: {} })).toBeNull();
   });
 
-  it("wraps the fire so items land at body.data and the returned cursor at discoveryState", async () => {
+  it("wraps the fire so items land at body.data and the returned cursor at paginationState", async () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async (_ctx, payload) => {
-          // Author reads the cursor as `paginationState` (aliased from the wire `discoveryState`).
           const cursor = payload.paginationState?.cursor ?? 0;
           return cursor >= 2
             ? { items: [cursor] }
@@ -211,17 +210,15 @@ describe("convertFlow with polling triggers", () => {
       ctx: unknown,
       payload: unknown,
       params: unknown,
-    ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
+    ) => Promise<{ payload: { body: { data: unknown }; paginationState: unknown } }>;
 
-    // The platform stamps the cursor onto the wire `discoveryState`; the author's returned
-    // `paginationState` is stamped back onto the wire `discoveryState` for the loop to read.
-    const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
+    const page1 = await perform({}, { paginationState: { cursor: 1 } }, {});
     expect(page1.payload.body.data).toEqual([1]);
-    expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
+    expect(page1.payload.paginationState).toEqual({ cursor: 2 });
 
-    const page2 = await perform({}, { discoveryState: { cursor: 2 } }, {});
+    const page2 = await perform({}, { paginationState: { cursor: 2 } }, {});
     expect(page2.payload.body.data).toEqual([2]);
-    expect(page2.payload.discoveryState).toBeNull();
+    expect(page2.payload.paginationState).toBeNull();
   });
 
   it("maps the on-deploy fire and pagination onto the synthesized trigger", () => {

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -147,13 +147,12 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("synthesizes the default resolveItems (reads payload.body.data) on the trigger", () => {
+  it("synthesizes the default resolveItems and getNextDiscoveryState on the trigger", () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
-      trigger: batchFlowTrigger<number>({
+      trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1, 2, 3] }),
-        getNextOnTriggerPaginationState: () => null,
       }),
     });
 
@@ -175,6 +174,51 @@ describe("convertFlow with polling triggers", () => {
       result: { payload: { body: { data: unknown } } },
     ) => unknown[];
     expect(resolveTriggerItems({}, { payload: { body: { data: [7, 8, 9] } } })).toEqual([7, 8, 9]);
+    const getNextDiscoveryState = trigger.getNextDiscoveryState as (
+      ctx: unknown,
+      result: { payload: { discoveryState?: unknown } },
+    ) => unknown;
+    expect(getNextDiscoveryState({}, { payload: { discoveryState: { cursor: 2 } } })).toEqual({
+      cursor: 2,
+    });
+    expect(getNextDiscoveryState({}, { payload: {} })).toBeNull();
+  });
+
+  it("wraps the fire so items land at body.data and the returned cursor at discoveryState", async () => {
+    const batchedFlow = flow({
+      ...baseFlowInput,
+      batchConfig: { batchSize: 10 },
+      trigger: batchFlowTrigger<number, { cursor: number }>({
+        onTrigger: async (_ctx, payload) => {
+          const cursor = payload.discoveryState?.cursor ?? 0;
+          return cursor >= 2
+            ? { items: [cursor] }
+            : { items: [cursor], discoveryState: { cursor: cursor + 1 } };
+        },
+      }),
+    });
+
+    const result = integration({
+      name: "Test",
+      flows: [batchedFlow],
+      configPages: {},
+      componentRegistry: {},
+    });
+
+    const trigger = Object.values(result.triggers)[0] as Record<string, unknown>;
+    const perform = trigger.perform as (
+      ctx: unknown,
+      payload: unknown,
+      params: unknown,
+    ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
+
+    const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
+    expect(page1.payload.body.data).toEqual([1]);
+    expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
+
+    const page2 = await perform({}, { discoveryState: { cursor: 2 } }, {});
+    expect(page2.payload.body.data).toEqual([2]);
+    expect(page2.payload.discoveryState).toBeNull();
   });
 
   it("maps the on-deploy fire and pagination onto the synthesized trigger", () => {
@@ -183,10 +227,9 @@ describe("convertFlow with polling triggers", () => {
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1] }),
-        onDeploy: async () => ({ items: [2] }),
-        getNextOnDeployPaginationState: (_ctx, result) => {
-          const cursor = result.payload.discoveryState?.cursor ?? 0;
-          return cursor >= 2 ? null : { cursor: cursor + 1 };
+        onDeploy: async (_ctx, payload) => {
+          const cursor = payload.discoveryState?.cursor ?? 0;
+          return cursor >= 2 ? { items: [2] } : { items: [2], discoveryState: { cursor: cursor + 1 } };
         },
       }),
     });

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -97,6 +97,39 @@ describe("convertFlow with polling triggers", () => {
     expect(result.onDeployResolver).toBeUndefined();
   });
 
+  it("emits the shared concurrentBatchLimit on the flow wire when set on batchConfig", () => {
+    const sharedBatchFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      onDeployTrigger: async (_context, payload) => ({ payload }),
+      batchConfig: { batchSize: 50, concurrentBatchLimit: 5 },
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+      onDeployResolver: { resolveItems: () => [4, 5, 6] },
+    });
+
+    const result = convertFlow(sharedBatchFlow, {}, "test-ref");
+
+    expect(result.triggerResolver).toEqual({
+      batchSize: 50,
+      enabled: true,
+      concurrentBatchLimit: 5,
+    });
+  });
+
+  it("throws when the flow-level batch concurrentBatchLimit is invalid", () => {
+    const invalidFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      // @ts-expect-error - intentionally invalid concurrentBatchLimit for runtime validation
+      batchConfig: { batchSize: 50, concurrentBatchLimit: 0 },
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+    });
+
+    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
+      /invalid batchConfig concurrentBatchLimit of 0/,
+    );
+  });
+
   it("throws when a resolver is defined without a batch config", () => {
     const invalidFlow = flow({
       ...baseFlowInput,

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -59,31 +59,78 @@ describe("convertFlow with polling triggers", () => {
     expect(result.name).toBe("Test Polling Flow");
   });
 
-  it("emits triggerResolver { batchSize } and strips resolveItems on the flow result", () => {
+  it("emits the single flow-level batch config and strips resolver behavior from the flow result", () => {
     const triggerResolverFlow = flow({
       ...baseFlowInput,
       onTrigger: async (_context, payload) => ({ payload }),
+      batchConfig: { batchSize: 25 },
       triggerResolver: {
-        batchSize: 25,
         resolveItems: () => [1, 2, 3],
       },
     });
 
     const result = convertFlow(triggerResolverFlow, {}, "test-ref");
 
-    expect(result.triggerResolver).toEqual({ batchSize: 25 });
+    // The single batch config is written to the existing `triggerResolver` flow wire field
+    // (→ trigger_resolver_batch_size / trigger_resolver_enabled), with enabled forced on.
+    expect(result.triggerResolver).toEqual({ batchSize: 25, enabled: true });
+    // Author-only fields are stripped; resolver behavior goes on the synthesized trigger.
+    expect(result.batchConfig).toBeUndefined();
+    expect(result.onDeployResolver).toBeUndefined();
   });
 
-  it("throws when flow-level triggerResolver batchSize is invalid", () => {
+  it("shares one batch config across triggerResolver and onDeployResolver", () => {
+    const sharedBatchFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      onDeployTrigger: async (_context, payload) => ({ payload }),
+      batchConfig: { batchSize: 50 },
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+      onDeployResolver: { resolveItems: () => [4, 5, 6] },
+    });
+
+    const result = convertFlow(sharedBatchFlow, {}, "test-ref");
+
+    // One config drives both the normal and on-deploy fires; no separate on-deploy field.
+    expect(result.triggerResolver).toEqual({ batchSize: 50, enabled: true });
+    expect(result.batchConfig).toBeUndefined();
+    expect(result.onDeployResolver).toBeUndefined();
+  });
+
+  it("throws when a resolver is defined without a batch config", () => {
+    const invalidFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+    });
+
+    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(/no batchConfig/);
+  });
+
+  it("throws when the flow-level batch batchSize is invalid", () => {
     const invalidFlow = flow({
       ...baseFlowInput,
       onTrigger: async (_context, payload) => ({ payload }),
       // @ts-expect-error - intentionally invalid batchSize for runtime validation
-      triggerResolver: { batchSize: 0 },
+      batchConfig: { batchSize: 0 },
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
     });
 
     expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
-      /invalid triggerResolver batchSize of 0/,
+      /invalid batchConfig batchSize of 0/,
+    );
+  });
+
+  it("throws when onDeployResolver is set without onDeployTrigger", () => {
+    const invalidFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      batchConfig: { batchSize: 10 },
+      onDeployResolver: { resolveItems: () => [1, 2, 3] },
+    });
+
+    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
+      /declares onDeployResolver without onDeployTrigger/,
     );
   });
 });

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -190,10 +190,11 @@ describe("convertFlow with polling triggers", () => {
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async (_ctx, payload) => {
-          const cursor = payload.discoveryState?.cursor ?? 0;
+          // Author reads the cursor as `paginationState` (aliased from the wire `discoveryState`).
+          const cursor = payload.paginationState?.cursor ?? 0;
           return cursor >= 2
             ? { items: [cursor] }
-            : { items: [cursor], discoveryState: { cursor: cursor + 1 } };
+            : { items: [cursor], paginationState: { cursor: cursor + 1 } };
         },
       }),
     });
@@ -212,6 +213,8 @@ describe("convertFlow with polling triggers", () => {
       params: unknown,
     ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
 
+    // The platform stamps the cursor onto the wire `discoveryState`; the author's returned
+    // `paginationState` is stamped back onto the wire `discoveryState` for the loop to read.
     const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
     expect(page1.payload.body.data).toEqual([1]);
     expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
@@ -228,8 +231,10 @@ describe("convertFlow with polling triggers", () => {
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1] }),
         onDeploy: async (_ctx, payload) => {
-          const cursor = payload.discoveryState?.cursor ?? 0;
-          return cursor >= 2 ? { items: [2] } : { items: [2], discoveryState: { cursor: cursor + 1 } };
+          const cursor = payload.paginationState?.cursor ?? 0;
+          return cursor >= 2
+            ? { items: [2] }
+            : { items: [2], paginationState: { cursor: cursor + 1 } };
         },
       }),
     });

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -58,6 +58,34 @@ describe("convertFlow with polling triggers", () => {
 
     expect(result.name).toBe("Test Polling Flow");
   });
+
+  it("emits triggerResolver { batchSize } and strips resolveItems on the flow result", () => {
+    const triggerResolverFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      triggerResolver: {
+        batchSize: 25,
+        resolveItems: () => [1, 2, 3],
+      },
+    });
+
+    const result = convertFlow(triggerResolverFlow, {}, "test-ref");
+
+    expect(result.triggerResolver).toEqual({ batchSize: 25 });
+  });
+
+  it("throws when flow-level triggerResolver batchSize is invalid", () => {
+    const invalidFlow = flow({
+      ...baseFlowInput,
+      onTrigger: async (_context, payload) => ({ payload }),
+      // @ts-expect-error - intentionally invalid batchSize for runtime validation
+      triggerResolver: { batchSize: 0 },
+    });
+
+    expect(() => convertFlow(invalidFlow, {}, "test-ref")).toThrow(
+      /invalid triggerResolver batchSize of 0/,
+    );
+  });
 });
 
 describe("convertConfigPages", () => {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -78,7 +78,12 @@ import {
   type Input as ServerInput,
   type RequiredConfigVariable as ServerRequiredConfigVariable,
 } from "./integration";
-import { createCNIComponentRefPerform, createCNIPerform, createCNIPollingPerform } from "./perform";
+import {
+  aliasPaginationState,
+  createCNIComponentRefPerform,
+  createCNIPerform,
+  createCNIPollingPerform,
+} from "./perform";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 export const CONCURRENCY_LIMIT_MAX = 15;
@@ -108,9 +113,11 @@ const defaultResolveItems = (
 
 /**
  * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
- * `discoveryState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
- * `payload.discoveryState`. Reading it back (defaulting to `null`) is the whole pagination
- * loop: a non-null value re-invokes the fire, `null` ends it. Authors never write this.
+ * `paginationState`; the wrapper {@link normalizeBatchedFlow} builds stamps it onto the wire
+ * field `payload.discoveryState` (the name the backend's discovery loop reads). Reading it back
+ * (defaulting to `null`) is the whole loop: a non-null value re-invokes the fire, `null` ends it.
+ * Authors never write this. The wire name stays `discoveryState` — only the author surface uses
+ * `paginationState`.
  */
 const defaultGetNextDiscoveryState = (
   _context: ActionContext,
@@ -120,11 +127,12 @@ const defaultGetNextDiscoveryState = (
 /**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
- * conversion pipeline already understands. The trigger fires return `{ items, discoveryState? }`;
+ * conversion pipeline already understands. The trigger fires return `{ items, paginationState? }`;
  * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
  * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
- * items back) and `getNextDiscoveryState` (reads the cursor back). Flows without a `trigger`
- * pass through unchanged.
+ * items back) and `getNextDiscoveryState` (reads the cursor back). The author surface speaks
+ * `paginationState`; this wrapper is the boundary where it is translated to/from the wire
+ * `discoveryState`. Flows without a `trigger` pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -146,20 +154,24 @@ const normalizeBatchedFlow = <
 
   const { onTrigger, onDeploy } = trigger;
 
-  // Wrap a batched fire (returns `{ items, discoveryState?, response? }`) into a
+  // Wrap a batched fire (returns `{ items, paginationState?, response? }`) into a
   // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
-  // next-page cursor at `discoveryState` (defaulting `null` to terminate the loop). The
-  // incoming payload's `discoveryState` was already consumed by the fire, so overwriting it
-  // with the returned cursor is safe — `getNextDiscoveryState` reads it straight back.
+  // next-page cursor at the wire field `discoveryState` (defaulting `null` to terminate the
+  // loop). This is the author/wire boundary: the incoming wire `discoveryState` is aliased to
+  // `paginationState` for the fire to read, and the cursor it returns is stamped back onto the
+  // wire `discoveryState` for `getNextDiscoveryState` to read straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, discoveryState, response } = await fire(context as never, payload as never);
+      const { items, paginationState, response } = await fire(
+        context as never,
+        aliasPaginationState(payload) as never,
+      );
       return {
         payload: {
           ...payload,
           body: { data: items, contentType: "application/json" },
-          discoveryState: discoveryState ?? null,
+          discoveryState: paginationState ?? null,
         },
         ...(response ? { response } : {}),
       };

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -63,7 +63,7 @@ import type {
 } from ".";
 import { runWithContext } from "./asyncContext";
 import { createCNIContext, logDebugResults } from "./context";
-import { convertInput, convertTemplateInput } from "./convertComponent";
+import { convertInput, convertTemplateInput, validateBatchSize } from "./convertComponent";
 import {
   DefinitionVersion,
   type ComponentReference as ServerComponentReference,
@@ -77,6 +77,17 @@ import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } fr
 
 export const CONCURRENCY_LIMIT_MAX = 15;
 export const CONCURRENCY_LIMIT_MIN = 2;
+
+const validateFlowResolverBatchSize = (
+  flowName: string,
+  configName: "triggerResolver",
+  resolver: { batchSize: number } | undefined,
+): { batchSize: number } | undefined => {
+  if (!resolver) {
+    return undefined;
+  }
+  return { batchSize: validateBatchSize(flowName, configName, resolver.batchSize) };
+};
 
 export const convertIntegration = <
   TInputs extends Inputs,
@@ -765,6 +776,15 @@ export const convertFlow = <
     };
   }
 
+  const triggerResolver = "triggerResolver" in flow ? flow.triggerResolver : undefined;
+  if (triggerResolver) {
+    result.triggerResolver = validateFlowResolverBatchSize(
+      flow.name,
+      "triggerResolver",
+      triggerResolver,
+    );
+  }
+
   const actionStep: Record<string, unknown> = {
     action: {
       key: flowFunctionKey(flow.name, "onExecution"),
@@ -997,7 +1017,10 @@ export const convertConfigVar = (
   }
 
   if (isJsonFormDataSourceConfigVar(configVar) && configVar.dataSourceReset) {
-    result.meta = { ...result.meta, dataSourceReset: configVar.dataSourceReset.mode };
+    result.meta = {
+      ...result.meta,
+      dataSourceReset: configVar.dataSourceReset.mode,
+    };
     // Create placeholder inputs for each config variable dependency, so that
     // the config wizard can detect if any changed and reset the data source.
     result.inputs = (configVar.dataSourceReset.dependencies || []).reduce(
@@ -1039,7 +1062,10 @@ export const convertConfigVar = (
     }
 
     if (configVar.dataSourceReset) {
-      result.meta = { ...result.meta, dataSourceReset: configVar.dataSourceReset.mode };
+      result.meta = {
+        ...result.meta,
+        dataSourceReset: configVar.dataSourceReset.mode,
+      };
     }
   }
 
@@ -1321,7 +1347,11 @@ function generateTriggerPerformFn<
     case "standard":
       return createCNIPerform({ componentRegistry, onTrigger });
     case "component-ref":
-      return createCNIComponentRefPerform({ componentRegistry, componentRef, onTrigger });
+      return createCNIComponentRefPerform({
+        componentRegistry,
+        componentRef,
+        onTrigger,
+      });
 
     default:
       throw new Error(`Invalid trigger configuration detected: ${JSON.stringify(params, null, 2)}`);
@@ -1511,6 +1541,7 @@ const codeNativeIntegrationComponent = <
         webhookLifecycleHandlers,
         schedule,
         triggerType,
+        triggerResolver,
       },
     ) => {
       if (
@@ -1599,6 +1630,24 @@ const codeNativeIntegrationComponent = <
           scheduleSupport: triggerType === "polling" ? "required" : "valid",
           synchronousResponseSupport: "valid",
           isPollingTrigger: triggerType === "polling",
+          triggerResolverSupport: triggerResolver ? "valid" : "invalid",
+          ...(triggerResolver
+            ? {
+                triggerResolverDefaultBatchSize: triggerResolver.batchSize,
+                ...(triggerResolver.resolveItems
+                  ? {
+                      resolveTriggerItems: triggerResolver.resolveItems,
+                      hasResolveTriggerItems: true,
+                    }
+                  : {}),
+                ...(triggerResolver.getNextDiscoveryState
+                  ? {
+                      getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
+                      hasGetNextDiscoveryState: true,
+                    }
+                  : {}),
+              }
+            : {}),
         },
       };
     },

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -63,7 +63,12 @@ import type {
 } from ".";
 import { runWithContext } from "./asyncContext";
 import { createCNIContext, logDebugResults } from "./context";
-import { convertInput, convertTemplateInput, validateBatchSize } from "./convertComponent";
+import {
+  convertInput,
+  convertTemplateInput,
+  validateBatchSize,
+  validateConcurrentBatchLimit,
+} from "./convertComponent";
 import {
   DefinitionVersion,
   type ComponentReference as ServerComponentReference,
@@ -797,9 +802,15 @@ export const convertFlow = <
 
     // `enabled: true` is required: for a "valid"-support trigger (which CNI synthesized
     // triggers are) the platform only batches when the flow's resolver is enabled.
+    const concurrentBatchLimit = validateConcurrentBatchLimit(
+      flow.name,
+      "batchConfig",
+      batchConfig.concurrentBatchLimit,
+    );
     result.triggerResolver = {
       batchSize: validateBatchSize(flow.name, "batchConfig", batchConfig.batchSize),
       enabled: true,
+      ...(concurrentBatchLimit !== undefined ? { concurrentBatchLimit } : {}),
     };
   }
 
@@ -1657,7 +1668,14 @@ const codeNativeIntegrationComponent = <
           // publish validation requires `triggerResolverDefaultBatchSize` whenever resolver
           // support is active; both derive from the one `flow.batchConfig`.
           ...(triggerResolver || onDeployResolver
-            ? { triggerResolverDefaultBatchSize: batchConfig?.batchSize ?? 1 }
+            ? {
+                triggerResolverDefaultBatchSize: batchConfig?.batchSize ?? 1,
+                ...(batchConfig?.concurrentBatchLimit !== undefined
+                  ? {
+                      triggerResolverDefaultConcurrentBatchLimit: batchConfig.concurrentBatchLimit,
+                    }
+                  : {}),
+              }
             : {}),
           ...(triggerResolver
             ? {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -7,6 +7,7 @@ import pick from "lodash/pick";
 import path from "path";
 import YAML from "yaml";
 import {
+  type BatchTrigger,
   type CollectionType,
   type ComponentManifest,
   type ComponentReference,
@@ -82,6 +83,94 @@ import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } fr
 
 export const CONCURRENCY_LIMIT_MAX = 15;
 export const CONCURRENCY_LIMIT_MIN = 2;
+
+/**
+ * The wire-shape resolver synthesized by {@link normalizeBatchedFlow} and read by the trigger
+ * reducer. Mirrors the server `Trigger`'s `resolveTriggerItems`/`getNextDiscoveryState` slots.
+ */
+interface WireResolver {
+  resolveItems?: (context: ActionContext, result: { payload: TriggerPayload }) => unknown[];
+  getNextDiscoveryState?: (
+    context: ActionContext,
+    result: { payload: TriggerPayload },
+  ) => Record<string, unknown> | null;
+}
+
+/**
+ * Default `resolveItems`: a batched `trigger`'s fires return their records under
+ * `payload.body.data` (the wrapper {@link normalizeBatchedFlow} builds writes them there),
+ * so extraction is just reading that array back. Authors never write this themselves.
+ */
+const defaultResolveItems = (
+  _context: ActionContext,
+  result: { payload: { body: { data: unknown } } },
+) => result.payload.body.data as unknown[];
+
+/**
+ * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
+ * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
+ * conversion pipeline already understands. The trigger fires return just `{ items }`; here we
+ * wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: { data:
+ * items } } }`, synthesize the default `resolveItems`, and map the pagination callbacks onto
+ * the resolver `getNextDiscoveryState`. Flows without a `trigger` pass through unchanged.
+ *
+ * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
+ * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
+ */
+const normalizeBatchedFlow = <
+  TInputs extends Inputs,
+  TActionInputs extends Inputs,
+  TPayload extends TriggerPayload,
+  TAllowsBranching extends boolean,
+  TResult extends TriggerPerformResult<TAllowsBranching, TPayload>,
+>(
+  flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>,
+): Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult> => {
+  const trigger =
+    "trigger" in flow ? (flow.trigger as BatchTrigger<unknown> | undefined) : undefined;
+  if (!trigger) {
+    return flow;
+  }
+
+  const { onTrigger, onDeploy, getNextOnTriggerPaginationState, getNextOnDeployPaginationState } =
+    trigger;
+
+  // Wrap a batched fire (returns `{ items, response? }`) into a TriggerPerformFunction that
+  // emits the wire payload shape (`body.data = items`), preserving the incoming payload fields.
+  const wrapFire =
+    (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
+    async (context: ActionContext, payload: TriggerPayload) => {
+      const { items, response } = await fire(context as never, payload as never);
+      return {
+        payload: { ...payload, body: { data: items, contentType: "application/json" } },
+        ...(response ? { response } : {}),
+      };
+    };
+
+  const { trigger: _omitTrigger, ...rest } = flow as unknown as Record<string, unknown>;
+
+  return {
+    ...rest,
+    onTrigger: wrapFire(onTrigger),
+    ...(onDeploy ? { onDeployTrigger: wrapFire(onDeploy) } : {}),
+    triggerResolver: {
+      resolveItems: defaultResolveItems,
+      ...(getNextOnTriggerPaginationState
+        ? { getNextDiscoveryState: getNextOnTriggerPaginationState }
+        : {}),
+    },
+    ...(onDeploy
+      ? {
+          onDeployResolver: {
+            resolveItems: defaultResolveItems,
+            ...(getNextOnDeployPaginationState
+              ? { getNextDiscoveryState: getNextOnDeployPaginationState }
+              : {}),
+          },
+        }
+      : {}),
+  } as unknown as Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>;
+};
 
 export const convertIntegration = <
   TInputs extends Inputs,
@@ -220,7 +309,7 @@ const codeNativeIntegrationYaml = <
     labels,
     endpointType,
     triggerPreprocessFlowConfig,
-    flows,
+    flows: rawFlows,
     configPages,
     userLevelConfigPages,
     scopedConfigVars,
@@ -231,6 +320,11 @@ const codeNativeIntegrationYaml = <
   configVars: Record<string, ConfigVar>,
   metadata?: Record<string, unknown>,
 ): string => {
+  // Expand any batched `trigger` (built with `batchFlowTrigger`) into the flat
+  // onTrigger/onDeployTrigger/triggerResolver/onDeployResolver shape the rest of this
+  // pipeline (convertFlow + the trigger reducer) already handles.
+  const flows = rawFlows.map((flow) => normalizeBatchedFlow(flow));
+
   // Find the preprocess flow config on the flow, if one exists.
   const preprocessFlows = flows.filter((flow) => flow.preprocessFlowConfig);
 
@@ -632,10 +726,13 @@ export const convertFlow = <
     TPayload
   >,
 >(
-  flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>,
+  rawFlow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>,
   componentRegistry: ComponentRegistry,
   referenceKey: string,
 ): Record<string, unknown> => {
+  // Expand a batched `trigger` into the flat shape this function serializes. Idempotent: a flow
+  // that already lacks `trigger` (including one pre-normalized by `convertIntegration`) is returned as-is.
+  const flow = normalizeBatchedFlow(rawFlow);
   const result: Record<string, unknown> = {
     ...flow,
   };
@@ -1512,7 +1609,7 @@ const codeNativeIntegrationComponent = <
     name,
     iconPath,
     description,
-    flows = [],
+    flows: rawFlows = [],
     componentRegistry = {},
   }: IntegrationDefinition<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>,
   referenceKey: string,
@@ -1525,6 +1622,9 @@ const codeNativeIntegrationComponent = <
   TAllowsBranching,
   TResult
 > => {
+  // Expand any batched `trigger` so the action/trigger reducers below see the flat shape.
+  const flows = rawFlows.map((flow) => normalizeBatchedFlow(flow));
+
   const convertedActions = flows.reduce<Record<string, ServerAction>>(
     (result, { name, onExecution }) => {
       const key = flowFunctionKey(name, "onExecution");
@@ -1559,172 +1659,170 @@ const codeNativeIntegrationComponent = <
         TResult
       >
     >
-  >(
-    (
-      result,
-      {
-        name,
+  >((result, flow) => {
+    const {
+      name,
+      onTrigger,
+      onInstanceDeploy,
+      onInstanceDelete,
+      webhookLifecycleHandlers,
+      schedule,
+      triggerType,
+      onDeployTrigger,
+    } = flow;
+    // `batchConfig`/`triggerResolver`/`onDeployResolver` are wire-only fields synthesized by
+    // `normalizeBatchedFlow`; they aren't on the author-facing `Flow` type, so read via cast.
+    const { batchConfig, triggerResolver, onDeployResolver } = flow as typeof flow & {
+      batchConfig?: { batchSize: number; concurrentBatchLimit?: number };
+      triggerResolver?: WireResolver;
+      onDeployResolver?: WireResolver;
+    };
+    if (
+      !flowUsesWrapperTrigger({
         onTrigger,
-        onInstanceDeploy,
         onInstanceDelete,
+        onInstanceDeploy,
         webhookLifecycleHandlers,
-        schedule,
-        triggerType,
-        batchConfig,
-        triggerResolver,
-        onDeployTrigger,
-        onDeployResolver,
+      })
+    ) {
+      // In this scenario, the user has defined an existing component trigger
+      // without any custom behavior, so we don't need to wrap anything.
+      return result;
+    }
+
+    const key = flowFunctionKey(name, "onTrigger");
+    const defaultComponentKey = schedule && typeof schedule === "object" ? "schedule" : "webhook";
+    const defaultComponentRef: ServerComponentReference = {
+      component: {
+        key: `${defaultComponentKey}-triggers`,
+        version: "LATEST",
+        isPublic: true,
       },
-    ) => {
-      if (
-        !flowUsesWrapperTrigger({
-          onTrigger,
-          onInstanceDelete,
-          onInstanceDeploy,
-          webhookLifecycleHandlers,
-        })
-      ) {
-        // In this scenario, the user has defined an existing component trigger
-        // without any custom behavior, so we don't need to wrap anything.
-        return result;
-      }
+      key: defaultComponentKey,
+    };
 
-      const key = flowFunctionKey(name, "onTrigger");
-      const defaultComponentKey = schedule && typeof schedule === "object" ? "schedule" : "webhook";
-      const defaultComponentRef: ServerComponentReference = {
-        component: {
-          key: `${defaultComponentKey}-triggers`,
-          version: "LATEST",
-          isPublic: true,
+    // The component ref here is undefined if onTrigger is a function.
+    const { ref } = isComponentReference(onTrigger)
+      ? convertComponentReference(onTrigger, componentRegistry, "triggers")
+      : { ref: onTrigger ? undefined : defaultComponentRef };
+
+    const performFn = generateTriggerPerformFn({
+      componentRef: ref,
+      onTrigger,
+      componentRegistry,
+      triggerType,
+    });
+    const deleteFn = generateTriggerEventWrapperFn(
+      ref,
+      onTrigger,
+      "onInstanceDelete",
+      componentRegistry,
+      onInstanceDelete,
+    );
+    const deployFn = generateTriggerEventWrapperFn(
+      ref,
+      onTrigger,
+      "onInstanceDeploy",
+      componentRegistry,
+      onInstanceDeploy,
+    );
+    const webhookCreateFn = generateTriggerEventWrapperFn(
+      ref,
+      onTrigger,
+      "webhookCreate",
+      componentRegistry,
+      webhookLifecycleHandlers?.create,
+    );
+    const webhookDeleteFn = generateTriggerEventWrapperFn(
+      ref,
+      onTrigger,
+      "webhookDelete",
+      componentRegistry,
+      webhookLifecycleHandlers?.delete,
+    );
+
+    return {
+      ...result,
+      [key]: {
+        key,
+        display: {
+          label: `${name} - onTrigger`,
+          description: "The function that will be executed by the flow to return an HTTP response.",
         },
-        key: defaultComponentKey,
-      };
-
-      // The component ref here is undefined if onTrigger is a function.
-      const { ref } = isComponentReference(onTrigger)
-        ? convertComponentReference(onTrigger, componentRegistry, "triggers")
-        : { ref: onTrigger ? undefined : defaultComponentRef };
-
-      const performFn = generateTriggerPerformFn({
-        componentRef: ref,
-        onTrigger,
-        componentRegistry,
-        triggerType,
-      });
-      const deleteFn = generateTriggerEventWrapperFn(
-        ref,
-        onTrigger,
-        "onInstanceDelete",
-        componentRegistry,
-        onInstanceDelete,
-      );
-      const deployFn = generateTriggerEventWrapperFn(
-        ref,
-        onTrigger,
-        "onInstanceDeploy",
-        componentRegistry,
-        onInstanceDeploy,
-      );
-      const webhookCreateFn = generateTriggerEventWrapperFn(
-        ref,
-        onTrigger,
-        "webhookCreate",
-        componentRegistry,
-        webhookLifecycleHandlers?.create,
-      );
-      const webhookDeleteFn = generateTriggerEventWrapperFn(
-        ref,
-        onTrigger,
-        "webhookDelete",
-        componentRegistry,
-        webhookLifecycleHandlers?.delete,
-      );
-
-      return {
-        ...result,
-        [key]: {
-          key,
-          display: {
-            label: `${name} - onTrigger`,
-            description:
-              "The function that will be executed by the flow to return an HTTP response.",
-          },
-          perform: performFn,
-          onInstanceDeploy: deployFn,
-          hasOnInstanceDeploy: !!deployFn,
-          onInstanceDelete: deleteFn,
-          hasOnInstanceDelete: !!deleteFn,
-          webhookCreate: webhookCreateFn,
-          hasWebhookCreateFunction: !!webhookCreateFn,
-          webhookDelete: webhookDeleteFn,
-          hasWebhookDeleteFunction: !!webhookDeleteFn,
-          inputs: wrapperTriggerInputsFromReference(onTrigger, componentRegistry),
-          scheduleSupport: triggerType === "polling" ? "required" : "valid",
-          synchronousResponseSupport: "valid",
-          isPollingTrigger: triggerType === "polling",
-          triggerResolverSupport: triggerResolver ? "valid" : "invalid",
-          // The authoritative batch size is stored on the flow (see convertFlow). We also
-          // emit the single shared default on the synthesized trigger because component
-          // publish validation requires `triggerResolverDefaultBatchSize` whenever resolver
-          // support is active; both derive from the one `flow.batchConfig`.
-          ...(triggerResolver || onDeployResolver
-            ? {
-                triggerResolverDefaultBatchSize: batchConfig?.batchSize ?? 1,
-                ...(batchConfig?.concurrentBatchLimit !== undefined
-                  ? {
-                      triggerResolverDefaultConcurrentBatchLimit: batchConfig.concurrentBatchLimit,
-                    }
-                  : {}),
-              }
-            : {}),
-          ...(triggerResolver
-            ? {
-                ...(triggerResolver.resolveItems
-                  ? {
-                      resolveTriggerItems: triggerResolver.resolveItems,
-                      hasResolveTriggerItems: true,
-                    }
-                  : {}),
-                ...(triggerResolver.getNextDiscoveryState
-                  ? {
-                      getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
-                      hasGetNextDiscoveryState: true,
-                    }
-                  : {}),
-              }
-            : {}),
-          // On-deploy is presence-driven (no support flag): the behavior flags below
-          // (hasOnDeployPerform / hasResolveOnDeployItems) tell the platform what runs.
-          ...(onDeployTrigger
-            ? {
-                onDeployPerform: createCNIPerform({
-                  componentRegistry,
-                  onTrigger: onDeployTrigger,
-                }),
-                hasOnDeployPerform: true,
-              }
-            : {}),
-          ...(onDeployResolver
-            ? {
-                ...(onDeployResolver.resolveItems
-                  ? {
-                      resolveOnDeployItems: onDeployResolver.resolveItems,
-                      hasResolveOnDeployItems: true,
-                    }
-                  : {}),
-                ...(onDeployResolver.getNextDiscoveryState
-                  ? {
-                      getOnDeployNextDiscoveryState: onDeployResolver.getNextDiscoveryState,
-                      hasGetOnDeployNextDiscoveryState: true,
-                    }
-                  : {}),
-              }
-            : {}),
-        },
-      };
-    },
-    {},
-  );
+        perform: performFn,
+        onInstanceDeploy: deployFn,
+        hasOnInstanceDeploy: !!deployFn,
+        onInstanceDelete: deleteFn,
+        hasOnInstanceDelete: !!deleteFn,
+        webhookCreate: webhookCreateFn,
+        hasWebhookCreateFunction: !!webhookCreateFn,
+        webhookDelete: webhookDeleteFn,
+        hasWebhookDeleteFunction: !!webhookDeleteFn,
+        inputs: wrapperTriggerInputsFromReference(onTrigger, componentRegistry),
+        scheduleSupport: triggerType === "polling" ? "required" : "valid",
+        synchronousResponseSupport: "valid",
+        isPollingTrigger: triggerType === "polling",
+        triggerResolverSupport: triggerResolver ? "valid" : "invalid",
+        // The authoritative batch size is stored on the flow (see convertFlow). We also
+        // emit the single shared default on the synthesized trigger because component
+        // publish validation requires `triggerResolverDefaultBatchSize` whenever resolver
+        // support is active; both derive from the one `flow.batchConfig`.
+        ...(triggerResolver || onDeployResolver
+          ? {
+              triggerResolverDefaultBatchSize: batchConfig?.batchSize ?? 1,
+              ...(batchConfig?.concurrentBatchLimit !== undefined
+                ? {
+                    triggerResolverDefaultConcurrentBatchLimit: batchConfig.concurrentBatchLimit,
+                  }
+                : {}),
+            }
+          : {}),
+        ...(triggerResolver
+          ? {
+              ...(triggerResolver.resolveItems
+                ? {
+                    resolveTriggerItems: triggerResolver.resolveItems,
+                    hasResolveTriggerItems: true,
+                  }
+                : {}),
+              ...(triggerResolver.getNextDiscoveryState
+                ? {
+                    getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
+                    hasGetNextDiscoveryState: true,
+                  }
+                : {}),
+            }
+          : {}),
+        // On-deploy is presence-driven (no support flag): the behavior flags below
+        // (hasOnDeployPerform / hasResolveOnDeployItems) tell the platform what runs.
+        ...(onDeployTrigger
+          ? {
+              onDeployPerform: createCNIPerform({
+                componentRegistry,
+                onTrigger: onDeployTrigger,
+              }),
+              hasOnDeployPerform: true,
+            }
+          : {}),
+        ...(onDeployResolver
+          ? {
+              ...(onDeployResolver.resolveItems
+                ? {
+                    resolveOnDeployItems: onDeployResolver.resolveItems,
+                    hasResolveOnDeployItems: true,
+                  }
+                : {}),
+              ...(onDeployResolver.getNextDiscoveryState
+                ? {
+                    getOnDeployNextDiscoveryState: onDeployResolver.getNextDiscoveryState,
+                    hasGetOnDeployNextDiscoveryState: true,
+                  }
+                : {}),
+            }
+          : {}),
+      },
+    };
+  }, {});
 
   const convertedDataSources = Object.entries(configVars).reduce<Record<string, ServerDataSource>>(
     (result, [key, configVar]) => {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -78,17 +78,6 @@ import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } fr
 export const CONCURRENCY_LIMIT_MAX = 15;
 export const CONCURRENCY_LIMIT_MIN = 2;
 
-const validateFlowResolverBatchSize = (
-  flowName: string,
-  configName: "triggerResolver",
-  resolver: { batchSize: number } | undefined,
-): { batchSize: number } | undefined => {
-  if (!resolver) {
-    return undefined;
-  }
-  return { batchSize: validateBatchSize(flowName, configName, resolver.batchSize) };
-};
-
 export const convertIntegration = <
   TInputs extends Inputs,
   TActionInputs extends Inputs,
@@ -651,6 +640,7 @@ export const convertFlow = <
   result.onInstanceDelete = undefined;
   result.webhookLifecycleHandlers = undefined;
   result.onExecution = undefined;
+  result.onDeployTrigger = undefined;
   result.preprocessFlowConfig = undefined;
   result.errorConfig = undefined;
   result.testApiKeys = undefined;
@@ -777,12 +767,40 @@ export const convertFlow = <
   }
 
   const triggerResolver = "triggerResolver" in flow ? flow.triggerResolver : undefined;
-  if (triggerResolver) {
-    result.triggerResolver = validateFlowResolverBatchSize(
-      flow.name,
-      "triggerResolver",
-      triggerResolver,
-    );
+  const onDeployResolver = "onDeployResolver" in flow ? flow.onDeployResolver : undefined;
+  const batchConfig = "batchConfig" in flow ? flow.batchConfig : undefined;
+
+  // Resolver behaviors (resolveItems/getNextDiscoveryState) are serialized onto the
+  // synthesized trigger below. On the flow wire we emit only `triggerResolver`, the single
+  // config the platform reads (`trigger_resolver_batch_size` / `trigger_resolver_enabled`)
+  // and shares between the normal and on-deploy fires. `batchConfig`/`onDeployResolver` are
+  // author-side only — clear them out of the `{ ...flow }` spread.
+  result.triggerResolver = undefined;
+  result.onDeployResolver = undefined;
+  result.batchConfig = undefined;
+
+  if (triggerResolver || onDeployResolver) {
+    if (!batchConfig) {
+      throw new Error(
+        `${flow.name} defines a triggerResolver/onDeployResolver but no batchConfig. Add \`batchConfig: { batchSize }\` to the flow.`,
+      );
+    }
+
+    if (
+      onDeployResolver &&
+      (!("onDeployTrigger" in flow) || typeof flow.onDeployTrigger !== "function")
+    ) {
+      throw new Error(
+        `${flow.name} declares onDeployResolver without onDeployTrigger. Set onDeployTrigger to handle the initial-deploy fire that the resolver fans out.`,
+      );
+    }
+
+    // `enabled: true` is required: for a "valid"-support trigger (which CNI synthesized
+    // triggers are) the platform only batches when the flow's resolver is enabled.
+    result.triggerResolver = {
+      batchSize: validateBatchSize(flow.name, "batchConfig", batchConfig.batchSize),
+      enabled: true,
+    };
   }
 
   const actionStep: Record<string, unknown> = {
@@ -1541,7 +1559,10 @@ const codeNativeIntegrationComponent = <
         webhookLifecycleHandlers,
         schedule,
         triggerType,
+        batchConfig,
         triggerResolver,
+        onDeployTrigger,
+        onDeployResolver,
       },
     ) => {
       if (
@@ -1631,9 +1652,15 @@ const codeNativeIntegrationComponent = <
           synchronousResponseSupport: "valid",
           isPollingTrigger: triggerType === "polling",
           triggerResolverSupport: triggerResolver ? "valid" : "invalid",
+          // The authoritative batch size is stored on the flow (see convertFlow). We also
+          // emit the single shared default on the synthesized trigger because component
+          // publish validation requires `triggerResolverDefaultBatchSize` whenever resolver
+          // support is active; both derive from the one `flow.batchConfig`.
+          ...(triggerResolver || onDeployResolver
+            ? { triggerResolverDefaultBatchSize: batchConfig?.batchSize ?? 1 }
+            : {}),
           ...(triggerResolver
             ? {
-                triggerResolverDefaultBatchSize: triggerResolver.batchSize,
                 ...(triggerResolver.resolveItems
                   ? {
                       resolveTriggerItems: triggerResolver.resolveItems,
@@ -1644,6 +1671,33 @@ const codeNativeIntegrationComponent = <
                   ? {
                       getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
                       hasGetNextDiscoveryState: true,
+                    }
+                  : {}),
+              }
+            : {}),
+          // On-deploy is presence-driven (no support flag): the behavior flags below
+          // (hasOnDeployPerform / hasResolveOnDeployItems) tell the platform what runs.
+          ...(onDeployTrigger
+            ? {
+                onDeployPerform: createCNIPerform({
+                  componentRegistry,
+                  onTrigger: onDeployTrigger,
+                }),
+                hasOnDeployPerform: true,
+              }
+            : {}),
+          ...(onDeployResolver
+            ? {
+                ...(onDeployResolver.resolveItems
+                  ? {
+                      resolveOnDeployItems: onDeployResolver.resolveItems,
+                      hasResolveOnDeployItems: true,
+                    }
+                  : {}),
+                ...(onDeployResolver.getNextDiscoveryState
+                  ? {
+                      getOnDeployNextDiscoveryState: onDeployResolver.getNextDiscoveryState,
+                      hasGetOnDeployNextDiscoveryState: true,
                     }
                   : {}),
               }

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -107,12 +107,24 @@ const defaultResolveItems = (
 ) => result.payload.body.data as unknown[];
 
 /**
+ * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
+ * `discoveryState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
+ * `payload.discoveryState`. Reading it back (defaulting to `null`) is the whole pagination
+ * loop: a non-null value re-invokes the fire, `null` ends it. Authors never write this.
+ */
+const defaultGetNextDiscoveryState = (
+  _context: ActionContext,
+  result: { payload: { discoveryState?: Record<string, unknown> | null } },
+) => result.payload.discoveryState ?? null;
+
+/**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
- * conversion pipeline already understands. The trigger fires return just `{ items }`; here we
- * wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: { data:
- * items } } }`, synthesize the default `resolveItems`, and map the pagination callbacks onto
- * the resolver `getNextDiscoveryState`. Flows without a `trigger` pass through unchanged.
+ * conversion pipeline already understands. The trigger fires return `{ items, discoveryState? }`;
+ * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
+ * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
+ * items back) and `getNextDiscoveryState` (reads the cursor back). Flows without a `trigger`
+ * pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -132,17 +144,23 @@ const normalizeBatchedFlow = <
     return flow;
   }
 
-  const { onTrigger, onDeploy, getNextOnTriggerPaginationState, getNextOnDeployPaginationState } =
-    trigger;
+  const { onTrigger, onDeploy } = trigger;
 
-  // Wrap a batched fire (returns `{ items, response? }`) into a TriggerPerformFunction that
-  // emits the wire payload shape (`body.data = items`), preserving the incoming payload fields.
+  // Wrap a batched fire (returns `{ items, discoveryState?, response? }`) into a
+  // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
+  // next-page cursor at `discoveryState` (defaulting `null` to terminate the loop). The
+  // incoming payload's `discoveryState` was already consumed by the fire, so overwriting it
+  // with the returned cursor is safe — `getNextDiscoveryState` reads it straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, response } = await fire(context as never, payload as never);
+      const { items, discoveryState, response } = await fire(context as never, payload as never);
       return {
-        payload: { ...payload, body: { data: items, contentType: "application/json" } },
+        payload: {
+          ...payload,
+          body: { data: items, contentType: "application/json" },
+          discoveryState: discoveryState ?? null,
+        },
         ...(response ? { response } : {}),
       };
     };
@@ -155,17 +173,13 @@ const normalizeBatchedFlow = <
     ...(onDeploy ? { onDeployTrigger: wrapFire(onDeploy) } : {}),
     triggerResolver: {
       resolveItems: defaultResolveItems,
-      ...(getNextOnTriggerPaginationState
-        ? { getNextDiscoveryState: getNextOnTriggerPaginationState }
-        : {}),
+      getNextDiscoveryState: defaultGetNextDiscoveryState,
     },
     ...(onDeploy
       ? {
           onDeployResolver: {
             resolveItems: defaultResolveItems,
-            ...(getNextOnDeployPaginationState
-              ? { getNextDiscoveryState: getNextOnDeployPaginationState }
-              : {}),
+            getNextDiscoveryState: defaultGetNextDiscoveryState,
           },
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -78,12 +78,7 @@ import {
   type Input as ServerInput,
   type RequiredConfigVariable as ServerRequiredConfigVariable,
 } from "./integration";
-import {
-  aliasPaginationState,
-  createCNIComponentRefPerform,
-  createCNIPerform,
-  createCNIPollingPerform,
-} from "./perform";
+import { createCNIComponentRefPerform, createCNIPerform, createCNIPollingPerform } from "./perform";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 export const CONCURRENCY_LIMIT_MAX = 15;
@@ -91,11 +86,11 @@ export const CONCURRENCY_LIMIT_MIN = 2;
 
 /**
  * The wire-shape resolver synthesized by {@link normalizeBatchedFlow} and read by the trigger
- * reducer. Mirrors the server `Trigger`'s `resolveTriggerItems`/`getNextDiscoveryState` slots.
+ * reducer. Mirrors the server `Trigger`'s `resolveTriggerItems`/`getNextPaginationState` slots.
  */
 interface WireResolver {
   resolveItems?: (context: ActionContext, result: { payload: TriggerPayload }) => unknown[];
-  getNextDiscoveryState?: (
+  getNextPaginationState?: (
     context: ActionContext,
     result: { payload: TriggerPayload },
   ) => Record<string, unknown> | null;
@@ -112,27 +107,24 @@ const defaultResolveItems = (
 ) => result.payload.body.data as unknown[];
 
 /**
- * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
- * `paginationState`; the wrapper {@link normalizeBatchedFlow} builds stamps it onto the wire
- * field `payload.discoveryState` (the name the backend's discovery loop reads). Reading it back
- * (defaulting to `null`) is the whole loop: a non-null value re-invokes the fire, `null` ends it.
- * Authors never write this. The wire name stays `discoveryState` — only the author surface uses
- * `paginationState`.
+ * Default `getNextPaginationState`: a batched fire returns the next page's cursor as
+ * `paginationState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
+ * `payload.paginationState`. Reading it back (defaulting to `null`) is the whole loop: a
+ * non-null value re-invokes the fire, `null` ends it. Authors never write this.
  */
-const defaultGetNextDiscoveryState = (
+const defaultGetNextPaginationState = (
   _context: ActionContext,
-  result: { payload: { discoveryState?: Record<string, unknown> | null } },
-) => result.payload.discoveryState ?? null;
+  result: { payload: { paginationState?: Record<string, unknown> | null } },
+) => result.payload.paginationState ?? null;
 
 /**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
  * conversion pipeline already understands. The trigger fires return `{ items, paginationState? }`;
  * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
- * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
- * items back) and `getNextDiscoveryState` (reads the cursor back). The author surface speaks
- * `paginationState`; this wrapper is the boundary where it is translated to/from the wire
- * `discoveryState`. Flows without a `trigger` pass through unchanged.
+ * data: items }, paginationState } }`, then synthesize the default `resolveItems` (reads the
+ * items back) and `getNextPaginationState` (reads the cursor back). Flows without a `trigger`
+ * pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -156,22 +148,18 @@ const normalizeBatchedFlow = <
 
   // Wrap a batched fire (returns `{ items, paginationState?, response? }`) into a
   // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
-  // next-page cursor at the wire field `discoveryState` (defaulting `null` to terminate the
-  // loop). This is the author/wire boundary: the incoming wire `discoveryState` is aliased to
-  // `paginationState` for the fire to read, and the cursor it returns is stamped back onto the
-  // wire `discoveryState` for `getNextDiscoveryState` to read straight back.
+  // next-page cursor at `paginationState` (defaulting `null` to terminate the loop). The
+  // incoming payload's `paginationState` was already consumed by the fire, so overwriting it
+  // with the returned cursor is safe — `getNextPaginationState` reads it straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, paginationState, response } = await fire(
-        context as never,
-        aliasPaginationState(payload) as never,
-      );
+      const { items, paginationState, response } = await fire(context as never, payload as never);
       return {
         payload: {
           ...payload,
           body: { data: items, contentType: "application/json" },
-          discoveryState: paginationState ?? null,
+          paginationState: paginationState ?? null,
         },
         ...(response ? { response } : {}),
       };
@@ -185,13 +173,13 @@ const normalizeBatchedFlow = <
     ...(onDeploy ? { onDeployTrigger: wrapFire(onDeploy) } : {}),
     triggerResolver: {
       resolveItems: defaultResolveItems,
-      getNextDiscoveryState: defaultGetNextDiscoveryState,
+      getNextPaginationState: defaultGetNextPaginationState,
     },
     ...(onDeploy
       ? {
           onDeployResolver: {
             resolveItems: defaultResolveItems,
-            getNextDiscoveryState: defaultGetNextDiscoveryState,
+            getNextPaginationState: defaultGetNextPaginationState,
           },
         }
       : {}),
@@ -898,7 +886,7 @@ export const convertFlow = <
   const onDeployResolver = "onDeployResolver" in flow ? flow.onDeployResolver : undefined;
   const batchConfig = "batchConfig" in flow ? flow.batchConfig : undefined;
 
-  // Resolver behaviors (resolveItems/getNextDiscoveryState) are serialized onto the
+  // Resolver behaviors (resolveItems/getNextPaginationState) are serialized onto the
   // synthesized trigger below. On the flow wire we emit only `triggerResolver`, the single
   // config the platform reads (`trigger_resolver_batch_size` / `trigger_resolver_enabled`)
   // and shares between the normal and on-deploy fires. `batchConfig`/`onDeployResolver` are
@@ -1811,9 +1799,9 @@ const codeNativeIntegrationComponent = <
                     hasResolveTriggerItems: true,
                   }
                 : {}),
-              ...(triggerResolver.getNextDiscoveryState
+              ...(triggerResolver.getNextPaginationState
                 ? {
-                    getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
+                    getNextPaginationState: triggerResolver.getNextPaginationState,
                     hasGetNextDiscoveryState: true,
                   }
                 : {}),
@@ -1838,9 +1826,9 @@ const codeNativeIntegrationComponent = <
                     hasResolveOnDeployItems: true,
                   }
                 : {}),
-              ...(onDeployResolver.getNextDiscoveryState
+              ...(onDeployResolver.getNextPaginationState
                 ? {
-                    getOnDeployNextDiscoveryState: onDeployResolver.getNextDiscoveryState,
+                    getOnDeployNextPaginationState: onDeployResolver.getNextPaginationState,
                     hasGetOnDeployNextDiscoveryState: true,
                   }
                 : {}),

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -201,7 +201,7 @@ export type TriggerEventFunction = (
 
 /**
  * Wire format the platform expects for a trigger. Note: function references
- * (perform, resolveTriggerItems, getNextDiscoveryState, ...) don't survive JSON
+ * (perform, resolveTriggerItems, getNextPaginationState, ...) don't survive JSON
  * serialization, so each callback has a paired `hasXxx: boolean` flag the
  * server reads to detect presence. Keep the flag and its callback in sync.
  *
@@ -267,7 +267,7 @@ export interface Trigger<
     result: TriggerBaseResult<TPayload>,
   ) => unknown[];
   hasResolveTriggerItems?: boolean;
-  getNextDiscoveryState?: (
+  getNextPaginationState?: (
     context: ActionContext<TConfigVars>,
     result: TriggerBaseResult<TPayload>,
   ) => Record<string, unknown> | null;
@@ -290,7 +290,7 @@ export interface Trigger<
     result: TriggerBaseResult<TPayload>,
   ) => unknown[];
   hasResolveOnDeployItems?: boolean;
-  getOnDeployNextDiscoveryState?: (
+  getOnDeployNextPaginationState?: (
     context: ActionContext<TConfigVars>,
     result: TriggerBaseResult<TPayload>,
   ) => Record<string, unknown> | null;

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -261,6 +261,7 @@ export interface Trigger<
    * platform reads only this field for both paths; there is no separate on-deploy default.
    */
   triggerResolverDefaultBatchSize?: number;
+  triggerResolverDefaultConcurrentBatchLimit?: number;
   resolveTriggerItems?: (
     context: ActionContext<TConfigVars>,
     result: TriggerBaseResult<TPayload>,

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -171,8 +171,8 @@ interface HttpResponse {
   body?: string;
 }
 
-interface TriggerBaseResult {
-  payload: TriggerPayload;
+interface TriggerBaseResult<TPayload extends TriggerPayload = TriggerPayload> {
+  payload: TPayload;
   response?: HttpResponse;
   instanceState?: Record<string, unknown>;
   crossFlowState?: Record<string, unknown>;
@@ -182,11 +182,15 @@ interface TriggerBaseResult {
   error?: Record<string, unknown>;
 }
 
-interface TriggerBranchingResult extends TriggerBaseResult {
+interface TriggerBranchingResult<TPayload extends TriggerPayload = TriggerPayload>
+  extends TriggerBaseResult<TPayload> {
   branch: string;
 }
 
-export type TriggerResult = TriggerBranchingResult | TriggerBaseResult | undefined;
+export type TriggerResult<TPayload extends TriggerPayload = TriggerPayload> =
+  | TriggerBranchingResult<TPayload>
+  | TriggerBaseResult<TPayload>
+  | undefined;
 
 export type TriggerEventFunctionResult = TriggerEventFunctionReturn | void;
 
@@ -195,6 +199,12 @@ export type TriggerEventFunction = (
   params: Record<string, unknown>,
 ) => Promise<TriggerEventFunctionResult>;
 
+/**
+ * Wire format the platform expects for a trigger. Note: function references
+ * (perform, resolveTriggerItems, getNextDiscoveryState, ...) don't survive JSON
+ * serialization, so each callback has a paired `hasXxx: boolean` flag the
+ * server reads to detect presence. Keep the flag and its callback in sync.
+ */
 export interface Trigger<
   TInputs extends Inputs,
   TActionInputs extends Inputs,
@@ -240,6 +250,18 @@ export interface Trigger<
   hasWebhookDeleteFunction?: boolean;
   scheduleSupport: TriggerOptionChoice;
   synchronousResponseSupport: TriggerOptionChoice;
+  triggerResolverSupport?: TriggerOptionChoice;
+  triggerResolverDefaultBatchSize?: number;
+  resolveTriggerItems?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => unknown[];
+  hasResolveTriggerItems?: boolean;
+  getNextDiscoveryState?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => Record<string, unknown> | null;
+  hasGetNextDiscoveryState?: boolean;
   examplePayload?: unknown;
   isCommonTrigger?: boolean;
   isPollingTrigger?: boolean;

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -204,6 +204,11 @@ export type TriggerEventFunction = (
  * (perform, resolveTriggerItems, getNextDiscoveryState, ...) don't survive JSON
  * serialization, so each callback has a paired `hasXxx: boolean` flag the
  * server reads to detect presence. Keep the flag and its callback in sync.
+ *
+ * The on-deploy fire is named asymmetrically by intent: CNI flow authors set
+ * `onDeployTrigger` (sibling to `onTrigger`), component-trigger authors set
+ * `onDeployPerform` (sibling to `perform`), and both flatten to
+ * `onDeployPerform` here on the wire.
  */
 export interface Trigger<
   TInputs extends Inputs,
@@ -251,6 +256,10 @@ export interface Trigger<
   scheduleSupport: TriggerOptionChoice;
   synchronousResponseSupport: TriggerOptionChoice;
   triggerResolverSupport?: TriggerOptionChoice;
+  /**
+   * The single default batch size shared by the trigger and on-deploy resolvers. The
+   * platform reads only this field for both paths; there is no separate on-deploy default.
+   */
   triggerResolverDefaultBatchSize?: number;
   resolveTriggerItems?: (
     context: ActionContext<TConfigVars>,
@@ -262,6 +271,29 @@ export interface Trigger<
     result: TriggerBaseResult<TPayload>,
   ) => Record<string, unknown> | null;
   hasGetNextDiscoveryState?: boolean;
+  onDeployPerform?:
+    | TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>
+    | PollingTriggerPerformFunction<
+        TInputs,
+        TActionInputs,
+        TConfigVars,
+        TPayload,
+        TAllowsBranching,
+        TResult
+      >
+    | CNIPollingPerformFunction<TInputs, TConfigVars, TPayload, TAllowsBranching>
+    | ComponentRefTriggerPerformFunction<TInputs, TConfigVars>;
+  hasOnDeployPerform?: boolean;
+  resolveOnDeployItems?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => unknown[];
+  hasResolveOnDeployItems?: boolean;
+  getOnDeployNextDiscoveryState?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => Record<string, unknown> | null;
+  hasGetOnDeployNextDiscoveryState?: boolean;
   examplePayload?: unknown;
   isCommonTrigger?: boolean;
   isPollingTrigger?: boolean;

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -77,6 +77,21 @@ export const cleanParams = (
   }, {});
 };
 
+/**
+ * The platform stamps a paginated re-run's cursor onto the runtime payload's `discoveryState`
+ * — the wire field the backend owns and re-stamps each round. Author-facing trigger code reads
+ * the cursor as `paginationState`, so we expose that alias on the payload before any author
+ * perform/resolver runs. The wire `discoveryState` is left intact, so the backend's discovery
+ * loop is unaffected.
+ */
+export const aliasPaginationState = <T>(payload: T): T => {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+  const { discoveryState } = payload as { discoveryState?: unknown };
+  return { ...(payload as Record<string, unknown>), paginationState: discoveryState } as T;
+};
+
 export const createPerform = (
   performFn: PerformFn,
   { inputCleaners, errorHandler }: CreatePerformProps,
@@ -110,7 +125,11 @@ export const createPerform = (
         invokeFlow: createInvokeFlow(context),
       };
 
-      const result = await performFn(actionContext, payload, cleanParams(params, inputCleaners));
+      const result = await performFn(
+        actionContext,
+        aliasPaginationState(payload),
+        cleanParams(params, inputCleaners),
+      );
 
       logDebugResults(actionContext);
 

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -77,21 +77,6 @@ export const cleanParams = (
   }, {});
 };
 
-/**
- * The platform stamps a paginated re-run's cursor onto the runtime payload's `discoveryState`
- * — the wire field the backend owns and re-stamps each round. Author-facing trigger code reads
- * the cursor as `paginationState`, so we expose that alias on the payload before any author
- * perform/resolver runs. The wire `discoveryState` is left intact, so the backend's discovery
- * loop is unaffected.
- */
-export const aliasPaginationState = <T>(payload: T): T => {
-  if (!payload || typeof payload !== "object") {
-    return payload;
-  }
-  const { discoveryState } = payload as { discoveryState?: unknown };
-  return { ...(payload as Record<string, unknown>), paginationState: discoveryState } as T;
-};
-
 export const createPerform = (
   performFn: PerformFn,
   { inputCleaners, errorHandler }: CreatePerformProps,
@@ -125,11 +110,7 @@ export const createPerform = (
         invokeFlow: createInvokeFlow(context),
       };
 
-      const result = await performFn(
-        actionContext,
-        aliasPaginationState(payload),
-        cleanParams(params, inputCleaners),
-      );
+      const result = await performFn(actionContext, payload, cleanParams(params, inputCleaners));
 
       logDebugResults(actionContext);
 

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -573,7 +573,7 @@ export const invokeFlow = async <
     TPayload
   >,
 >(
-  // `any` for TItem/TDiscoveryState/TTriggerPayload: the tester accepts a flow with any
+  // `any` for TItem/TPaginationState/TTriggerPayload: the tester accepts a flow with any
   // resolver item and cursor typing; it drives the flow dynamically and does not rely on
   // the precise `onExecution` param type.
   flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, any, any, any>,

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -573,7 +573,10 @@ export const invokeFlow = async <
     TPayload
   >,
 >(
-  flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>,
+  // `any` for TItem/TDiscoveryState/TTriggerPayload: the tester accepts a flow with any
+  // resolver item and cursor typing; it drives the flow dynamically and does not rely on
+  // the precise `onExecution` param type.
+  flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, any, any, any>,
   {
     configVars,
     context,

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -64,7 +64,7 @@ export type IntegrationDefinition<
    * Flows for this integration. See
    * https://prismatic.io/docs/integrations/code-native/flows/
    *
-   * The trailing `any`s for `TItem`/`TDiscoveryState`/`TTriggerPayload` let flows with
+   * The trailing `any`s for `TItem`/`TPaginationState`/`TTriggerPayload` let flows with
    * different resolver item and cursor types live in one array. `integration` only holds
    * and serializes these flows (it never invokes `onExecution`), so the precise — and
    * per-flow distinct — `onExecution` param type does not need to be preserved here.
@@ -105,9 +105,10 @@ export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unkn
 
 /**
  * The page of records a batched trigger fire (`onTrigger`/`onDeploy`) returns. The author
- * returns the items plus, when paginating, the cursor for the next page, spectral
- * wraps the items into the wire trigger payload (`body.data`), stamps `discoveryState` onto it,
- * and synthesizes the resolver that reads both back. There is no separate pagination callback to define.
+ * returns the items plus, when paginating, the cursor for the next page. spectral wraps the
+ * items into the wire trigger payload (`body.data`), carries the `paginationState` to the next
+ * round, and synthesizes the resolver that reads both back. There is no separate pagination
+ * callback to define.
  */
 export interface BatchedTriggerReturn<
   TItem,
@@ -117,21 +118,21 @@ export interface BatchedTriggerReturn<
   items: TItem[];
   /**
    * Cursor for the next page. Return it to paginate — the fire is re-invoked with this object on
-   * `payload.discoveryState`. Omit or return `null` to stop. Compute it here from the fetch
+   * `payload.paginationState`. Omit or return `null` to stop. Compute it here from the fetch
    * response, where the next-page token is still in scope.
    */
-  discoveryState?: TPaginationState | null;
+  paginationState?: TPaginationState | null;
   /** Optional HTTP response to the request that invoked the integration. */
   response?: HttpResponse;
 }
 
 /**
  * A batched trigger built by {@link batchFlowTrigger}. Bundles the normal and on-deploy trigger
- * fires, each returning `{ items, discoveryState? }`. The two type parameters — supplied
+ * fires, each returning `{ items, paginationState? }`. The two type parameters — supplied
  * explicitly to `batchFlowTrigger<TItem, TPaginationState>(...)` — flow through to the rest of
  * the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
- * `TPaginationState` types both `payload.discoveryState` (read on the way in) and the
- * `discoveryState` each fire returns (the next page's cursor).
+ * `TPaginationState` types both `payload.paginationState` (read on the way in) and the
+ * `paginationState` each fire returns (the next page's cursor).
  */
 export interface BatchTrigger<
   TItem,
@@ -139,8 +140,8 @@ export interface BatchTrigger<
 > {
   /**
    * The trigger function for this flow. Fetches a page of records and returns them as `items`,
-   * plus the next page's `discoveryState` to paginate (omit/`null` to stop). Read the cursor for
-   * the current page from `payload.discoveryState`.
+   * plus the next page's `paginationState` to paginate (omit/`null` to stop). Read the cursor for
+   * the current page from `payload.paginationState`.
    */
   onTrigger: (
     context: ActionContext<ConfigVars>,
@@ -148,7 +149,7 @@ export interface BatchTrigger<
   ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
   /**
    * The on-deploy trigger fire, run once on initial instance deploy. Same shape as `onTrigger`;
-   * return `discoveryState` to paginate the backfill.
+   * return `paginationState` to paginate the backfill.
    */
   onDeploy?: (
     context: ActionContext<ConfigVars>,
@@ -203,7 +204,7 @@ export type FlowExecutionContextActions = FlowExecutionContext["components"];
  * union is deliberate — a function property living in a union member loses contextual
  * parameter typing, which would make `onExecution`'s `context`/`params` implicitly `any`.
  */
-interface BatchFields<TItem, TDiscoveryState extends Record<string, unknown>> {
+interface BatchFields<TItem, TPaginationState extends Record<string, unknown>> {
   /**
    * Batch-dispatch config for this flow. Items returned by the `trigger`'s fires are chunked
    * into batches of `batchSize`. For a CNI flow this value is authoritative (what's written
@@ -215,7 +216,7 @@ interface BatchFields<TItem, TDiscoveryState extends Record<string, unknown>> {
    * (`onTrigger`/`onDeploy`) return just `items`; spectral synthesizes the resolver that
    * extracts them and maps the pagination callbacks. Required when `batchConfig` is set.
    */
-  trigger: BatchTrigger<TItem, TDiscoveryState>;
+  trigger: BatchTrigger<TItem, TPaginationState>;
   /** A batched flow's trigger fires live inside `trigger`; the flat `onTrigger` is forbidden. */
   onTrigger?: never;
   /** A batched flow's on-deploy fire lives inside `trigger`; the flat `onDeployTrigger` is forbidden. */
@@ -233,8 +234,8 @@ interface NonBatchFields {
  * The discriminated union coupling `batchConfig` and the batched `trigger`. Intersected
  * into each flow variant at {@link Flow}.
  */
-type BatchDiscriminant<TItem, TDiscoveryState extends Record<string, unknown>> =
-  | BatchFields<TItem, TDiscoveryState>
+type BatchDiscriminant<TItem, TPaginationState extends Record<string, unknown>> =
+  | BatchFields<TItem, TPaginationState>
   | NonBatchFields;
 
 /** Base properties shared by all flow types. */
@@ -317,7 +318,7 @@ interface StandardFlow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > extends FlowBase<TTriggerPayload, TItem> {
   triggerType?: StandardTriggerType;
   /** Schedule configuration that defines the frequency with which this flow will be automatically executed. */
@@ -327,7 +328,7 @@ interface StandardFlow<
   /** Specifies the trigger function for this flow, which returns a payload and optional HTTP response. */
   onTrigger?:
     | TriggerReference
-    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult, TDiscoveryState>;
+    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult, TPaginationState>;
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
@@ -337,7 +338,7 @@ interface StandardFlow<
     ConfigVars,
     TAllowsBranching,
     TResult,
-    TDiscoveryState
+    TPaginationState
   >;
 }
 
@@ -355,7 +356,7 @@ interface PollingFlow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > extends FlowBase<TTriggerPayload, TItem> {
   /**
    * Type of trigger for this flow. A "polling" trigger runs on a schedule
@@ -386,7 +387,7 @@ interface PollingFlow<
     ConfigVars,
     TAllowsBranching,
     TResult,
-    TDiscoveryState
+    TPaginationState
   >;
 }
 
@@ -402,7 +403,7 @@ export type Flow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | (StandardFlow<
       TInputs,
@@ -411,9 +412,9 @@ export type Flow<
       TResult,
       TTriggerPayload,
       TItem,
-      TDiscoveryState
+      TPaginationState
     > &
-      BatchDiscriminant<TItem, TDiscoveryState>)
+      BatchDiscriminant<TItem, TPaginationState>)
   | (PollingFlow<
       TInputs,
       TActionInputs,
@@ -422,9 +423,9 @@ export type Flow<
       TResult,
       TTriggerPayload,
       TItem,
-      TDiscoveryState
+      TPaginationState
     > &
-      BatchDiscriminant<TItem, TDiscoveryState>);
+      BatchDiscriminant<TItem, TPaginationState>);
 
 export type FlowTriggerType = PollingTriggerType | StandardTriggerType;
 

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -13,11 +13,11 @@ import type { HttpResponse } from "./HttpResponse";
 import type { Inputs } from "./Inputs";
 import type { PollingTriggerPerformFunction } from "./PollingTriggerDefinition";
 import type { ScopedConfigVarMap } from "./ScopedConfigVars";
-import type { BatchConfig, WithDiscoveryState } from "./TriggerDefinition";
+import type { BatchConfig } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
+import type { TriggerResult } from "./TriggerResult";
 
 /**
  * Defines attributes of a code-native integration. See
@@ -105,59 +105,55 @@ export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unkn
 
 /**
  * The page of records a batched trigger fire (`onTrigger`/`onDeploy`) returns. The author
- * returns just the items; spectral wraps them into the wire trigger payload (`body.data`)
- * and synthesizes the resolver that extracts them. Returning `items` is the whole contract —
- * there is no `payload` to thread by hand.
+ * returns the items plus, when paginating, the cursor for the next page, spectral
+ * wraps the items into the wire trigger payload (`body.data`), stamps `discoveryState` onto it,
+ * and synthesizes the resolver that reads both back. There is no separate pagination callback to define.
  */
-export interface BatchedTriggerReturn<TItem> {
+export interface BatchedTriggerReturn<
+  TItem,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** The records produced by this trigger fire. Chunked into batches of the flow's `batchConfig.batchSize`. */
   items: TItem[];
+  /**
+   * Cursor for the next page. Return it to paginate — the fire is re-invoked with this object on
+   * `payload.discoveryState`. Omit or return `null` to stop. Compute it here from the fetch
+   * response, where the next-page token is still in scope.
+   */
+  discoveryState?: TPaginationState | null;
   /** Optional HTTP response to the request that invoked the integration. */
   response?: HttpResponse;
 }
 
 /**
- * The pagination callback for a batched trigger fire. Returns the state for the next page,
- * or `null` to stop. A non-null return re-invokes the corresponding trigger with this object
- * stamped onto `payload.discoveryState`; the loop ends when it returns `null`.
- */
-export type BatchPaginationStateFunction<TPaginationState extends Record<string, unknown>> = (
-  context: ActionContext<ConfigVars>,
-  result: TriggerBaseResult<WithDiscoveryState<TriggerPayload, TPaginationState>>,
-) => TPaginationState | null;
-
-/**
  * A batched trigger built by {@link batchFlowTrigger}. Bundles the normal and on-deploy trigger
- * fires (each returning just `items`) with their pagination callbacks. The two type parameters
- * — supplied explicitly to `batchTrigger<TItem, TPaginationState>(...)` — flow through to the
- * rest of the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
- * `TPaginationState` types `payload.discoveryState` and the pagination callbacks' return.
+ * fires, each returning `{ items, discoveryState? }`. The two type parameters — supplied
+ * explicitly to `batchFlowTrigger<TItem, TPaginationState>(...)` — flow through to the rest of
+ * the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
+ * `TPaginationState` types both `payload.discoveryState` (read on the way in) and the
+ * `discoveryState` each fire returns (the next page's cursor).
  */
 export interface BatchTrigger<
   TItem,
   TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /**
-   * The trigger function for this flow. Fetches a page of records and returns them as `items`.
-   * Re-invoked once per pagination round (see `getNextOnTriggerPaginationState`); read the
-   * cursor for the current page from `payload.discoveryState`.
+   * The trigger function for this flow. Fetches a page of records and returns them as `items`,
+   * plus the next page's `discoveryState` to paginate (omit/`null` to stop). Read the cursor for
+   * the current page from `payload.discoveryState`.
    */
   onTrigger: (
     context: ActionContext<ConfigVars>,
     payload: TriggerPayload<TPaginationState>,
-  ) => Promise<BatchedTriggerReturn<TItem>>;
+  ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
   /**
    * The on-deploy trigger fire, run once on initial instance deploy. Same shape as `onTrigger`;
-   * pair with `getNextOnDeployPaginationState` to paginate.
+   * return `discoveryState` to paginate the backfill.
    */
   onDeploy?: (
     context: ActionContext<ConfigVars>,
     payload: TriggerPayload<TPaginationState>,
-  ) => Promise<BatchedTriggerReturn<TItem>>;
-  /** Pagination for `onTrigger`: return the next page's state, or `null` to stop. */
-  getNextOnTriggerPaginationState?: BatchPaginationStateFunction<TPaginationState>;
-  /** Pagination for `onDeploy`: return the next page's state, or `null` to stop. */
-  getNextOnDeployPaginationState?: BatchPaginationStateFunction<TPaginationState>;
+  ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
 }
 
 export type FlowOnExecution<

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -9,13 +9,14 @@ import type {
 import type { ConfigPages, UserLevelConfigPages } from "./ConfigPages";
 import type { ConfigVars } from "./ConfigVars";
 import type { FlowDefinitionFlowSchema } from "./FlowSchemas";
-import type { ConfigVarResultCollection, Inputs } from "./Inputs";
+import type { Inputs } from "./Inputs";
 import type { PollingTriggerPerformFunction } from "./PollingTriggerDefinition";
 import type { ScopedConfigVarMap } from "./ScopedConfigVars";
+import type { BatchConfig, TriggerResolverBehavior } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
+import type { TriggerResult } from "./TriggerResult";
 
 /**
  * Defines attributes of a code-native integration. See
@@ -61,8 +62,13 @@ export type IntegrationDefinition<
   /**
    * Flows for this integration. See
    * https://prismatic.io/docs/integrations/code-native/flows/
+   *
+   * The trailing `any`s for `TItem`/`TDiscoveryState`/`TTriggerPayload` let flows with
+   * different resolver item and cursor types live in one array. `integration` only holds
+   * and serializes these flows (it never invokes `onExecution`), so the precise — and
+   * per-flow distinct — `onExecution` param type does not need to be preserved here.
    */
-  flows: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult>[];
+  flows: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, any, any, any>[];
   /**
    * Config wizard pages for this integration. See
    * https://prismatic.io/docs/integrations/code-native/config-wizard/
@@ -86,12 +92,25 @@ export type IntegrationDefinition<
   componentRegistry?: ComponentRegistry;
 };
 
-export type FlowOnExecution<TTriggerPayload extends TriggerPayload> = ActionPerformFunction<
+/**
+ * The trigger payload as `onExecution` sees it. When a `triggerResolver` is in
+ * play, the platform replaces `body.data` with this execution's batch slice —
+ * a single `TItem` when `batchSize` is 1, otherwise a `TItem[]`. When no item
+ * type is known (`TItem` defaults to `unknown`), the payload is left untouched.
+ */
+export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unknown extends TItem
+  ? TPayload
+  : Omit<TPayload, "body"> & { body: { data: TItem | TItem[]; contentType?: string } };
+
+export type FlowOnExecution<
+  TTriggerPayload extends TriggerPayload,
+  TItem = unknown,
+> = ActionPerformFunction<
   {
     onTrigger: {
       type: "data";
       label: string;
-      clean: (value: unknown) => { results: TTriggerPayload };
+      clean: (value: unknown) => { results: BatchedTriggerPayload<TTriggerPayload, TItem> };
     };
   },
   ConfigVars,
@@ -112,7 +131,11 @@ export type FlowExecutionContext = ActionContext<
 export type FlowExecutionContextActions = FlowExecutionContext["components"];
 
 /** Base properties shared by all flow types. */
-interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload> {
+interface FlowBase<
+  TTriggerPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** The unique name for this flow. */
   name: string;
   /** A unique, unchanging value that is used to maintain identity for the flow even if the name changes. */
@@ -144,12 +167,24 @@ interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload> {
   organizationApiKeys?: string[];
   testApiKeys?: string[];
   /**
-   * Trigger resolver configuration: batches the records returned by the
-   * trigger into parallel dispatches. When using an existing component
-   * trigger, that trigger must declare `triggerResolverSupport`. CNI flows
-   * infer support from the resolver's presence.
+   * Batch-dispatch config for this flow's resolvers. A single config shared by both
+   * `triggerResolver` and `onDeployResolver` — they always batch the same way. For a
+   * CNI flow this value is authoritative (what's written here is what's used). Required
+   * whenever the flow defines a `triggerResolver` or `onDeployResolver`.
    */
-  triggerResolver?: TriggerResolverConfig<ConfigVars, TTriggerPayload>;
+  batchConfig?: BatchConfig;
+  /**
+   * Trigger resolver behavior: extracts the items returned by the trigger into batched
+   * dispatches and (optionally) paginates. Sizing comes from the flow's `batchConfig`.
+   * When using an existing component trigger, that trigger must declare
+   * `triggerResolverSupport`; CNI flows infer support from the resolver's presence.
+   */
+  triggerResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
+  /**
+   * On-deploy resolver behavior: same as `triggerResolver` but for the `onDeployTrigger`
+   * initial-deploy fire. Shares the flow's `batchConfig`.
+   */
+  onDeployResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
   /** Error handling configuration. */
   errorConfig?: StepErrorConfig;
   /** Optional schemas definitions for the flow. Currently only for use with AI agents. */
@@ -177,7 +212,7 @@ interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload> {
     delete: TriggerEventFunction<Inputs, ConfigVars>;
   };
   /** Specifies the main function for this flow which is run when this flow is invoked. */
-  onExecution: FlowOnExecution<TTriggerPayload>;
+  onExecution: FlowOnExecution<TTriggerPayload, TItem>;
 }
 
 export type StandardTriggerType = "standard";
@@ -192,7 +227,9 @@ interface StandardFlow<
     TPayload
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
-> extends FlowBase<TTriggerPayload> {
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+> extends FlowBase<TTriggerPayload, TItem, TDiscoveryState> {
   triggerType?: StandardTriggerType;
   /** Schedule configuration that defines the frequency with which this flow will be automatically executed. */
   schedule?: (ValueExpression<string> | ConfigVarExpression) & {
@@ -201,7 +238,22 @@ interface StandardFlow<
   /** Specifies the trigger function for this flow, which returns a payload and optional HTTP response. */
   onTrigger?:
     | TriggerReference
-    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult>;
+    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult, TDiscoveryState>;
+  /**
+   * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
+   * Typically used to backfill baseline records for systems whose webhooks only emit future events.
+   *
+   * Sibling to `onTrigger` (just as a component trigger's `onDeployPerform` is the
+   * sibling to its `perform`). Pair with `onDeployResolver` to batch the records this
+   * initial-deploy fire returns.
+   */
+  onDeployTrigger?: TriggerPerformFunction<
+    TInputs,
+    ConfigVars,
+    TAllowsBranching,
+    TResult,
+    TDiscoveryState
+  >;
 }
 
 export type PollingTriggerType = "polling";
@@ -217,7 +269,9 @@ interface PollingFlow<
     TPayload
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
-> extends FlowBase<TTriggerPayload> {
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+> extends FlowBase<TTriggerPayload, TItem, TDiscoveryState> {
   /**
    * Type of trigger for this flow. A "polling" trigger runs on a schedule
    * and can use context.polling.* functions. Requires schedule to be set.
@@ -238,6 +292,21 @@ interface PollingFlow<
     TAllowsBranching,
     TResult
   >;
+  /**
+   * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
+   * Typically used to backfill baseline records for systems whose webhooks only emit future events.
+   *
+   * Sibling to `onTrigger` (just as a component trigger's `onDeployPerform` is the
+   * sibling to its `perform`). Pair with `onDeployResolver` to batch the records this
+   * initial-deploy fire returns.
+   */
+  onDeployTrigger?: TriggerPerformFunction<
+    TInputs,
+    ConfigVars,
+    TAllowsBranching,
+    TResult,
+    TDiscoveryState
+  >;
 }
 
 /** Defines attributes of a flow of a code-native integration. */
@@ -251,9 +320,28 @@ export type Flow<
     TPayload
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
 > =
-  | StandardFlow<TInputs, TPayload, TAllowsBranching, TResult, TTriggerPayload>
-  | PollingFlow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, TTriggerPayload>;
+  | StandardFlow<
+      TInputs,
+      TPayload,
+      TAllowsBranching,
+      TResult,
+      TTriggerPayload,
+      TItem,
+      TDiscoveryState
+    >
+  | PollingFlow<
+      TInputs,
+      TActionInputs,
+      TPayload,
+      TAllowsBranching,
+      TResult,
+      TTriggerPayload,
+      TItem,
+      TDiscoveryState
+    >;
 
 export type FlowTriggerType = PollingTriggerType | StandardTriggerType;
 
@@ -344,25 +432,3 @@ export type EndpointSecurityType =
 
 /** Choices of Step Error Handlers that define the behavior when a step error occurs. */
 export type StepErrorHandlerType = "fail" | "ignore" | "retry";
-
-/** Configures how trigger items are batched when the trigger supports a resolver. */
-export type TriggerResolverConfig<
-  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
-  TPayload extends TriggerPayload = TriggerPayload,
-  TItem = unknown,
-> = {
-  /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
-  batchSize: number;
-  /** Extracts an array of items from the trigger result for batched dispatch. Receives the same context as the trigger's perform function. */
-  resolveItems?: (
-    context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<TPayload>,
-  ) => TItem[];
-  /** Called after each trigger run. When defined and returns a non-null object, the platform
-   *  queues another pagination round (re-invokes the trigger) and stamps the returned object
-   *  onto `payload.discoveryState` for that next invocation. Return `null` to stop. */
-  getNextDiscoveryState?: (
-    context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<TPayload>,
-  ) => Record<string, unknown> | null;
-};

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -9,14 +9,15 @@ import type {
 import type { ConfigPages, UserLevelConfigPages } from "./ConfigPages";
 import type { ConfigVars } from "./ConfigVars";
 import type { FlowDefinitionFlowSchema } from "./FlowSchemas";
+import type { HttpResponse } from "./HttpResponse";
 import type { Inputs } from "./Inputs";
 import type { PollingTriggerPerformFunction } from "./PollingTriggerDefinition";
 import type { ScopedConfigVarMap } from "./ScopedConfigVars";
-import type { BatchConfig, TriggerResolverBehavior } from "./TriggerDefinition";
+import type { BatchConfig, WithDiscoveryState } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerResult } from "./TriggerResult";
+import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
 
 /**
  * Defines attributes of a code-native integration. See
@@ -102,6 +103,63 @@ export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unkn
   ? TPayload
   : Omit<TPayload, "body"> & { body: { data: TItem | TItem[]; contentType?: string } };
 
+/**
+ * The page of records a batched trigger fire (`onTrigger`/`onDeploy`) returns. The author
+ * returns just the items; spectral wraps them into the wire trigger payload (`body.data`)
+ * and synthesizes the resolver that extracts them. Returning `items` is the whole contract —
+ * there is no `payload` to thread by hand.
+ */
+export interface BatchedTriggerReturn<TItem> {
+  /** The records produced by this trigger fire. Chunked into batches of the flow's `batchConfig.batchSize`. */
+  items: TItem[];
+  /** Optional HTTP response to the request that invoked the integration. */
+  response?: HttpResponse;
+}
+
+/**
+ * The pagination callback for a batched trigger fire. Returns the state for the next page,
+ * or `null` to stop. A non-null return re-invokes the corresponding trigger with this object
+ * stamped onto `payload.discoveryState`; the loop ends when it returns `null`.
+ */
+export type BatchPaginationStateFunction<TPaginationState extends Record<string, unknown>> = (
+  context: ActionContext<ConfigVars>,
+  result: TriggerBaseResult<WithDiscoveryState<TriggerPayload, TPaginationState>>,
+) => TPaginationState | null;
+
+/**
+ * A batched trigger built by {@link batchFlowTrigger}. Bundles the normal and on-deploy trigger
+ * fires (each returning just `items`) with their pagination callbacks. The two type parameters
+ * — supplied explicitly to `batchTrigger<TItem, TPaginationState>(...)` — flow through to the
+ * rest of the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
+ * `TPaginationState` types `payload.discoveryState` and the pagination callbacks' return.
+ */
+export interface BatchTrigger<
+  TItem,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
+> {
+  /**
+   * The trigger function for this flow. Fetches a page of records and returns them as `items`.
+   * Re-invoked once per pagination round (see `getNextOnTriggerPaginationState`); read the
+   * cursor for the current page from `payload.discoveryState`.
+   */
+  onTrigger: (
+    context: ActionContext<ConfigVars>,
+    payload: TriggerPayload<TPaginationState>,
+  ) => Promise<BatchedTriggerReturn<TItem>>;
+  /**
+   * The on-deploy trigger fire, run once on initial instance deploy. Same shape as `onTrigger`;
+   * pair with `getNextOnDeployPaginationState` to paginate.
+   */
+  onDeploy?: (
+    context: ActionContext<ConfigVars>,
+    payload: TriggerPayload<TPaginationState>,
+  ) => Promise<BatchedTriggerReturn<TItem>>;
+  /** Pagination for `onTrigger`: return the next page's state, or `null` to stop. */
+  getNextOnTriggerPaginationState?: BatchPaginationStateFunction<TPaginationState>;
+  /** Pagination for `onDeploy`: return the next page's state, or `null` to stop. */
+  getNextOnDeployPaginationState?: BatchPaginationStateFunction<TPaginationState>;
+}
+
 export type FlowOnExecution<
   TTriggerPayload extends TriggerPayload,
   TItem = unknown,
@@ -130,12 +188,61 @@ export type FlowExecutionContext = ActionContext<
 
 export type FlowExecutionContextActions = FlowExecutionContext["components"];
 
+/**
+ * The batch-discriminated fields of a flow. A flow either batches or it does not, and
+ * the presence of `batchConfig` is the discriminant TypeScript uses to choose a member:
+ *
+ * - {@link BatchFields}: `batchConfig` is present, which requires a batched `trigger`
+ *   (built with {@link batchFlowTrigger}). The flat `onTrigger`/`onDeployTrigger` are
+ *   forbidden — the trigger fires live inside the `trigger` object.
+ * - {@link NonBatchFields}: `batchConfig`/`trigger` are absent; the flow uses the plain
+ *   `onTrigger`/`onDeployTrigger` on its variant.
+ *
+ * Discrimination is structural — it depends only on whether the object literal you write
+ * has a `batchConfig` key — so it works without TypeScript having to infer any type
+ * parameter from the value. The batched-vs-not shape of `onExecution`'s payload is handled
+ * separately, on `FlowBase`, via `TItem`: when a `trigger` is present `TItem` is inferred
+ * (so `onExecution` sees `TItem | TItem[]`); otherwise it stays `unknown` and the payload
+ * is left untouched (see {@link BatchedTriggerPayload}). Keeping `onExecution` out of this
+ * union is deliberate — a function property living in a union member loses contextual
+ * parameter typing, which would make `onExecution`'s `context`/`params` implicitly `any`.
+ */
+interface BatchFields<TItem, TDiscoveryState extends Record<string, unknown>> {
+  /**
+   * Batch-dispatch config for this flow. Items returned by the `trigger`'s fires are chunked
+   * into batches of `batchSize`. For a CNI flow this value is authoritative (what's written
+   * here is what's used). Its presence requires a batched `trigger`.
+   */
+  batchConfig: BatchConfig;
+  /**
+   * The batched trigger for this flow, built with {@link batchFlowTrigger}. Its fires
+   * (`onTrigger`/`onDeploy`) return just `items`; spectral synthesizes the resolver that
+   * extracts them and maps the pagination callbacks. Required when `batchConfig` is set.
+   */
+  trigger: BatchTrigger<TItem, TDiscoveryState>;
+  /** A batched flow's trigger fires live inside `trigger`; the flat `onTrigger` is forbidden. */
+  onTrigger?: never;
+  /** A batched flow's on-deploy fire lives inside `trigger`; the flat `onDeployTrigger` is forbidden. */
+  onDeployTrigger?: never;
+}
+
+interface NonBatchFields {
+  /** A non-batching flow may not declare batch config. */
+  batchConfig?: never;
+  /** A non-batching flow may not declare a batched trigger. */
+  trigger?: never;
+}
+
+/**
+ * The discriminated union coupling `batchConfig` and the batched `trigger`. Intersected
+ * into each flow variant at {@link Flow}.
+ */
+type BatchDiscriminant<TItem, TDiscoveryState extends Record<string, unknown>> =
+  | BatchFields<TItem, TDiscoveryState>
+  | NonBatchFields;
+
 /** Base properties shared by all flow types. */
-interface FlowBase<
-  TTriggerPayload extends TriggerPayload = TriggerPayload,
-  TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
-> {
+interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload, TItem = unknown> {
   /** The unique name for this flow. */
   name: string;
   /** A unique, unchanging value that is used to maintain identity for the flow even if the name changes. */
@@ -166,25 +273,6 @@ interface FlowBase<
    */
   organizationApiKeys?: string[];
   testApiKeys?: string[];
-  /**
-   * Batch-dispatch config for this flow's resolvers. A single config shared by both
-   * `triggerResolver` and `onDeployResolver` — they always batch the same way. For a
-   * CNI flow this value is authoritative (what's written here is what's used). Required
-   * whenever the flow defines a `triggerResolver` or `onDeployResolver`.
-   */
-  batchConfig?: BatchConfig;
-  /**
-   * Trigger resolver behavior: extracts the items returned by the trigger into batched
-   * dispatches and (optionally) paginates. Sizing comes from the flow's `batchConfig`.
-   * When using an existing component trigger, that trigger must declare
-   * `triggerResolverSupport`; CNI flows infer support from the resolver's presence.
-   */
-  triggerResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
-  /**
-   * On-deploy resolver behavior: same as `triggerResolver` but for the `onDeployTrigger`
-   * initial-deploy fire. Shares the flow's `batchConfig`.
-   */
-  onDeployResolver?: TriggerResolverBehavior<ConfigVars, TriggerPayload, TItem, TDiscoveryState>;
   /** Error handling configuration. */
   errorConfig?: StepErrorConfig;
   /** Optional schemas definitions for the flow. Currently only for use with AI agents. */
@@ -211,7 +299,12 @@ interface FlowBase<
     /** Function to execute for webhook teardown. */
     delete: TriggerEventFunction<Inputs, ConfigVars>;
   };
-  /** Specifies the main function for this flow which is run when this flow is invoked. */
+  /**
+   * Specifies the main function for this flow which is run when this flow is invoked.
+   * When the flow batches (has a `triggerResolver`/`onDeployResolver`, so `TItem` is
+   * inferred), `params.onTrigger.results.body.data` is typed as the resolved item type
+   * (`TItem | TItem[]`); otherwise the trigger payload is left untouched.
+   */
   onExecution: FlowOnExecution<TTriggerPayload, TItem>;
 }
 
@@ -229,7 +322,7 @@ interface StandardFlow<
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
   TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
-> extends FlowBase<TTriggerPayload, TItem, TDiscoveryState> {
+> extends FlowBase<TTriggerPayload, TItem> {
   triggerType?: StandardTriggerType;
   /** Schedule configuration that defines the frequency with which this flow will be automatically executed. */
   schedule?: (ValueExpression<string> | ConfigVarExpression) & {
@@ -242,7 +335,6 @@ interface StandardFlow<
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
-   * Pair with `onDeployResolver` to batch the records it returns.
    */
   onDeployTrigger?: TriggerPerformFunction<
     TInputs,
@@ -268,7 +360,7 @@ interface PollingFlow<
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
   TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
-> extends FlowBase<TTriggerPayload, TItem, TDiscoveryState> {
+> extends FlowBase<TTriggerPayload, TItem> {
   /**
    * Type of trigger for this flow. A "polling" trigger runs on a schedule
    * and can use context.polling.* functions. Requires schedule to be set.
@@ -292,7 +384,6 @@ interface PollingFlow<
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
-   * Pair with `onDeployResolver` to batch the records it returns.
    */
   onDeployTrigger?: TriggerPerformFunction<
     TInputs,
@@ -317,7 +408,7 @@ export type Flow<
   TItem = unknown,
   TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
 > =
-  | StandardFlow<
+  | (StandardFlow<
       TInputs,
       TPayload,
       TAllowsBranching,
@@ -325,8 +416,9 @@ export type Flow<
       TTriggerPayload,
       TItem,
       TDiscoveryState
-    >
-  | PollingFlow<
+    > &
+      BatchDiscriminant<TItem, TDiscoveryState>)
+  | (PollingFlow<
       TInputs,
       TActionInputs,
       TPayload,
@@ -335,7 +427,8 @@ export type Flow<
       TTriggerPayload,
       TItem,
       TDiscoveryState
-    >;
+    > &
+      BatchDiscriminant<TItem, TDiscoveryState>);
 
 export type FlowTriggerType = PollingTriggerType | StandardTriggerType;
 

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -242,10 +242,7 @@ interface StandardFlow<
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
-   *
-   * Sibling to `onTrigger` (just as a component trigger's `onDeployPerform` is the
-   * sibling to its `perform`). Pair with `onDeployResolver` to batch the records this
-   * initial-deploy fire returns.
+   * Pair with `onDeployResolver` to batch the records it returns.
    */
   onDeployTrigger?: TriggerPerformFunction<
     TInputs,
@@ -295,10 +292,7 @@ interface PollingFlow<
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
-   *
-   * Sibling to `onTrigger` (just as a component trigger's `onDeployPerform` is the
-   * sibling to its `perform`). Pair with `onDeployResolver` to batch the records this
-   * initial-deploy fire returns.
+   * Pair with `onDeployResolver` to batch the records it returns.
    */
   onDeployTrigger?: TriggerPerformFunction<
     TInputs,

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -9,13 +9,13 @@ import type {
 import type { ConfigPages, UserLevelConfigPages } from "./ConfigPages";
 import type { ConfigVars } from "./ConfigVars";
 import type { FlowDefinitionFlowSchema } from "./FlowSchemas";
-import type { Inputs } from "./Inputs";
+import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { PollingTriggerPerformFunction } from "./PollingTriggerDefinition";
 import type { ScopedConfigVarMap } from "./ScopedConfigVars";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerResult } from "./TriggerResult";
+import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
 
 /**
  * Defines attributes of a code-native integration. See
@@ -143,6 +143,13 @@ interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload> {
    */
   organizationApiKeys?: string[];
   testApiKeys?: string[];
+  /**
+   * Trigger resolver configuration: batches the records returned by the
+   * trigger into parallel dispatches. When using an existing component
+   * trigger, that trigger must declare `triggerResolverSupport`. CNI flows
+   * infer support from the resolver's presence.
+   */
+  triggerResolver?: TriggerResolverConfig<ConfigVars, TTriggerPayload>;
   /** Error handling configuration. */
   errorConfig?: StepErrorConfig;
   /** Optional schemas definitions for the flow. Currently only for use with AI agents. */
@@ -337,3 +344,25 @@ export type EndpointSecurityType =
 
 /** Choices of Step Error Handlers that define the behavior when a step error occurs. */
 export type StepErrorHandlerType = "fail" | "ignore" | "retry";
+
+/** Configures how trigger items are batched when the trigger supports a resolver. */
+export type TriggerResolverConfig<
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+> = {
+  /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
+  batchSize: number;
+  /** Extracts an array of items from the trigger result for batched dispatch. Receives the same context as the trigger's perform function. */
+  resolveItems?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => TItem[];
+  /** Called after each trigger run. When defined and returns a non-null object, the platform
+   *  queues another pagination round (re-invokes the trigger) and stamps the returned object
+   *  onto `payload.discoveryState` for that next invocation. Return `null` to stop. */
+  getNextDiscoveryState?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => Record<string, unknown> | null;
+};

--- a/packages/spectral/src/types/PollingTriggerDefinition.ts
+++ b/packages/spectral/src/types/PollingTriggerDefinition.ts
@@ -4,7 +4,7 @@ import type { ActionContext } from "./ActionPerformFunction";
 import type { ActionPerformReturn } from "./ActionPerformReturn";
 import type { ActionDisplayDefinition } from "./DisplayDefinition";
 import type { ConfigVarResultCollection, Inputs } from "./Inputs";
-import type { TriggerResolverDecl } from "./TriggerDefinition";
+import type { BatchConfig, OnDeployDecl, TriggerResolverDecl } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerResult } from "./TriggerResult";
@@ -43,8 +43,8 @@ export type PollingTriggerPerformFunction<
  * PollingTriggerDefinition is the type of the object that is passed in to `pollingTrigger` function to
  * define a component trigger.
  *
- * Composed from `PollingTriggerDefinitionBase` plus `TriggerResolverDecl`, which
- * enforces the resolver support relationship at the type level.
+ * Composed from `PollingTriggerDefinitionBase` plus `TriggerResolverDecl` (resolver support)
+ * and `OnDeployDecl` (the on-deploy perform/resolver relationship), enforced at the type level.
  */
 export type PollingTriggerDefinition<
   TInputs extends Inputs = Inputs,
@@ -68,7 +68,8 @@ export type PollingTriggerDefinition<
   TAction,
   TCombinedInputs
 > &
-  TriggerResolverDecl<TConfigVars, TPayload>;
+  TriggerResolverDecl<TConfigVars, TPayload> &
+  OnDeployDecl<TInputs, TConfigVars, TPayload, TAllowsBranching, TResult>;
 
 interface PollingTriggerDefinitionBase<
   TInputs extends Inputs = Inputs,
@@ -86,6 +87,12 @@ interface PollingTriggerDefinitionBase<
   triggerType?: "polling";
   /** Defines how the Action is displayed in the Prismatic interface. */
   display: ActionDisplayDefinition;
+  /**
+   * Default batch-dispatch config for this trigger's resolvers — a single config shared
+   * by `triggerResolver` and `onDeployResolver`. Required when this trigger declares a
+   * `triggerResolver` (`triggerResolverSupport` `"valid"`/`"required"`) or an `onDeployResolver`.
+   */
+  batchConfig?: BatchConfig;
   /** Defines your trigger's polling behavior. */
   pollAction?: TAction;
   /** Function to perform when this Trigger is invoked. A default perform will be provided for most polling triggers but defining this allows for custom behavior. */

--- a/packages/spectral/src/types/PollingTriggerDefinition.ts
+++ b/packages/spectral/src/types/PollingTriggerDefinition.ts
@@ -4,6 +4,7 @@ import type { ActionContext } from "./ActionPerformFunction";
 import type { ActionPerformReturn } from "./ActionPerformReturn";
 import type { ActionDisplayDefinition } from "./DisplayDefinition";
 import type { ConfigVarResultCollection, Inputs } from "./Inputs";
+import type { TriggerResolverDecl } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerResult } from "./TriggerResult";
@@ -41,8 +42,35 @@ export type PollingTriggerPerformFunction<
 /**
  * PollingTriggerDefinition is the type of the object that is passed in to `pollingTrigger` function to
  * define a component trigger.
+ *
+ * Composed from `PollingTriggerDefinitionBase` plus `TriggerResolverDecl`, which
+ * enforces the resolver support relationship at the type level.
  */
-export interface PollingTriggerDefinition<
+export type PollingTriggerDefinition<
+  TInputs extends Inputs = Inputs,
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TPayload extends TriggerPayload = TriggerPayload,
+  TAllowsBranching extends boolean = boolean,
+  TResult extends TriggerResult<TAllowsBranching, TPayload> = TriggerResult<
+    TAllowsBranching,
+    TPayload
+  >,
+  TActionInputs extends Inputs = Inputs,
+  TAction extends ActionDefinition<TActionInputs> = ActionDefinition<TActionInputs>,
+  TCombinedInputs extends TInputs & TActionInputs = TInputs & TActionInputs,
+> = PollingTriggerDefinitionBase<
+  TInputs,
+  TConfigVars,
+  TPayload,
+  TAllowsBranching,
+  TResult,
+  TActionInputs,
+  TAction,
+  TCombinedInputs
+> &
+  TriggerResolverDecl<TConfigVars, TPayload>;
+
+interface PollingTriggerDefinitionBase<
   TInputs extends Inputs = Inputs,
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,

--- a/packages/spectral/src/types/PollingTriggerDefinition.ts
+++ b/packages/spectral/src/types/PollingTriggerDefinition.ts
@@ -88,9 +88,9 @@ interface PollingTriggerDefinitionBase<
   /** Defines how the Action is displayed in the Prismatic interface. */
   display: ActionDisplayDefinition;
   /**
-   * Default batch-dispatch config for this trigger's resolvers — a single config shared
-   * by `triggerResolver` and `onDeployResolver`. Required when this trigger declares a
-   * `triggerResolver` (`triggerResolverSupport` `"valid"`/`"required"`) or an `onDeployResolver`.
+   * Default batch-dispatch config shared by `triggerResolver` and `onDeployResolver`.
+   * Required when this trigger declares either (a `triggerResolver` with
+   * `triggerResolverSupport` `"valid"`/`"required"`, or an `onDeployResolver`).
    */
   batchConfig?: BatchConfig;
   /** Defines your trigger's polling behavior. */

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -113,8 +113,7 @@ export type WithDiscoveryState<
 
 /**
  * The single batch-dispatch config shared by a trigger's `triggerResolver` and
- * `onDeployResolver` — they always batch the same way. One place for batch settings;
- * `concurrency` will join `batchSize` here later.
+ * `onDeployResolver` — they always batch the same way. One place for batch settings.
  *
  * On a CNI flow (`flow.batchConfig`) this value is authoritative. On a component trigger
  * (`TriggerDefinition.batchConfig`) it's the default the platform seeds, which a low-code
@@ -123,6 +122,8 @@ export type WithDiscoveryState<
 export interface BatchConfig {
   /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
   batchSize: number;
+  /** Max batches of a single execution dispatched concurrently. Must be an integer >= 1 when set. Omit for unlimited. */
+  concurrentBatchLimit?: number;
 }
 
 /**

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -161,11 +161,9 @@ interface TriggerDefinitionBase<
   /** Function to perform when this trigger is invoked. */
   perform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
   /**
-   * Default batch-dispatch config for this trigger's resolvers — a single config shared
-   * by `triggerResolver` and `onDeployResolver`. The platform seeds instances with this
-   * default; a low-code user may override the batch size per instance. Required when this
-   * trigger declares a `triggerResolver` (`triggerResolverSupport` `"valid"`/`"required"`)
-   * or an `onDeployResolver`.
+   * Default batch-dispatch config shared by `triggerResolver` and `onDeployResolver`.
+   * Required when this trigger declares either (a `triggerResolver` with
+   * `triggerResolverSupport` `"valid"`/`"required"`, or an `onDeployResolver`).
    */
   batchConfig?: BatchConfig;
   /**

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -11,19 +11,49 @@ import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
  * - absent or `"invalid"`: no resolver allowed
  * - `"valid"`: resolver optional
  * - `"required"`: resolver required
+ *
+ * `triggerResolver` is the resolver *behavior* only; batch sizing comes from the
+ * trigger's shared `batchConfig` (see `TriggerDefinition`).
  */
 export type TriggerResolverDecl<
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | { triggerResolverSupport?: "invalid" | undefined; triggerResolver?: undefined }
   | {
       triggerResolverSupport: "valid";
-      triggerResolver?: TriggerResolver<TConfigVars, TPayload>;
+      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
     }
   | {
       triggerResolverSupport: "required";
-      triggerResolver: TriggerResolver<TConfigVars, TPayload>;
+      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+    };
+
+/**
+ * Encodes the relationship between `onDeployPerform` and `onDeployResolver`. On-deploy is
+ * presence-driven — there is no separate support flag: a trigger fires on deploy if it
+ * defines `onDeployPerform`, and batches that fire if it also defines an `onDeployResolver`.
+ * An `onDeployResolver` therefore requires an `onDeployPerform`.
+ *
+ * `onDeployPerform` is the component-trigger sibling to `perform`. A CNI flow names the
+ * same on-deploy fire `onDeployTrigger` (sibling to its `onTrigger`); both flatten to
+ * `onDeployPerform` on the wire.
+ */
+export type OnDeployDecl<
+  TInputs extends Inputs,
+  TConfigVars extends ConfigVarResultCollection,
+  TPayload extends TriggerPayload,
+  TAllowsBranching extends boolean,
+  TResult extends TriggerResult<TAllowsBranching, TPayload>,
+  TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+> =
+  | { onDeployPerform?: undefined; onDeployResolver?: undefined }
+  | {
+      onDeployPerform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
+      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
     };
 
 const optionChoices = ["invalid", "valid", "required"] as const;
@@ -32,26 +62,67 @@ export type TriggerOptionChoice = (typeof optionChoices)[number];
 
 export const TriggerOptionChoices: TriggerOptionChoice[] = [...optionChoices];
 
-export interface TriggerResolver<
+/**
+ * The batching/pagination behavior shared by every resolver surface — component
+ * triggers (`TriggerResolver`), CNI flows (`TriggerResolverConfig`), and the
+ * on-deploy variants. Defining it once keeps the contract from drifting across
+ * those surfaces.
+ *
+ * The two type variables ARE the data that flows through the batch chain:
+ *
+ *   perform ──▶ resolveItems ──▶ [batch of TItem] ──▶ onExecution
+ *                    │
+ *                    └─ getNextDiscoveryState ──▶ payload.discoveryState ──▶ next perform
+ *
+ * @typeParam TItem - element produced by `resolveItems`. With `batchSize: 1`
+ *   each execution receives one `TItem` as its trigger data; with `batchSize > 1`
+ *   it receives a `TItem[]` slice.
+ * @typeParam TDiscoveryState - the pagination cursor. Whatever
+ *   `getNextDiscoveryState` returns is what the next round reads back on
+ *   `payload.discoveryState` (see {@link TriggerPayload}). The `result.payload`
+ *   passed to both callbacks has its `discoveryState` narrowed to this type, so
+ *   the cursor round-trip is checked end to end.
+ */
+export interface TriggerResolverBehavior<
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
 > {
-  /** Author-declared defaults for how this trigger's items are batched. */
-  default: {
-    /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
-    batchSize: number;
-  };
-  /** Extracts an array of items from the trigger result for batched dispatch. Receives the same context as the trigger's perform function. */
+  /** Extracts the items to dispatch from one trigger result. Receives the same context as the trigger's perform function. With `batchSize: 1` each item is delivered to its own execution; with `batchSize > 1` items are grouped into `TItem[]` slices. */
   resolveItems?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<TPayload>,
+    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
   ) => TItem[];
-  /** Extracts data from the trigger result to be passed to the next trigger invocation to fetch another page of data. */
+  /** Returns the cursor for the next page, or `null` to stop. A non-null return re-invokes the trigger with this object stamped onto `payload.discoveryState`. */
   getNextDiscoveryState?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<TPayload>,
-  ) => Record<string, unknown> | null;
+    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
+  ) => TDiscoveryState | null;
+}
+
+/**
+ * A trigger payload with its `discoveryState` field narrowed to `TDiscoveryState`,
+ * leaving every other field of `TPayload` intact. Lets a resolver type the cursor
+ * it reads back independently of how the base payload was parameterized.
+ */
+export type WithDiscoveryState<
+  TPayload extends TriggerPayload,
+  TDiscoveryState extends Record<string, unknown>,
+> = Omit<TPayload, "discoveryState"> & { discoveryState?: TDiscoveryState };
+
+/**
+ * The single batch-dispatch config shared by a trigger's `triggerResolver` and
+ * `onDeployResolver` — they always batch the same way. One place for batch settings;
+ * `concurrency` will join `batchSize` here later.
+ *
+ * On a CNI flow (`flow.batchConfig`) this value is authoritative. On a component trigger
+ * (`TriggerDefinition.batchConfig`) it's the default the platform seeds, which a low-code
+ * user may override per instance.
+ */
+export interface BatchConfig {
+  /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
+  batchSize: number;
 }
 
 /**
@@ -59,9 +130,9 @@ export interface TriggerResolver<
  * define a component trigger. See
  * https://prismatic.io/docs/custom-connectors/triggers/
  *
- * Composed from `TriggerDefinitionBase` (static fields) plus the discriminated union
- * `TriggerResolverDecl`, which enforces the resolver support relationship at the type
- * level.
+ * Composed from `TriggerDefinitionBase` (static fields) plus `TriggerResolverDecl` (the
+ * resolver support relationship) and `OnDeployDecl` (the on-deploy perform/resolver
+ * relationship), which enforce those constraints at the type level.
  */
 export type TriggerDefinition<
   TInputs extends Inputs = Inputs,
@@ -72,7 +143,8 @@ export type TriggerDefinition<
     TriggerPayload
   >,
 > = TriggerDefinitionBase<TInputs, TConfigVars, TAllowsBranching, TResult> &
-  TriggerResolverDecl<TConfigVars, TriggerPayload>;
+  TriggerResolverDecl<TConfigVars, TriggerPayload> &
+  OnDeployDecl<TInputs, TConfigVars, TriggerPayload, TAllowsBranching, TResult>;
 
 interface TriggerDefinitionBase<
   TInputs extends Inputs = Inputs,
@@ -87,6 +159,14 @@ interface TriggerDefinitionBase<
   display: ActionDisplayDefinition;
   /** Function to perform when this trigger is invoked. */
   perform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
+  /**
+   * Default batch-dispatch config for this trigger's resolvers — a single config shared
+   * by `triggerResolver` and `onDeployResolver`. The platform seeds instances with this
+   * default; a low-code user may override the batch size per instance. Required when this
+   * trigger declares a `triggerResolver` (`triggerResolverSupport` `"valid"`/`"required"`)
+   * or an `onDeployResolver`.
+   */
+  batchConfig?: BatchConfig;
   /**
    * Function to execute when an instance of an integration with a flow that uses this trigger is deployed. See
    * https://prismatic.io/docs/custom-connectors/triggers/#instance-deploy-and-delete-events-for-triggers

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -19,16 +19,16 @@ export type TriggerResolverDecl<
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | { triggerResolverSupport?: "invalid" | undefined; triggerResolver?: undefined }
   | {
       triggerResolverSupport: "valid";
-      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     }
   | {
       triggerResolverSupport: "required";
-      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     };
 
 /**
@@ -48,12 +48,12 @@ export type OnDeployDecl<
   TAllowsBranching extends boolean,
   TResult extends TriggerResult<TAllowsBranching, TPayload>,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | { onDeployPerform?: undefined; onDeployResolver?: undefined }
   | {
       onDeployPerform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
-      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     };
 
 const optionChoices = ["invalid", "valid", "required"] as const;
@@ -72,44 +72,44 @@ export const TriggerOptionChoices: TriggerOptionChoice[] = [...optionChoices];
  *
  *   perform ──▶ resolveItems ──▶ [batch of TItem] ──▶ onExecution
  *                    │
- *                    └─ getNextDiscoveryState ──▶ payload.discoveryState ──▶ next perform
+ *                    └─ getNextPaginationState ──▶ payload.paginationState ──▶ next perform
  *
  * @typeParam TItem - element produced by `resolveItems`. With `batchSize: 1`
  *   each execution receives one `TItem` as its trigger data; with `batchSize > 1`
  *   it receives a `TItem[]` slice.
- * @typeParam TDiscoveryState - the pagination cursor. Whatever
- *   `getNextDiscoveryState` returns is what the next round reads back on
- *   `payload.discoveryState` (see {@link TriggerPayload}). The `result.payload`
- *   passed to both callbacks has its `discoveryState` narrowed to this type, so
+ * @typeParam TPaginationState - the pagination cursor. Whatever
+ *   `getNextPaginationState` returns is what the next round reads back on
+ *   `payload.paginationState` (see {@link TriggerPayload}). The `result.payload`
+ *   passed to both callbacks has its `paginationState` narrowed to this type, so
  *   the cursor round-trip is checked end to end.
  */
 export interface TriggerResolverBehavior<
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /** Extracts the items to dispatch from one trigger result. Receives the same context as the trigger's perform function. With `batchSize: 1` each item is delivered to its own execution; with `batchSize > 1` items are grouped into `TItem[]` slices. */
   resolveItems?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
+    result: TriggerBaseResult<WithPaginationState<TPayload, TPaginationState>>,
   ) => TItem[];
-  /** Returns the cursor for the next page, or `null` to stop. A non-null return re-invokes the trigger with this object stamped onto `payload.discoveryState`. */
-  getNextDiscoveryState?: (
+  /** Returns the cursor for the next page, or `null` to stop. A non-null return re-invokes the trigger with this object stamped onto `payload.paginationState`. */
+  getNextPaginationState?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
-  ) => TDiscoveryState | null;
+    result: TriggerBaseResult<WithPaginationState<TPayload, TPaginationState>>,
+  ) => TPaginationState | null;
 }
 
 /**
- * A trigger payload with its `discoveryState` field narrowed to `TDiscoveryState`,
+ * A trigger payload with its `paginationState` field narrowed to `TPaginationState`,
  * leaving every other field of `TPayload` intact. Lets a resolver type the cursor
  * it reads back independently of how the base payload was parameterized.
  */
-export type WithDiscoveryState<
+export type WithPaginationState<
   TPayload extends TriggerPayload,
-  TDiscoveryState extends Record<string, unknown>,
-> = Omit<TPayload, "discoveryState"> & { discoveryState?: TDiscoveryState };
+  TPaginationState extends Record<string, unknown>,
+> = Omit<TPayload, "paginationState"> & { paginationState?: TPaginationState };
 
 /**
  * The single batch-dispatch config shared by a trigger's `triggerResolver` and

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -1,9 +1,30 @@
+import type { ActionContext } from "./ActionPerformFunction";
 import type { ActionDisplayDefinition } from "./DisplayDefinition";
 import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerResult } from "./TriggerResult";
+import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
+
+/**
+ * Encodes the relationship between `triggerResolverSupport` and `triggerResolver`:
+ * - absent or `"invalid"`: no resolver allowed
+ * - `"valid"`: resolver optional
+ * - `"required"`: resolver required
+ */
+export type TriggerResolverDecl<
+  TConfigVars extends ConfigVarResultCollection,
+  TPayload extends TriggerPayload,
+> =
+  | { triggerResolverSupport?: "invalid" | undefined; triggerResolver?: undefined }
+  | {
+      triggerResolverSupport: "valid";
+      triggerResolver?: TriggerResolver<TConfigVars, TPayload>;
+    }
+  | {
+      triggerResolverSupport: "required";
+      triggerResolver: TriggerResolver<TConfigVars, TPayload>;
+    };
 
 const optionChoices = ["invalid", "valid", "required"] as const;
 
@@ -11,12 +32,49 @@ export type TriggerOptionChoice = (typeof optionChoices)[number];
 
 export const TriggerOptionChoices: TriggerOptionChoice[] = [...optionChoices];
 
+export interface TriggerResolver<
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+> {
+  /** Author-declared defaults for how this trigger's items are batched. */
+  default: {
+    /** Number of items per batch. Must be an integer >= 1. `1` dispatches each item individually; `>1` groups items into batches. */
+    batchSize: number;
+  };
+  /** Extracts an array of items from the trigger result for batched dispatch. Receives the same context as the trigger's perform function. */
+  resolveItems?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => TItem[];
+  /** Extracts data from the trigger result to be passed to the next trigger invocation to fetch another page of data. */
+  getNextDiscoveryState?: (
+    context: ActionContext<TConfigVars>,
+    result: TriggerBaseResult<TPayload>,
+  ) => Record<string, unknown> | null;
+}
+
 /**
  * TriggerDefinition is the type of the object that is passed in to `trigger` function to
  * define a component trigger. See
  * https://prismatic.io/docs/custom-connectors/triggers/
+ *
+ * Composed from `TriggerDefinitionBase` (static fields) plus the discriminated union
+ * `TriggerResolverDecl`, which enforces the resolver support relationship at the type
+ * level.
  */
-export interface TriggerDefinition<
+export type TriggerDefinition<
+  TInputs extends Inputs = Inputs,
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TAllowsBranching extends boolean = boolean,
+  TResult extends TriggerResult<TAllowsBranching, TriggerPayload> = TriggerResult<
+    TAllowsBranching,
+    TriggerPayload
+  >,
+> = TriggerDefinitionBase<TInputs, TConfigVars, TAllowsBranching, TResult> &
+  TriggerResolverDecl<TConfigVars, TriggerPayload>;
+
+interface TriggerDefinitionBase<
   TInputs extends Inputs = Inputs,
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TAllowsBranching extends boolean = boolean,

--- a/packages/spectral/src/types/TriggerPayload.ts
+++ b/packages/spectral/src/types/TriggerPayload.ts
@@ -6,12 +6,12 @@ import type { UserAttributes } from "./UserAttributes";
 
 /** Represents a Trigger Payload, which is data passed into a Trigger to invoke an Integration execution.
  *
- * The optional `TDiscoveryState` parameter types the `discoveryState` field, so authors who
- * declare a pagination-state shape on their `getNextDiscoveryState` resolver can read back
+ * The optional `TPaginationState` parameter types the `paginationState` field, so authors who
+ * declare a pagination-state shape on their `getNextPaginationState` resolver can read back
  * the same shape on the next round's payload. Defaults to `Record<string, unknown>`.
  */
 export interface TriggerPayload<
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /** The headers sent in the webhook request. */
   headers: {
@@ -59,7 +59,7 @@ export interface TriggerPayload<
   /** Determines whether the execution will run in debug mode. */
   globalDebug: boolean;
   /** Managed by the execution when this trigger invocation is a paginated re-run.
-   *  Contains the object returned by `getNextDiscoveryState` from the previous round.
+   *  Contains the object returned by `getNextPaginationState` from the previous round.
    *  Absent on the initial invocation. */
-  discoveryState?: TDiscoveryState;
+  paginationState?: TPaginationState;
 }

--- a/packages/spectral/src/types/TriggerPayload.ts
+++ b/packages/spectral/src/types/TriggerPayload.ts
@@ -4,8 +4,15 @@ import type { InstanceAttributes } from "./InstanceAttributes";
 import type { IntegrationAttributes } from "./IntegrationAttributes";
 import type { UserAttributes } from "./UserAttributes";
 
-/** Represents a Trigger Payload, which is data passed into a Trigger to invoke an Integration execution. */
-export interface TriggerPayload {
+/** Represents a Trigger Payload, which is data passed into a Trigger to invoke an Integration execution.
+ *
+ * The optional `TDiscoveryState` parameter types the `discoveryState` field, so authors who
+ * declare a pagination-state shape on their `getNextDiscoveryState` resolver can read back
+ * the same shape on the next round's payload. Defaults to `Record<string, unknown>`.
+ */
+export interface TriggerPayload<
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** The headers sent in the webhook request. */
   headers: {
     [key: string]: string;
@@ -51,4 +58,8 @@ export interface TriggerPayload {
   startedAt: string;
   /** Determines whether the execution will run in debug mode. */
   globalDebug: boolean;
+  /** Managed by the execution when this trigger invocation is a paginated re-run.
+   *  Contains the object returned by `getNextDiscoveryState` from the previous round.
+   *  Absent on the initial invocation. */
+  discoveryState?: TDiscoveryState;
 }

--- a/packages/spectral/src/types/TriggerPerformFunction.ts
+++ b/packages/spectral/src/types/TriggerPerformFunction.ts
@@ -4,14 +4,20 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerResult } from "./TriggerResult";
 
-/** Definition of the function to perform when a Trigger is invoked. */
+/** Definition of the function to perform when a Trigger is invoked.
+ *
+ * The optional `TDiscoveryState` parameter types `payload.discoveryState`, so a
+ * perform that paginates can read back the cursor shape its paired
+ * `getNextDiscoveryState` resolver returns. Defaults to `Record<string, unknown>`.
+ */
 export type TriggerPerformFunction<
   TInputs extends Inputs,
   TConfigVars extends ConfigVarResultCollection,
   TAllowsBranching extends boolean | undefined,
   TResult extends TriggerResult<TAllowsBranching, TriggerPayload>,
+  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
 > = (
   context: ActionContext<TConfigVars>,
-  payload: TriggerPayload,
+  payload: TriggerPayload<TDiscoveryState>,
   params: ActionInputParameters<TInputs>,
 ) => Promise<TResult>;

--- a/packages/spectral/src/types/TriggerPerformFunction.ts
+++ b/packages/spectral/src/types/TriggerPerformFunction.ts
@@ -4,12 +4,7 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerResult } from "./TriggerResult";
 
-/** Definition of the function to perform when a Trigger is invoked.
- *
- * The optional `TDiscoveryState` parameter types `payload.discoveryState`, so a
- * perform that paginates can read back the cursor shape its paired
- * `getNextDiscoveryState` resolver returns. Defaults to `Record<string, unknown>`.
- */
+/** Definition of the function to perform when a Trigger is invoked. */
 export type TriggerPerformFunction<
   TInputs extends Inputs,
   TConfigVars extends ConfigVarResultCollection,

--- a/packages/spectral/src/types/TriggerPerformFunction.ts
+++ b/packages/spectral/src/types/TriggerPerformFunction.ts
@@ -10,9 +10,9 @@ export type TriggerPerformFunction<
   TConfigVars extends ConfigVarResultCollection,
   TAllowsBranching extends boolean | undefined,
   TResult extends TriggerResult<TAllowsBranching, TriggerPayload>,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > = (
   context: ActionContext<TConfigVars>,
-  payload: TriggerPayload<TDiscoveryState>,
+  payload: TriggerPayload<TPaginationState>,
   params: ActionInputParameters<TInputs>,
 ) => Promise<TResult>;


### PR DESCRIPTION
Introduces resolver support for triggers to enable:
- on deploy triggers for initial executions (backfills)
- trigger resolution to enable batching
- and the ability for both to be present on one trigger so they can feed the same flow