### PR TITLE
support dynamicObject inputs

### DIFF
--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -2,6 +2,7 @@ import {
   type ActionInputParameters,
   type ConditionalExpression,
   type Connection,
+  dynamicObjectInput,
   input,
   structuredObjectInput,
   util,
@@ -61,3 +62,96 @@ expectType<unknown>(structuredResult.name.first);
 expectType<unknown>(structuredResult.name.last);
 // @ts-expect-error: structuredObject params only expose declared children.
 structuredResult.name.nonexistent;
+
+const dynamicInputs = {
+  data: dynamicObjectInput({
+    label: "Record Data",
+    required: true,
+    configurations: {
+      contact: {
+        label: "Contact",
+        inputs: {
+          name: structuredObjectInput({
+            label: "Name",
+            inputs: {
+              first: input({ type: "string", label: "First", required: true }),
+              last: input({ type: "string", label: "Last", required: true }),
+            },
+          }),
+          email: input({ type: "string", label: "Email", required: true }),
+        },
+      },
+      account: {
+        label: "Account",
+        inputs: {
+          companyName: input({ type: "string", label: "Company Name", required: true }),
+        },
+      },
+    },
+  }),
+};
+
+const dynamicResult: ActionInputParameters<typeof dynamicInputs> = {
+  data: {
+    configuration: "contact",
+    values: { name: { first: "Ada", last: "Lovelace" }, email: "ada@example.com" },
+  },
+};
+if (dynamicResult.data.configuration === "contact") {
+  expectType<unknown>(dynamicResult.data.values.email);
+  expectType<unknown>(dynamicResult.data.values.name.first);
+  // @ts-expect-error: companyName is on the `account` variant, not `contact`.
+  dynamicResult.data.values.companyName;
+}
+if (dynamicResult.data.configuration === "account") {
+  expectType<unknown>(dynamicResult.data.values.companyName);
+  // @ts-expect-error: email is on the `contact` variant, not `account`.
+  dynamicResult.data.values.email;
+}
+// @ts-expect-error: only declared configuration keys are valid discriminants.
+if (dynamicResult.data.configuration === "nonexistent") {
+  /* unreachable */
+}
+
+dynamicObjectInput({
+  label: "Bad",
+  // @ts-expect-error: factory disallows callers from setting `type`.
+  type: "string",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: { email: input({ type: "string", label: "Email" }) },
+    },
+  },
+});
+
+dynamicObjectInput({
+  label: "Outer",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        // @ts-expect-error: dynamicObject configurations cannot contain a nested dynamicObject.
+        nested: dynamicObjectInput({
+          label: "Inner",
+          configurations: {
+            x: { label: "X", inputs: { y: input({ type: "string", label: "Y" }) } },
+          },
+        }),
+      },
+    },
+  },
+});
+
+structuredObjectInput({
+  label: "Parent",
+  inputs: {
+    // @ts-expect-error: structuredObject children cannot be a dynamicObject.
+    bad: dynamicObjectInput({
+      label: "Inner Dynamic",
+      configurations: {
+        x: { label: "X", inputs: { y: input({ type: "string", label: "Y" }) } },
+      },
+    }),
+  },
+});

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { action, component, input, pollingTrigger, structuredObjectInput, trigger } from ".";
+import {
+  action,
+  component,
+  dynamicObjectInput,
+  input,
+  pollingTrigger,
+  structuredObjectInput,
+  trigger,
+} from ".";
 import { convertTrigger } from "./serverTypes/convertComponent";
 import type { PerformFn } from "./serverTypes/perform";
 
@@ -283,5 +291,21 @@ describe("structuredObject inputs in a published component", () => {
         }),
       },
     });
+  });
+});
+
+describe("dynamicObject inputs in a published component", () => {
+  it("dynamicObjectInput factory forces type to 'dynamicObject'", () => {
+    const fromFactory = dynamicObjectInput({
+      label: "Record Data",
+      configurations: {
+        contact: {
+          label: "Contact",
+          inputs: { email: input({ type: "string", label: "Email" }) },
+        },
+      },
+    });
+    expect(fromFactory.type).toBe("dynamicObject");
+    expect(Object.keys(fromFactory.configurations)).toEqual(["contact"]);
   });
 });

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -101,6 +101,9 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   // TODO: emit a typed record matching the declared children once the
   // code-native action-calling type generator handles structuredObject.
   structuredObject: "unknown",
