### PR TITLE
Add types for structuredObject and dynamicObject inputs in CNI manifest

### DIFF
--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -84,6 +84,55 @@ describe("getInputs — structuredObject", () => {
     expect(result.valueType).toBe("{ color: `red` | `blue` }");
   });
 
+  it("wraps a valuelist string child as Array<string>", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "tags", type: "string", collection: "valuelist" }),
+            baseInput({ key: "title", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ tags: Array<string>; title: string }");
+  });
+
+  it("wraps a keyvaluelist string child as the record-or-pairs union", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [baseInput({ key: "headers", type: "string", collection: "keyvaluelist" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      "{ headers: Record<string, string> | Array<{key: string, value: string}> }",
+    );
+  });
+
+  it("wraps a valuelist import-object child as Array<import(...).Type>", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [baseInput({ key: "conns", type: "connection", collection: "valuelist" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ conns: Array<import("@prismatic-io/spectral/dist/types").Connection> }',
+    );
+  });
+
   it("falls back to StructuredObject import when inputs are empty", () => {
     const [result] = getInputs({
       inputs: [baseInput({ key: "empty", type: "structuredObject", inputs: [] })],

--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { ServerTypeInput } from "./getInputs";
+import { getInputs } from "./getInputs";
+
+const baseInput = (
+  overrides: Partial<ServerTypeInput> & { key: string; type: string },
+): ServerTypeInput => ({ label: overrides.key, required: false, ...overrides }) as ServerTypeInput;
+
+describe("getInputs — structuredObject", () => {
+  it("emits an inline object type from declared children", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "person",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "first", type: "string" }),
+            baseInput({ key: "last", type: "string" }),
+            baseInput({ key: "active", type: "boolean" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ first: string; last: string; active: boolean }");
+  });
+
+  it("quotes non-identifier child keys", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "my-field", type: "string" }),
+            baseInput({ key: "normal", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe('{ "my-field": string; normal: string }');
+  });
+
+  it("uses inline import() syntax for import-object leaf types (e.g. connection)", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "config",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "conn", type: "connection" }),
+            baseInput({ key: "name", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ conn: import("@prismatic-io/spectral/dist/types").Connection; name: string }',
+    );
+  });
+
+  it("narrows leaf children that have a model to a literal union", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "config",
+          type: "structuredObject",
+          inputs: [
+            baseInput({
+              key: "color",
+              type: "string",
+              model: [
+                { label: "Red", value: "red" },
+                { label: "Blue", value: "blue" },
+              ],
+            } as unknown as ServerTypeInput),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ color: `red` | `blue` }");
+  });
+
+  it("falls back to StructuredObject import when inputs are empty", () => {
+    const [result] = getInputs({
+      inputs: [baseInput({ key: "empty", type: "structuredObject", inputs: [] })],
+    });
+
+    expect(result.valueType).toBe('import("@prismatic-io/spectral/dist/types").StructuredObject');
+  });
+});
+
+describe("getInputs — dynamicObject", () => {
+  it("emits a discriminated union from configurations", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          configurations: [
+            {
+              key: "contact",
+              type: "configuration",
+              label: "Contact",
+              inputs: [
+                baseInput({ key: "firstName", type: "string" }),
+                baseInput({ key: "lastName", type: "string" }),
+              ],
+            } as unknown as ServerTypeInput,
+            {
+              key: "account",
+              type: "configuration",
+              label: "Account",
+              inputs: [baseInput({ key: "companyName", type: "string" })],
+            } as unknown as ServerTypeInput,
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "contact"; values: { firstName: string; lastName: string } } | { configuration: "account"; values: { companyName: string } }',
+    );
+  });
+
+  it("handles a configuration whose inputs include a structuredObject child", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          configurations: [
+            {
+              key: "contact",
+              type: "configuration",
+              label: "Contact",
+              inputs: [
+                {
+                  key: "name",
+                  type: "structuredObject",
+                  label: "Name",
+                  inputs: [
+                    baseInput({ key: "first", type: "string" }),
+                    baseInput({ key: "last", type: "string" }),
+                  ],
+                } as unknown as ServerTypeInput,
+                baseInput({ key: "email", type: "string" }),
+              ],
+            } as unknown as ServerTypeInput,
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "contact"; values: { name: { first: string; last: string }; email: string } }',
+    );
+  });
+
+  it("uses StructuredObject import for a configuration with no inputs", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          configurations: [
+            {
+              key: "empty",
+              type: "configuration",
+              label: "Empty",
+              inputs: [],
+            } as unknown as ServerTypeInput,
+            {
+              key: "hasFields",
+              type: "configuration",
+              label: "Has Fields",
+              inputs: [baseInput({ key: "name", type: "string" })],
+            } as unknown as ServerTypeInput,
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "empty"; values: import("@prismatic-io/spectral/dist/types").StructuredObject } | { configuration: "hasFields"; values: { name: string } }',
+    );
+  });
+
+  it("falls back to DynamicObject import when configurations are empty", () => {
+    const [result] = getInputs({
+      inputs: [baseInput({ key: "empty", type: "dynamicObject", configurations: [] })],
+    });
+
+    expect(result.valueType).toBe('import("@prismatic-io/spectral/dist/types").DynamicObject');
+  });
+});

