### PR TITLE
fix: update dynamic objects to use comments and input fields.

### DIFF
--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -711,7 +711,7 @@ export const structuredObjectInput = <
  *   configurations: {
  *     contact: {
  *       label: "Contact",
- *       description: "Create a new contact",
+ *       comments: "Create a new contact",
  *       inputs: {
  *         name: structuredObjectInput({
  *           label: "Name",
@@ -725,7 +725,7 @@ export const structuredObjectInput = <
  *     },
  *     account: {
  *       label: "Account",
- *       description: "Create a new account",
+ *       comments: "Create a new account",
  *       inputs: {
  *         companyName: input({ type: "string", label: "Company Name", required: true }),
  *       },

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -80,7 +80,7 @@ describe("convertInput", () => {
       configurations: {
         contact: {
           label: "Contact",
-          description: "Create a new contact",
+          comments: "Create a new contact",
           inputs: {
             name: structuredObjectInput({
               label: "Name",
@@ -94,7 +94,7 @@ describe("convertInput", () => {
         },
         account: {
           label: "Account",
-          description: "Create a new account",
+          comments: "Create a new account",
           inputs: {
             companyName: input({ type: "string", label: "Company Name", required: true }),
           },
@@ -114,7 +114,7 @@ describe("convertInput", () => {
       key: "contact",
       type: "configuration",
       label: "Contact",
-      description: "Create a new contact",
+      comments: "Create a new contact",
     });
     expect(contact?.inputs).toHaveLength(2);
     const contactName = contact?.inputs?.find((i) => i.key === "name");

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -107,12 +107,12 @@ describe("convertInput", () => {
     expect(converted.key).toBe("data");
     expect(converted.type).toBe("dynamicObject");
     expect(converted.required).toBe(true);
-    expect(converted.configurations).toHaveLength(2);
+    expect(converted.inputs).toHaveLength(2);
 
-    const contact = converted.configurations?.find((c) => c.key === "contact");
+    const contact = converted.inputs?.find((c) => c.key === "contact");
     expect(contact).toMatchObject({
       key: "contact",
-      type: "configuration",
+      type: "structuredObject",
       label: "Contact",
       comments: "Create a new contact",
     });
@@ -126,19 +126,19 @@ describe("convertInput", () => {
       required: true,
     });
 
-    const account = converted.configurations?.find((c) => c.key === "account");
+    const account = converted.inputs?.find((c) => c.key === "account");
+    expect(account).toMatchObject({
+      key: "account",
+      type: "structuredObject",
+      label: "Account",
+      comments: "Create a new account",
+    });
     expect(account?.inputs).toHaveLength(1);
     expect(account?.inputs?.[0]).toMatchObject({
       key: "companyName",
       type: "string",
       required: true,
     });
-  });
-
-  it("does not emit `configurations` on a non-dynamicObject input", () => {
-    const basicInput = input({ type: "string", label: "Basic" });
-    const converted = convertInput("basic", basicInput);
-    expect(converted.configurations).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -64,7 +64,7 @@ export const convertInput = (
       string,
       {
         label: string | { key: string; value: string };
-        description?: string;
+        comments?: string;
         inputs: Record<string, InputFieldDefinition>;
       }
     >;
@@ -86,7 +86,7 @@ export const convertInput = (
           key: configKey,
           type: "configuration",
           label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
-          description: configDef.description,
+          comments: configDef.comments,
           inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
             convertInput(childKey, childDef as InputFieldDefinition),
           ),

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -44,8 +44,7 @@ export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
-  // Cast: union members don't all carry `default`/`collection`/`inputs`/`configurations`;
-  // runtime guards below handle the differences.
+  // Cast: the field union is wider than any single member; runtime guards below handle it.
   const {
     default: defaultValue,
     type,
@@ -78,20 +77,17 @@ export const convertInput = (
       ? Object.entries(childInputs).map(([childKey, childDef]) =>
           convertInput(childKey, childDef as InputFieldDefinition),
         )
-      : undefined;
-
-  const convertedConfigurations =
-    type === "dynamicObject" && configurations
-      ? Object.entries(configurations).map(([configKey, configDef]) => ({
-          key: configKey,
-          type: "configuration",
-          label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
-          comments: configDef.comments,
-          inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
-            convertInput(childKey, childDef as InputFieldDefinition),
-          ),
-        }))
-      : undefined;
+      : type === "dynamicObject" && configurations
+        ? Object.entries(configurations).map(([configKey, configDef]) => ({
+            key: configKey,
+            type: "structuredObject",
+            label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
+            comments: configDef.comments,
+            inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
+              convertInput(childKey, childDef as InputFieldDefinition),
+            ),
+          }))
+        : undefined;
 
   return {
     ...omit(rest, [
@@ -108,7 +104,6 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
-    configurations: convertedConfigurations,
   };
 };
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,12 +364,9 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  /** Nested child inputs; populated when `type === "structuredObject"` or for
-   * a `configuration` entry inside a `dynamicObject`'s `configurations`. */
+  /** Nested children. For `structuredObject`, the declared inputs; for
+   * `dynamicObject`, one `structuredObject` per configuration. */
   inputs?: Input[];
-  /** Configurations of a `dynamicObject` input. Each entry has
-   * `type: "configuration"` and carries its own `inputs`. */
-  configurations?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,7 +364,6 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  description?: string;
   /** Nested child inputs; populated when `type === "structuredObject"` or for
    * a `configuration` entry inside a `dynamicObject`'s `configurations`. */
   inputs?: Input[];

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -415,7 +415,7 @@ export interface DynamicObjectConfiguration {
   /** Name of this configuration to present in the UI. */
   label: { key: string; value: string } | string;
   /** Additional text to give guidance to the user when this configuration is selected. */
-  description?: string;
+  comments?: string;
   /** Inputs that become available when this configuration is selected. May
    * include leaf inputs and structuredObject inputs; nested dynamicObjects
    * are rejected at the type level. */


### PR DESCRIPTION
# What changed

- Updates the `description` field to `comments` for `DynamicObjectConfiguration` to bring it in line with what the server will expect and naming conventions we use for spectral types.  
- Collapses `Input.configurations` for dynamic objects back to `Input.inputs` to match the field we already have. 