+  // TODO: emit a precise discriminated-union type matching the declared
+  // configurations once the CNI manifest generator handles dynamicObject.
+  dynamicObject: "unknown",
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -20,6 +20,7 @@ import type {
   DataSourceDefinition,
   DataSourceType,
   DefaultConnectionDefinition,
+  DynamicObjectInputField,
   Flow,
   InputFieldDefinition,
   Inputs,
@@ -693,6 +694,52 @@ export const structuredObjectInput = <
 ): T & { type: "structuredObject" } => ({
   ...definition,
   type: "structuredObject" as const,
+});
+
+/**
+ * Presents a discriminated set of input configurations; the integration builder
+ * picks a configuration and its inputs become available. Configurations may
+ * contain leaf inputs and structuredObject inputs but not nested dynamicObjects
+ * (the type signature enforces this at compile time).
+ *
+ * @example
+ * import { input, structuredObjectInput, dynamicObjectInput } from "@prismatic-io/spectral";
+ *
+ * const recordData = dynamicObjectInput({
+ *   label: "Record Data",
+ *   required: true,
+ *   configurations: {
+ *     contact: {
+ *       label: "Contact",
+ *       description: "Create a new contact",
+ *       inputs: {
+ *         name: structuredObjectInput({
+ *           label: "Name",
+ *           inputs: {
+ *             first: input({ type: "string", label: "First Name", required: true }),
+ *             last: input({ type: "string", label: "Last Name", required: true }),
+ *           },
+ *         }),
+ *         email: input({ type: "string", label: "Email", required: true }),
+ *       },
+ *     },
+ *     account: {
+ *       label: "Account",
+ *       description: "Create a new account",
+ *       inputs: {
+ *         companyName: input({ type: "string", label: "Company Name", required: true }),
+ *       },
+ *     },
+ *   },
+ * });
+ */
+export const dynamicObjectInput = <
+  T extends Omit<DynamicObjectInputField, "type"> & { type?: never },
+>(
+  definition: T,
+): T & { type: "dynamicObject" } => ({
+  ...definition,
+  type: "dynamicObject" as const,
 });
 
 /**

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connection, input, structuredObjectInput } from "..";
+import { connection, dynamicObjectInput, input, structuredObjectInput } from "..";
 import { convertConnection, convertInput, convertTemplateInput } from "./convertComponent";
 
 describe("convertConnection", () => {
@@ -71,6 +71,74 @@ describe("convertInput", () => {
     const basicInput = input({ type: "string", label: "Basic" });
     const converted = convertInput("basic", basicInput);
     expect(converted.inputs).toBeUndefined();
+  });
+
+  it("converts a dynamicObject input with configurations and nested children", () => {
+    const data = dynamicObjectInput({
+      label: "Record Data",
+      required: true,
+      configurations: {
+        contact: {
+          label: "Contact",
+          description: "Create a new contact",
+          inputs: {
+            name: structuredObjectInput({
+              label: "Name",
+              inputs: {
+                first: input({ type: "string", label: "First Name", required: true }),
+                last: input({ type: "string", label: "Last Name", required: true }),
+              },
+            }),
+            email: input({ type: "string", label: "Email", required: true }),
+          },
+        },
+        account: {
+          label: "Account",
+          description: "Create a new account",
+          inputs: {
+            companyName: input({ type: "string", label: "Company Name", required: true }),
+          },
+        },
+      },
+    });
+
+    const converted = convertInput("data", data);
+
+    expect(converted.key).toBe("data");
+    expect(converted.type).toBe("dynamicObject");
+    expect(converted.required).toBe(true);
+    expect(converted.configurations).toHaveLength(2);
+
+    const contact = converted.configurations?.find((c) => c.key === "contact");
+    expect(contact).toMatchObject({
+      key: "contact",
+      type: "configuration",
+      label: "Contact",
+      description: "Create a new contact",
+    });
+    expect(contact?.inputs).toHaveLength(2);
+    const contactName = contact?.inputs?.find((i) => i.key === "name");
+    expect(contactName).toMatchObject({ key: "name", type: "structuredObject" });
+    expect(contactName?.inputs).toHaveLength(2);
+    expect(contactName?.inputs?.[0]).toMatchObject({
+      key: "first",
+      type: "string",
+      required: true,
+    });
+
+    const account = converted.configurations?.find((c) => c.key === "account");
+    expect(account?.inputs).toHaveLength(1);
+    expect(account?.inputs?.[0]).toMatchObject({
+      key: "companyName",
+      type: "string",
+      required: true,
+    });
+  });
+
+  it("does not emit `configurations` on a non-dynamicObject input", () => {
+    const basicInput = input({ type: "string", label: "Basic" });
+    const converted = convertInput("basic", basicInput);
+    expect(converted.configurations).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -44,7 +44,7 @@ export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
-  // Cast: union members don't all carry `default`/`collection`/`inputs`;
+  // Cast: union members don't all carry `default`/`collection`/`inputs`/`configurations`;
   // runtime guards below handle the differences.
   const {
     default: defaultValue,
@@ -52,6 +52,7 @@ export const convertInput = (
     label,
     collection,
     inputs: childInputs,
+    configurations,
     ...rest
   } = definition as {
     default?: unknown;
@@ -59,6 +60,14 @@ export const convertInput = (
     label: string | { key: string; value: string };
     collection?: "valuelist" | "keyvaluelist";
     inputs?: Record<string, InputFieldDefinition>;
+    configurations?: Record<
+      string,
+      {
+        label: string | { key: string; value: string };
+        description?: string;
+        inputs: Record<string, InputFieldDefinition>;
+      }
+    >;
     [key: string]: unknown;
   };
   const keyLabel =
@@ -69,6 +78,19 @@ export const convertInput = (
       ? Object.entries(childInputs).map(([childKey, childDef]) =>
           convertInput(childKey, childDef as InputFieldDefinition),
         )
+      : undefined;
+
+  const convertedConfigurations =
+    type === "dynamicObject" && configurations
+      ? Object.entries(configurations).map(([configKey, configDef]) => ({
+          key: configKey,
+          type: "configuration",
+          label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
+          description: configDef.description,
+          inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
+            convertInput(childKey, childDef as InputFieldDefinition),
+          ),
+        }))
       : undefined;
 
   return {
@@ -86,6 +108,7 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
+    configurations: convertedConfigurations,
   };
 };
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,8 +364,13 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  /** Nested child inputs; populated only when `type === "structuredObject"`. */
+  description?: string;
+  /** Nested child inputs; populated when `type === "structuredObject"` or for
+   * a `configuration` entry inside a `dynamicObject`'s `configurations`. */
   inputs?: Input[];