--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -100,22 +100,20 @@ describe("getInputs — dynamicObject", () => {
         baseInput({
           key: "record",
           type: "dynamicObject",
-          configurations: [
-            {
+          inputs: [
+            baseInput({
               key: "contact",
-              type: "configuration",
-              label: "Contact",
+              type: "structuredObject",
               inputs: [
                 baseInput({ key: "firstName", type: "string" }),
                 baseInput({ key: "lastName", type: "string" }),
               ],
-            } as unknown as ServerTypeInput,
-            {
+            }),
+            baseInput({
               key: "account",
-              type: "configuration",
-              label: "Account",
+              type: "structuredObject",
               inputs: [baseInput({ key: "companyName", type: "string" })],
-            } as unknown as ServerTypeInput,
+            }),
           ],
         }),
       ],
@@ -132,24 +130,22 @@ describe("getInputs — dynamicObject", () => {
         baseInput({
           key: "record",
           type: "dynamicObject",
-          configurations: [
-            {
+          inputs: [
+            baseInput({
               key: "contact",
-              type: "configuration",
-              label: "Contact",
+              type: "structuredObject",
               inputs: [
-                {
+                baseInput({
                   key: "name",
                   type: "structuredObject",
-                  label: "Name",
                   inputs: [
                     baseInput({ key: "first", type: "string" }),
                     baseInput({ key: "last", type: "string" }),
                   ],
-                } as unknown as ServerTypeInput,
+                }),
                 baseInput({ key: "email", type: "string" }),
               ],
-            } as unknown as ServerTypeInput,
+            }),
           ],
         }),
       ],
@@ -166,19 +162,13 @@ describe("getInputs — dynamicObject", () => {
         baseInput({
           key: "record",
           type: "dynamicObject",
-          configurations: [
-            {
-              key: "empty",
-              type: "configuration",
-              label: "Empty",
-              inputs: [],
-            } as unknown as ServerTypeInput,
-            {
+          inputs: [
+            baseInput({ key: "empty", type: "structuredObject", inputs: [] }),
+            baseInput({
               key: "hasFields",
-              type: "configuration",
-              label: "Has Fields",
+              type: "structuredObject",
               inputs: [baseInput({ key: "name", type: "string" })],
-            } as unknown as ServerTypeInput,
+            }),
           ],
         }),
       ],
@@ -191,7 +181,7 @@ describe("getInputs — dynamicObject", () => {
 
   it("falls back to DynamicObject import when configurations are empty", () => {
     const [result] = getInputs({
-      inputs: [baseInput({ key: "empty", type: "dynamicObject", configurations: [] })],
+      inputs: [baseInput({ key: "empty", type: "dynamicObject", inputs: [] })],
     });
 
     expect(result.valueType).toBe('import("@prismatic-io/spectral/dist/types").DynamicObject');

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -25,15 +25,6 @@ interface GetInputsProps {
   docBlock?: (input: ServerTypeInput) => string;
 }
 
-const getDefaultValue = (value: ServerTypeInput["default"], isCollection: boolean) => {
-  if (value === undefined || value === "") {
-    return isCollection ? [] : value;
-  }
-
-  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
-  return escapeSpecialCharacters(stringValue);
-};
-
 export const getInputs = ({ inputs, docBlock = DOC_BLOCK_DEFAULT }: GetInputsProps): Input[] => {
   return inputs.reduce((acc, input) => {
     if (
@@ -98,16 +89,27 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   timestamp: "string",
   flow: "string",
   template: "string",
-  // TODO: emit a typed record matching the declared children once the
-  // code-native action-calling type generator handles structuredObject.
-  structuredObject: "unknown",
-  // TODO: emit a precise discriminated-union type matching the declared
-  // configurations once the CNI manifest generator handles dynamicObject.
-  dynamicObject: "unknown",
+  structuredObject: {
+    module: "@prismatic-io/spectral/dist/types",
+    type: "StructuredObject",
+  },
+  dynamicObject: {
+    module: "@prismatic-io/spectral/dist/types",
+    type: "DynamicObject",
+  },
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {
+  if (input.type === "structuredObject") {
+    return structuredObjectTypeString(input.inputs ?? []);
+  }
+
+  if (input.type === "dynamicObject") {
+    return dynamicObjectTypeString(input.configurations ?? []);
+  }
+
   const inputType = INPUT_TYPE_MAP[input.type as InputFieldDefinition["type"]];
+
   const valueType = input.model
     ? input.model
         .map((choice) => {
@@ -139,4 +141,74 @@ const getInputValueType = (input: ServerTypeInput): ValueType => {
   }
 
   return valueType;
+};
+
+const getDefaultValue = (value: ServerTypeInput["default"], isCollection: boolean) => {
+  if (value === undefined || value === "") {
+    return isCollection ? [] : value;
+  }
+
+  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
+
+  return escapeSpecialCharacters(stringValue);
+};
+
+const isValidIdentifier = (key: string) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key);
+
+const getLeafTypeString = (child: ServerTypeInput): string => {
+  if (child.type === "structuredObject") {
+    return structuredObjectTypeString(child.inputs ?? []);
+  }
+
+  if (child.model?.length) {
+    return child.model
+      .map(({ value }) => `\`${value.replaceAll("\r", "\\r").replaceAll("\n", "\\n")}\``)
+      .join(" | ");
+  }
+
+  const mapped = INPUT_TYPE_MAP[child.type as InputFieldDefinition["type"]];
+
+  if (!mapped) {
+    return "unknown";
+  }
+
+  if (typeof mapped === "string") {
+    return mapped;
+  }
+
+  return `import("${mapped.module}").${mapped.type}`;
+};
+
+const SPECTRAL_TYPES_MODULE = "@prismatic-io/spectral/dist/types";
+
+const structuredObjectTypeString = (inputs: ServerTypeInput[]): string => {
+  if (!inputs.length) {
+    return `import("${SPECTRAL_TYPES_MODULE}").StructuredObject`;
+  }
+
+  const fields = inputs
+    .map((child) => {
+      const key = isValidIdentifier(child.key) ? child.key : JSON.stringify(child.key);
+
+      return `${key}: ${getLeafTypeString(child)}`;
+    })
+    .join("; ");
+
+  return `{ ${fields} }`;
+};
+
+const dynamicObjectTypeString = (configurations: ServerTypeInput[]): string => {
+  if (!configurations.length) {
+    return `import("${SPECTRAL_TYPES_MODULE}").DynamicObject`;
+  }
+
+  return configurations
+    .map((config) => {
+      const valuesType = config.inputs?.length
+        ? structuredObjectTypeString(config.inputs)
+        : `import("${SPECTRAL_TYPES_MODULE}").StructuredObject`;
+
+      return `{ configuration: ${JSON.stringify(config.key)}; values: ${valuesType} }`;
+    })
+    .join(" | ");
 };

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -155,11 +155,19 @@ const getDefaultValue = (value: ServerTypeInput["default"], isCollection: boolea
 
 const isValidIdentifier = (key: string) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key);
 
-const getLeafTypeString = (child: ServerTypeInput): string => {
-  if (child.type === "structuredObject") {
-    return structuredObjectTypeString(child.inputs ?? []);
+const wrapCollection = (valueType: string, collection: ServerTypeInput["collection"]): string => {
+  if (collection === "valuelist") {
+    return `Array<${valueType}>`;
   }
 
+  if (collection === "keyvaluelist") {
+    return `Record<string, ${valueType}> | Array<{key: string, value: ${valueType}}>`;
+  }
+  
+  return valueType;
+};
+
+const getLeafBaseType = (child: ServerTypeInput): string => {
   if (child.model?.length) {
     return child.model
       .map(({ value }) => `\`${value.replaceAll("\r", "\\r").replaceAll("\n", "\\n")}\``)
@@ -177,6 +185,14 @@ const getLeafTypeString = (child: ServerTypeInput): string => {
   }
 
   return `import("${mapped.module}").${mapped.type}`;
+};
+
+const getLeafTypeString = (child: ServerTypeInput): string => {
+  if (child.type === "structuredObject") {
+    return structuredObjectTypeString(child.inputs ?? []);
+  }
+
+  return wrapCollection(getLeafBaseType(child), child.collection);
 };
 
 const SPECTRAL_TYPES_MODULE = "@prismatic-io/spectral/dist/types";

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -105,7 +105,7 @@ const getInputValueType = (input: ServerTypeInput): ValueType => {
   }
 
   if (input.type === "dynamicObject") {
-    return dynamicObjectTypeString(input.configurations ?? []);
+    return dynamicObjectTypeString(input.inputs ?? []);
   }
 
   const inputType = INPUT_TYPE_MAP[input.type as InputFieldDefinition["type"]];

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -72,6 +72,10 @@ export type DynamicObjectSelection = string;
 
 export type DynamicFieldSelection = string;
 
+export type StructuredObject = Record<string, unknown>;
+
+export type DynamicObject = Record<string, unknown>;
+
 /** InputField type enumeration. */
 export type InputFieldType = InputFieldDefinition["type"];
 export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = {


### PR DESCRIPTION
Previously, structuredObject and dynamicObject inputs fell back to "unknown" in the generated component manifest, giving CNI authors no type safety when calling actions that use these input types.

This change updates the manifest generator (getInputs.ts) to emit inline TypeScript types derived from the actual input definition:

  - structuredObject → inline object type: { first: string; last: string }
  - dynamicObject → discriminated union: { configuration: "contact"; values: {...} } | { configuration: "account"; values: {...} }

Fallback cases (empty inputs/configurations) now reference named exported types. StructuredObject and DynamicObject - added to @prismatic-io/spectral/dist/types, consistent with how Connection, ObjectFieldMap, and other complex types are handled.




## Component

**Structured Object Type**

<img width="921" height="385" alt="Screenshot 2026-05-18 at 2 16 39 PM" src="https://github.com/user-attachments/assets/15b833fc-1e5d-49a1-9453-9eb239919e53" />

**Dynamic Object Type**

<img width="995" height="780" alt="Screenshot 2026-05-18 at 2 16 17 PM" src="https://github.com/user-attachments/assets/b91ea4c1-983c-4d99-89b8-235da3d09fb8" />

## Manifest

**Structured Object Type**

<img width="989" height="1233" alt="Screenshot 2026-05-18 at 2 18 15 PM" src="https://github.com/user-attachments/assets/8ead9a89-6a9a-48ea-a47e-bf258f230369" />

**Dynamic Object Type**

<img width="1020" height="1382" alt="Screenshot 2026-05-18 at 2 17 24 PM" src="https://github.com/user-attachments/assets/e2becc0a-3043-4bc0-bbda-d166a2456460" />

## CNI

**Structured Object Type**

<img width="759" height="512" alt="Screenshot 2026-05-18 at 2 11 44 PM" src="https://github.com/user-attachments/assets/c1516e8b-e1e4-4402-bb7e-49b08518f684" />

<img width="824" height="525" alt="Screenshot 2026-05-18 at 2 12 04 PM" src="https://github.com/user-attachments/assets/0752661b-35f8-448b-81aa-869fc5ee3865" />

<img width="1069" height="651" alt="Screenshot 2026-05-18 at 2 12 29 PM" src="https://github.com/user-attachments/assets/9074f7e0-6ba7-4053-a736-a3ef0ad2085c" />

**Dynamic Object Type**

<img width="799" height="554" alt="Screenshot 2026-05-18 at 2 13 52 PM" src="https://github.com/user-attachments/assets/0b2440e2-2f88-4934-8f90-d1b87d6c9a31" />

<img width="1101" height="553" alt="Screenshot 2026-05-18 at 2 13 03 PM" src="https://github.com/user-attachments/assets/2ebe490f-2483-454c-a206-eafb5d616a77" />

<img width="1109" height="767" alt="Screenshot 2026-05-18 at 2 14 10 PM" src="https://github.com/user-attachments/assets/a2955883-48eb-4e20-8138-2e52f49abfc1" />

<img width="938" height="554" alt="Screenshot 2026-05-18 at 2 14 44 PM" src="https://github.com/user-attachments/assets/85244835-8c86-49fe-b088-f4ba14c11c40" />

<img width="1126" height="588" alt="Screenshot 2026-05-18 at 2 15 00 PM" src="https://github.com/user-attachments/assets/86624242-df48-4497-929c-e53f5d317714" />