### PR TITLE
Align tsd usage with best practices

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/spectral": {
       "name": "@prismatic-io/spectral",
-      "version": "10.18.5",
+      "version": "10.18.6",
       "bin": {
         "component-manifest": "bin/component-manifest.js",
         "cni-component-manifest": "bin/cni-component-manifest.js",
@@ -76,7 +76,6 @@
         "@prismatic-io/spectral": "*",
         "@types/node": "25.7.0",
         "tsd": "^0.33.0",
-        "typescript": "6.0.3",
       },
     },
   },

--- a/packages/spectral-test/package.json
+++ b/packages/spectral-test/package.json
@@ -23,22 +23,18 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "bun run format && bun run clean && tsc",
+    "build": "bun run format && bun run clean",
     "prepack": "bun run build",
     "lint": "biome lint .",
     "format": "biome check --write --unsafe .",
     "check": "biome check .",
-    "tsd": "tsd"
+    "tsd": "tsd --typings ../spectral/dist/index.d.ts"
   },
-  "files": [
-    "dist/"
-  ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@prismatic-io/spectral": "*",
     "@types/node": "25.7.0",
-    "tsd": "^0.33.0",
-    "typescript": "6.0.3"
+    "tsd": "^0.33.0"
   },
   "tsd": {
     "directory": "./src"

--- a/packages/spectral-test/src/ConfigVars.test-d.ts
+++ b/packages/spectral-test/src/ConfigVars.test-d.ts
@@ -76,16 +76,9 @@ expectAssignable<DataSourceConfigVar>({
 
 const createDataSourceConfigVar = (configVar: DataSourceConfigVar) => configVar;
 
-// biome-ignore lint/suspicious/noTsIgnore: type system does not currently error here, but @ts-expect-error causes tsc to fail
-// @ts-ignore Collection type is not supported for this data source type.
 createDataSourceConfigVar({
   perform: async () => Promise.resolve({ result: { value: "string" } }),
   stableKey: "ds",
-  // TODO: This causes a compile erorr when it's `jsonForm`
-  // Need to figure out why that is happening. It also only happens when running
-  // tsc via the cli instead of surfacing in my editor
   dataSourceType: "schedule",
-  // biome-ignore lint/suspicious/noTsIgnore: type system does not currently error here, but @ts-expect-error causes tsc to fail
-  // @ts-ignore `collectionType` is not a valid property for this data source type.
   collectionType: "valuelist",
 });


### PR DESCRIPTION
Notably to avoid using tsc as that's what motivated a lot of extra comments about disabling tsc and telling biome to allow _those_ comments.