### PR TITLE
Component manifests should use static typescript version

### DIFF
--- a/packages/spectral/src/generators/componentManifest/cli.ts
+++ b/packages/spectral/src/generators/componentManifest/cli.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { existsSync, readJsonSync } from "fs-extra";
+import { existsSync } from "fs-extra";
 import path from "path";
 import { isObjectWithOneTruthyKey, isObjectWithTruthyKeys } from "../../util";
 import { createFlagHelpText } from "../utils/createFlagHelpText";
@@ -122,22 +122,14 @@ export const runMain = async (process: NodeJS.Process) => {
     process.exit(1);
   }
 
-  const packageJson: {
-    version: string;
-    dependencies: Record<string, string>;
-    devDependencies: Record<string, string>;
-  } = readJsonSync(path.join(__dirname, "../../../package.json"));
+  const { version: spectralVersion } = require("../../../package.json");
 
   await createComponentManifest({
     component,
     dryRun: flags.dry_run.value,
     skipSignatureVerify: flags.skip_signature_verify.value,
     packageName: flags.name.value ?? `@component-manifests/${component.key}`,
-    dependencies: {
-      spectral: packageJson.version,
-      dependencies: packageJson.dependencies,
-      devDependencies: packageJson.devDependencies,
-    },
+    spectralVersion,
     verbose: flags.verbose.value,
     sourceDir: path.join(__dirname, "templates"),
     destinationDir: flags.output_dir.value

--- a/packages/spectral/src/generators/componentManifest/createStaticFiles.test.ts
+++ b/packages/spectral/src/generators/componentManifest/createStaticFiles.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { renderPackageJson } from "./createStaticFiles";
+
+describe("renderPackageJson", () => {
+  const sourceDir = path.join(__dirname, "templates");
+  let destinationDir: string;
+
+  beforeEach(async () => {
+    destinationDir = await mkdtemp(path.join(tmpdir(), "spectral-component-manifest-"));
+  });
+
+  afterEach(async () => {
+    await rm(destinationDir, { recursive: true, force: true });
+  });
+
+  const render = async (
+    overrides: Partial<Parameters<typeof renderPackageJson>[0]> = {},
+  ): Promise<Record<string, any>> => {
+    await renderPackageJson({
+      dryRun: false,
+      packageName: "@component-manifests/test",
+      spectralVersion: "1.2.3",
+      verbose: false,
+      sourceDir,
+      destinationDir,
+      registry: null,
+      ...overrides,
+    });
+    return JSON.parse(await readFile(path.join(destinationDir, "package.json"), "utf-8"));
+  };
+
+  test("uses the provided spectral version for the dev and peer dependency", async () => {
+    const pkg = await render({ spectralVersion: "10.99.0" });
+    expect(pkg.devDependencies["@prismatic-io/spectral"]).toBe("10.99.0");
+    expect(pkg.peerDependencies["@prismatic-io/spectral"]).toBe(">= 10.99.0");
+  });
+
+  test("only the spectral dependency tracks the caller's spectralVersion", async () => {
+    const a = await render({ spectralVersion: "1.0.0" });
+    const b = await render({ spectralVersion: "999.0.0" });
+    expect(a.devDependencies).toMatchObject({
+      ...b.devDependencies,
+      "@prismatic-io/spectral": expect.any(String),
+    });
+  });
+
+  test("uses the provided package name", async () => {
+    const pkg = await render({ packageName: "@acme/widget-manifest" });
+    expect(pkg.name).toBe("@acme/widget-manifest");
+  });
+
+  test("omits publishConfig when no registry is provided", async () => {
+    const pkg = await render({ registry: null });
+    expect(pkg.publishConfig).toBeUndefined();
+  });
+
+  test("includes publishConfig when a registry is provided", async () => {
+    const pkg = await render({ registry: "https://npm.example.com/" });
+    expect(pkg.publishConfig).toEqual({ registry: "https://npm.example.com/" });
+  });
+});

--- a/packages/spectral/src/generators/componentManifest/createStaticFiles.ts
+++ b/packages/spectral/src/generators/componentManifest/createStaticFiles.ts
@@ -4,12 +4,6 @@ import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult }
 import { createTemplate } from "../utils/createTemplate";
 import { helpers } from "./helpers";
 
-export interface PackageDependencies {
-  spectral: string;
-  dependencies: Record<string, string>;
-  devDependencies: Record<string, string>;
-}
-
 interface CreateStaticFilesProps<
   TInputs extends Inputs,
   TActionInputs extends Inputs,
@@ -25,7 +19,7 @@ interface CreateStaticFilesProps<
   dryRun: boolean;
   signature: string | null;
   packageName: string;
-  dependencies: PackageDependencies;
+  spectralVersion: string;
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
@@ -47,7 +41,7 @@ export const createStaticFiles = async <
   dryRun,
   signature,
   packageName,
-  dependencies,
+  spectralVersion,
   verbose,
   sourceDir,
   destinationDir,
@@ -78,7 +72,7 @@ export const createStaticFiles = async <
 
   const packageJson = await renderPackageJson({
     dryRun,
-    dependencies,
+    spectralVersion,
     packageName,
     verbose,
     sourceDir,
@@ -173,7 +167,7 @@ export const renderIndex = async ({
 interface RenderPackageJsonProps {
   dryRun: boolean;
   packageName: string;
-  dependencies: PackageDependencies;
+  spectralVersion: string;
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
@@ -183,7 +177,7 @@ interface RenderPackageJsonProps {
 export const renderPackageJson = async ({
   dryRun,
   packageName,
-  dependencies,
+  spectralVersion,
   verbose,
   sourceDir,
   destinationDir,
@@ -194,8 +188,7 @@ export const renderPackageJson = async ({
     destination: path.join(destinationDir, "package.json"),
     data: {
       packageName,
-      spectralVersion: dependencies.spectral,
-      typescriptVersion: dependencies.devDependencies.typescript,
+      spectralVersion,
       helpers,
       registry,
     },

--- a/packages/spectral/src/generators/componentManifest/index.ts
+++ b/packages/spectral/src/generators/componentManifest/index.ts
@@ -5,7 +5,7 @@ import { getComponentSignatureWithPrism } from "../utils/prism";
 import { createActions } from "./createActions";
 import { createConnections } from "./createConnections";
 import { createDataSources } from "./createDataSources";
-import { createStaticFiles, type PackageDependencies } from "./createStaticFiles";
+import { createStaticFiles } from "./createStaticFiles";
 import { createTriggers } from "./createTriggers";
 import { removeComponentManifest } from "./removeComponentManifest";
 
@@ -24,7 +24,7 @@ interface CreateComponentManifestProps<
   dryRun: boolean;
   skipSignatureVerify: boolean;
   packageName: string;
-  dependencies: PackageDependencies;
+  spectralVersion: string;
   verbose: boolean;
   sourceDir: string;
   destinationDir: string;
@@ -46,7 +46,7 @@ export const createComponentManifest = async <
   dryRun,
   skipSignatureVerify,
   packageName,
-  dependencies,
+  spectralVersion,
   verbose,
   sourceDir,
   destinationDir,
@@ -78,7 +78,7 @@ export const createComponentManifest = async <
     dryRun,
     packageName,
     signature,
-    dependencies,
+    spectralVersion,
     verbose,
     sourceDir,
     destinationDir,

--- a/packages/spectral/src/generators/componentManifest/templates/package.json.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/package.json.ejs
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@prismatic-io/spectral": "<%= spectralVersion %>",
     "rimraf": "5.0.7",
-    "typescript": "<%= typescriptVersion %>"
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@prismatic-io/spectral": ">= <%= spectralVersion %>"


### PR DESCRIPTION
Instead of updating to align with Spectral's since we should have compat with the type defs themselves.