+  /** Configurations of a `dynamicObject` input. Each entry has
+   * `type: "configuration"` and carries its own `inputs`. */
+  configurations?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -1,6 +1,7 @@
 import type { ConditionalExpression } from "./conditional-logic";
 import type {
   Connection,
+  DynamicObjectInputField,
   InputCleanFunction,
   InputFieldCollection,
   Inputs,
@@ -8,20 +9,35 @@ import type {
   StructuredObjectInputField,
 } from "./Inputs";
 
-/** Resolves a single InputFieldDefinition's runtime value type. A structuredObject
- * resolves to a record of its declared children's resolved value types; the
- * depth-1 nesting cap (`LeafInputFieldDefinition`) prevents unbounded recursion. */
+/** Resolves a single InputFieldDefinition's runtime value type.
+ * - structuredObject: record of declared children's resolved value types.
+ * - dynamicObject: discriminated union keyed by the selected configuration,
+ *   with the configuration's resolved inputs nested under `values` to avoid
+ *   collisions with the `configuration` discriminant key.
+ * The depth caps (`LeafInputFieldDefinition`, `StructuredOrLeafInputFieldDefinition`)
+ * prevent unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
   ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
-  : T extends { clean: InputCleanFunction<any> }
-    ? ReturnType<T["clean"]>
-    : T extends { type: "connection"; collection?: InputFieldCollection }
-      ? ExtractValue<Connection, T["collection"]>
-      : T extends { type: "conditional"; collection?: InputFieldCollection }
-        ? ExtractValue<ConditionalExpression, T["collection"]>
-        : T extends { default?: unknown; collection?: InputFieldCollection }
-          ? ExtractValue<T["default"], T["collection"]>
-          : unknown;
+  : T extends DynamicObjectInputField
+    ? {
+        [C in keyof T["configurations"]]: {
+          configuration: C;
+          values: {
+            [K in keyof T["configurations"][C]["inputs"]]: InputValue<
+              T["configurations"][C]["inputs"][K]
+            >;
+          };
+        };
+      }[keyof T["configurations"]]
+    : T extends { clean: InputCleanFunction<any> }
+      ? ReturnType<T["clean"]>
+      : T extends { type: "connection"; collection?: InputFieldCollection }
+        ? ExtractValue<Connection, T["collection"]>
+        : T extends { type: "conditional"; collection?: InputFieldCollection }
+          ? ExtractValue<ConditionalExpression, T["collection"]>
+          : T extends { default?: unknown; collection?: InputFieldCollection }
+            ? ExtractValue<T["default"], T["collection"]>
+            : unknown;
 
 /**
  * Collection of input parameters.

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -93,6 +93,7 @@ export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = 
   flow: "",
   template: "",
   structuredObject: undefined,
+  dynamicObject: undefined,
 };
 
 export type Inputs = Record<string, InputFieldDefinition>;
@@ -141,7 +142,8 @@ export type InputFieldDefinition =
   | DateInputField
   | DateTimeInputField
   | FlowInputField
-  | StructuredObjectInputField;
+  | StructuredObjectInputField
+  | DynamicObjectInputField;
 
 export type InputCleanFunction<TValue, TResult = TValue> = (value: TValue) => TResult;
 
@@ -382,9 +384,20 @@ export type DateTimeInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/** `InputFieldDefinition` minus `StructuredObjectInputField`; used to cap
- * structuredObject nesting at one level. */
-export type LeafInputFieldDefinition = Exclude<InputFieldDefinition, StructuredObjectInputField>;
+/** `InputFieldDefinition` minus container input types; used to cap
+ * structuredObject nesting at one level and to enforce leaf-only positions. */
+export type LeafInputFieldDefinition = Exclude<
+  InputFieldDefinition,
+  StructuredObjectInputField | DynamicObjectInputField
+>;
+
+/** `InputFieldDefinition` minus `DynamicObjectInputField`; used inside a
+ * dynamicObject's `configurations.<key>.inputs` to allow leaves *and*
+ * structuredObject children while still rejecting nested dynamicObjects. */
+export type StructuredOrLeafInputFieldDefinition = Exclude<
+  InputFieldDefinition,
+  DynamicObjectInputField
+>;
 
 /** Groups related primitive inputs under a single named container.
  * Nesting is capped at one level. */
@@ -393,6 +406,32 @@ export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
   type: "structuredObject";
   /** Nested input fields keyed by their local key. */
   inputs: Record<string, LeafInputFieldDefinition>;
+};
+
+/** A single configuration within a dynamicObject. Each configuration declares
+ * a labeled set of inputs that become available when this configuration is
+ * selected at runtime. */
+export interface DynamicObjectConfiguration {
+  /** Name of this configuration to present in the UI. */
+  label: { key: string; value: string } | string;
+  /** Additional text to give guidance to the user when this configuration is selected. */
+  description?: string;
+  /** Inputs that become available when this configuration is selected. May
+   * include leaf inputs and structuredObject inputs; nested dynamicObjects
+   * are rejected at the type level. */
+  inputs: Record<string, StructuredOrLeafInputFieldDefinition>;
+}
+
+/** Presents a discriminated set of input groups; the user picks a configuration
+ * at integration-build time and that configuration's inputs become available.
+ * Nesting is capped: configurations may contain structuredObject children
+ * (depth-1) but never another dynamicObject. */
+export type DynamicObjectInputField = Omit<BaseInputField, "dataSource"> & {
+  /** Data type the input will collect. */
+  type: "dynamicObject";
+  /** Available configurations keyed by their local key (used as the
+   * runtime discriminant). */
+  configurations: Record<string, DynamicObjectConfiguration>;
 };
 
 /** Defines a single Choice option for a InputField. */


### PR DESCRIPTION
# Problem

Spectral has structuredObjectInput for grouping relative primitives under a single named container but not in a way to model a choice between different input shapes. For example the Salesforce Create Record picks Contact vs Account and reveal a different set of fields. This MR adds `dynamicObjectInput` a discriminated set of input configurations.

# What we added

- A new `dynamicObjectInput({ configurations })` factory where `configurations` is a discriminant where each one has a label, description and its own inputs record. 
- `InputValue<T>` gains a branch for `DynamicObjectInputField`. 
- `convertInput` recognizes `dynamicObject` and emits a new `configurations` array on the server `Input`. 
- `INPUT_TYPE_MAP.dynamicObject = "unknown"` is added as a placeholder to match `structuredObject`. CNI work will enable this functionality in future work.
- New tests are added to make sure the discriminated union + narrowing behavior works correctly with typescript.