### PR TITLE
block connections from being structured and dynamic object input children

### DIFF
--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -216,3 +216,21 @@ dynamicObjectInput({
     },
   },
 });
+
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        name: structuredObjectInput({
+          label: "Name",
+          inputs: {
+            // @ts-expect-error: connection rejected at depth 2 (structuredObject inside dynamicObject configuration).
+            cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+          },
+        }),
+      },
+    },
+  },
+});

--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -155,3 +155,64 @@ structuredObjectInput({
     }),
   },
 });
+
+structuredObjectInput({
+  label: "Parent",
+  inputs: {
+    // @ts-expect-error: structuredObject children cannot be a connection.
+    cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+    // @ts-expect-error: structuredObject children cannot be a connection template.
+    tmpl: input({
+      type: "template",
+      key: "tmpl",
+      label: "Template",
+      templateValue: "",
+    }),
+  },
+});
+
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    salesforce: {
+      label: "Salesforce",
+      inputs: {
+        // @ts-expect-error: dynamicObject configurations cannot contain a connection child.
+        cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+        // @ts-expect-error: dynamicObject configurations cannot contain a connection template child.
+        tmpl: input({
+          type: "template",
+          key: "tmpl",
+          label: "Template",
+          templateValue: "",
+        }),
+      },
+    },
+  },
+});
+
+// Positive-compile probes for the depth-2 position: a structuredObject
+// living inside a dynamicObject configuration, whose leaves must still
+// accept ordinary scalar and conditional inputs. If
+// `LeafInputFieldDefinition` ever over-narrows, these factory calls
+// fail to satisfy the SO factory's generic constraint and the
+// regression surfaces here. Paired with the rejection directives above
+// so each directive is provably load-bearing on its precise position.
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        name: structuredObjectInput({
+          label: "Name",
+          inputs: {
+            first: input({ type: "string", label: "First" }),
+            count: input({ type: "string", label: "Count", collection: "valuelist" }),
+            cond: input({ type: "conditional", label: "Cond", collection: "valuelist" }),
+          },
+        }),
+      },
+    },
+  },
+});

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -420,9 +420,7 @@ export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
 
 /** A single configuration within a dynamicObject. Each configuration declares
  * a labeled set of inputs that become available when this configuration is
- * selected at runtime. May contain leaf inputs and structuredObject
- * children; nested dynamicObjects and connection pickers are rejected at
- * the type level. */
+ * selected at runtime. */
 export interface DynamicObjectConfiguration {
   /** Name of this configuration to present in the UI. */
   label: { key: string; value: string } | string;

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -388,23 +388,29 @@ export type DateTimeInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/** `InputFieldDefinition` minus container input types; used to cap
- * structuredObject nesting at one level and to enforce leaf-only positions. */
+/** `InputFieldDefinition` minus container input types and connection
+ * pickers. Connections resolve to config-var references outside the
+ * parent's value tree, so they're only valid at the top level — never as
+ * a child of a structuredObject or a dynamicObject configuration. */
 export type LeafInputFieldDefinition = Exclude<
   InputFieldDefinition,
-  StructuredObjectInputField | DynamicObjectInputField
+  | StructuredObjectInputField
+  | DynamicObjectInputField
+  | ConnectionInputField
+  | ConnectionTemplateInputField
 >;
 
-/** `InputFieldDefinition` minus `DynamicObjectInputField`; used inside a
- * dynamicObject's `configurations.<key>.inputs` to allow leaves *and*
- * structuredObject children while still rejecting nested dynamicObjects. */
-export type StructuredOrLeafInputFieldDefinition = Exclude<
-  InputFieldDefinition,
-  DynamicObjectInputField
->;
+/** `LeafInputFieldDefinition` plus `StructuredObjectInputField`; used
+ * inside a dynamicObject's `configurations.<key>.inputs` to allow leaves
+ * and structuredObject children while still rejecting nested
+ * dynamicObjects and connection pickers. */
+export type StructuredOrLeafInputFieldDefinition =
+  | LeafInputFieldDefinition
+  | StructuredObjectInputField;
 
 /** Groups related primitive inputs under a single named container.
- * Nesting is capped at one level. */
+ * Nesting is capped at one level. Connection pickers are rejected as
+ * children — they may only appear at the top level. */
 export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
   /** Data type the input will collect. */
   type: "structuredObject";
@@ -414,15 +420,15 @@ export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
 
 /** A single configuration within a dynamicObject. Each configuration declares
  * a labeled set of inputs that become available when this configuration is
- * selected at runtime. */
+ * selected at runtime. May contain leaf inputs and structuredObject
+ * children; nested dynamicObjects and connection pickers are rejected at
+ * the type level. */
 export interface DynamicObjectConfiguration {
   /** Name of this configuration to present in the UI. */
   label: { key: string; value: string } | string;
   /** Additional text to give guidance to the user when this configuration is selected. */
   comments?: string;
-  /** Inputs that become available when this configuration is selected. May
-   * include leaf inputs and structuredObject inputs; nested dynamicObjects
-   * are rejected at the type level. */
+  /** Inputs that become available when this configuration is selected. */
   inputs: Record<string, StructuredOrLeafInputFieldDefinition>;
 }
 


### PR DESCRIPTION
# Problem

We need to ensure connection inputs cannot be nested within structured and dynamic object inputs

# Approach
- Exclude `ConnectionInputField` and `ConnectionTemplateInputField` from `LeafInputFieldDefinition` so we now have the uniform rule that connections may only appear at the top level and never as children to structured or dynamic objects.