### PR TITLE
feat: add outputSchema to action definitions

### DIFF
--- a/packages/spectral-test/src/OutputSchema.test-d.ts
+++ b/packages/spectral-test/src/OutputSchema.test-d.ts
@@ -1,0 +1,40 @@
+import type { OutputSchema } from "@prismatic-io/spectral";
+import { expectAssignable, expectNotAssignable } from "tsd";
+
+// actionOutput carries a single `schema`.
+expectAssignable<OutputSchema>({
+  type: "actionOutput",
+  schema: { type: "object", properties: { id: { type: "string" } } },
+});
+
+// branchingOutput carries a per-branch map under `branchSchemas`.
+expectAssignable<OutputSchema>({
+  type: "branchingOutput",
+  branchSchemas: {
+    found: { type: "object" },
+    notFound: { type: "object" },
+  },
+});
+
+// branchingOutput requires `branchSchemas`; the legacy `branches` key is invalid.
+expectNotAssignable<OutputSchema>({
+  type: "branchingOutput",
+  branches: { found: { type: "object" } },
+});
+
+// The two variants don't cross: actionOutput cannot carry branchSchemas, and
+// branchingOutput cannot carry a bare schema.
+expectNotAssignable<OutputSchema>({
+  type: "actionOutput",
+  branchSchemas: { found: { type: "object" } },
+});
+expectNotAssignable<OutputSchema>({
+  type: "branchingOutput",
+  schema: { type: "object" },
+});
+
+// Unknown discriminants are rejected.
+expectNotAssignable<OutputSchema>({
+  type: "somethingElse",
+  schema: { type: "object" },
+});

--- a/packages/spectral-test/src/OutputSchema.test-d.ts
+++ b/packages/spectral-test/src/OutputSchema.test-d.ts
@@ -1,5 +1,26 @@
-import type { OutputSchema } from "@prismatic-io/spectral";
-import { expectAssignable, expectNotAssignable } from "tsd";
+import { type OutputSchema, outputSchema } from "@prismatic-io/spectral";
+import { expectAssignable, expectNotAssignable, expectType } from "tsd";
+
+// The `outputSchema` helper preserves the literal discriminant without a
+// trailing `as const` — even when the schema is hoisted into its own variable,
+// where TS would otherwise widen `type` to `string`.
+const hoistedAction = outputSchema({
+  type: "actionOutput",
+  schema: { type: "object", properties: { id: { type: "string" } } },
+});
+expectAssignable<OutputSchema>(hoistedAction);
+expectType<"actionOutput">(hoistedAction.type);
+
+const hoistedBranching = outputSchema({
+  type: "branchingOutput",
+  branchSchemas: { found: { type: "object" }, notFound: { type: "object" } },
+});
+expectAssignable<OutputSchema>(hoistedBranching);
+expectType<"branchingOutput">(hoistedBranching.type);
+
+// The helper still rejects invalid shapes (no escape hatch from the union).
+// @ts-expect-error — unknown discriminant is not an OutputSchema.
+outputSchema({ type: "somethingElse", schema: { type: "object" } });
 
 // actionOutput carries a single `schema`.
 expectAssignable<OutputSchema>({

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -52,10 +52,10 @@ export interface InputNode {
   onPremiseControlled: boolean;
 }
 
-export type FormattedAction = Pick<
-  Action,
-  "key" | "display" | "inputs" | "examplePayload" | "outputSchema"
->;
+export type FormattedAction = Pick<Action, "key" | "display" | "inputs" | "examplePayload"> & {
+  /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
+  outputSchema?: unknown;
+};
 export type FormattedTrigger<
   TInputs extends Inputs,
   TActionInputs extends Inputs,

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -54,7 +54,7 @@ export interface InputNode {
 
 export type FormattedAction = Pick<
   Action,
-  "key" | "display" | "inputs" | "examplePayload" | "output"
+  "key" | "display" | "inputs" | "examplePayload" | "outputSchema"
 >;
 export type FormattedTrigger<
   TInputs extends Inputs,

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -52,7 +52,10 @@ export interface InputNode {
   onPremiseControlled: boolean;
 }
 
-export type FormattedAction = Pick<Action, "key" | "display" | "inputs" | "examplePayload">;
+export type FormattedAction = Pick<
+  Action,
+  "key" | "display" | "inputs" | "examplePayload" | "output"
+>;
 export type FormattedTrigger<
   TInputs extends Inputs,
   TActionInputs extends Inputs,

--- a/packages/spectral/src/generators/componentManifest/createActions.test.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { OutputSchema } from "../../types/OutputSchema";
+import type { ComponentForManifest } from "../cniComponentManifest/types";
+import { createActions } from "./createActions";
+
+const sourceDir = path.join(__dirname, "templates");
+
+const buildComponent = (
+  actionOverrides: Record<string, unknown> = {},
+): ComponentForManifest<any, any> =>
+  ({
+    key: "acme",
+    public: false,
+    display: { label: "Acme", description: "Acme", iconPath: "icon.png" },
+    connections: [],
+    actions: {
+      doThing: {
+        key: "doThing",
+        display: { label: "Do Thing", description: "Does the thing" },
+        inputs: [],
+        perform: async () => ({ data: {} }),
+        ...actionOverrides,
+      },
+    },
+    triggers: {},
+    dataSources: {},
+  }) as unknown as ComponentForManifest<any, any>;
+
+describe("createActions outputSchema emission", () => {
+  let destinationDir: string;
+
+  beforeEach(async () => {
+    destinationDir = await mkdtemp(path.join(tmpdir(), "spectral-create-actions-"));
+  });
+
+  afterEach(async () => {
+    await rm(destinationDir, { recursive: true, force: true });
+  });
+
+  const render = async (actionOverrides: Record<string, unknown> = {}): Promise<string> => {
+    await createActions({
+      component: buildComponent(actionOverrides),
+      dryRun: false,
+      verbose: false,
+      sourceDir,
+      destinationDir,
+    });
+    return readFile(path.join(destinationDir, "actions", "doThing.ts"), "utf-8");
+  };
+
+  test("emits an actionOutput outputSchema", async () => {
+    const outputSchema: OutputSchema = {
+      type: "actionOutput",
+      schema: { type: "object", properties: { id: { type: "string" } } },
+    };
+    const rendered = await render({ outputSchema });
+    expect(rendered).toContain("outputSchema:");
+    expect(rendered).toContain('type: "actionOutput"');
+    expect(rendered).toContain("id:");
+  });
+
+  test("emits a branchingOutput outputSchema keyed by branchSchemas", async () => {
+    const outputSchema: OutputSchema = {
+      type: "branchingOutput",
+      branchSchemas: {
+        found: { type: "object" },
+        notFound: { type: "object" },
+      },
+    };
+    const rendered = await render({ outputSchema });
+    expect(rendered).toContain("outputSchema:");
+    expect(rendered).toContain('type: "branchingOutput"');
+    expect(rendered).toContain("branchSchemas:");
+    expect(rendered).toContain("found:");
+    expect(rendered).toContain("notFound:");
+  });
+
+  test("omits outputSchema when the action declares none", async () => {
+    const rendered = await render();
+    expect(rendered).not.toContain("outputSchema:");
+  });
+});

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
-import type { JsonSchema } from "../../types/jsonforms/JsonSchema";
+import type { OutputSchema } from "../../types/OutputSchema";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -150,7 +150,7 @@ interface RenderActionProps {
     description: string;
     inputs: Input[];
     examplePayload?: unknown;
-    outputSchema?: JsonSchema;
+    outputSchema?: OutputSchema;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
-import type { ComponentForManifest } from "../cniComponentManifest/types";
 import type { JsonSchema } from "../../types/jsonforms/JsonSchema";
+import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
 import { createTypeInterface } from "../utils/createTypeInterface";
@@ -91,7 +91,7 @@ export const createActions = async <
           description: action.display.description,
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
-          ...(action.output ? { output: action.output } : {}),
+          ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
           componentKey: component.key,
         },
         imports,
@@ -150,7 +150,7 @@ interface RenderActionProps {
     description: string;
     inputs: Input[];
     examplePayload?: unknown;
-    output?: JsonSchema;
+    outputSchema?: JsonSchema;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
-import type { OutputSchema } from "../../types/OutputSchema";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -150,7 +149,7 @@ interface RenderActionProps {
     description: string;
     inputs: Input[];
     examplePayload?: unknown;
-    outputSchema?: OutputSchema;
+    outputSchema?: unknown;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
+import type { JsonSchema } from "../../types/jsonforms/JsonSchema";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
 import { createTypeInterface } from "../utils/createTypeInterface";
@@ -90,6 +91,7 @@ export const createActions = async <
           description: action.display.description,
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
+          ...(action.output ? { output: action.output } : {}),
           componentKey: component.key,
         },
         imports,
@@ -148,6 +150,7 @@ interface RenderActionProps {
     description: string;
     inputs: Input[];
     examplePayload?: unknown;
+    output?: JsonSchema;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -25,7 +25,7 @@ export const <%= action.import %> = {
   <%_ if (action.examplePayload) { -%>
   examplePayload: <%- typeof action.examplePayload === 'string' ? action.examplePayload : JSON.stringify(action.examplePayload, null, 2) %>,
   <%_ } -%>
-  <%_ if (action.output) { -%>
-  output: <%- typeof action.output === 'string' ? action.output : JSON.stringify(action.output, null, 2) %>,
+  <%_ if (action.outputSchema) { -%>
+  outputSchema: <%- typeof action.outputSchema === 'string' ? action.outputSchema : JSON.stringify(action.outputSchema, null, 2) %>,
   <%_ } -%>
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -25,4 +25,7 @@ export const <%= action.import %> = {
   <%_ if (action.examplePayload) { -%>
   examplePayload: <%- typeof action.examplePayload === 'string' ? action.examplePayload : JSON.stringify(action.examplePayload, null, 2) %>,
   <%_ } -%>
+  <%_ if (action.output) { -%>
+  output: <%- typeof action.output === 'string' ? action.output : JSON.stringify(action.output, null, 2) %>,
+  <%_ } -%>
 } as const;

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -29,6 +29,7 @@ import type {
   OAuth2ConnectionDefinition,
   OnPremConnectionDefinition,
   OrganizationActivatedConnectionConfigVar,
+  OutputSchema,
   StandardConfigVar,
   StructuredObjectInputField,
   TriggerDefinition,
@@ -523,6 +524,41 @@ export const action = <
 >(
   definition: ActionDefinition<TInputs, TConfigVars, TAllowsBranching, TReturn>,
 ): ActionDefinition<TInputs, TConfigVars, TAllowsBranching, TReturn> => definition;
+
+/**
+ * Declares the output schema for an action and preserves its literal types,
+ * so authors don't need a trailing `as const` (or `satisfies OutputSchema`)
+ * to keep the `type` discriminant from widening to `string`.
+ *
+ * Wrapping the schema in this helper lets it be hoisted into a standalone
+ * variable and still satisfy the {@link OutputSchema} discriminated union:
+ *
+ * @example
+ * import { action, outputSchema } from "@prismatic-io/spectral";
+ *
+ * // Hoisted out of the action — no `as const` needed.
+ * const listItemsOutput = outputSchema({
+ *   type: "actionOutput",
+ *   schema: {
+ *     type: "object",
+ *     properties: { items: { type: "array" } },
+ *   },
+ * });
+ *
+ * export const listItems = action({
+ *   display: { label: "List Items", description: "..." },
+ *   inputs: {},
+ *   perform: async () => ({ data: { items: [] } }),
+ *   outputSchema: listItemsOutput,
+ * });
+ *
+ * @param definition An {@link OutputSchema} object — either an `actionOutput`
+ *   single-payload schema or a `branchingOutput` per-branch map.
+ * @returns The same object, typed with its literal discriminant preserved.
+ */
+export const outputSchema = <const TOutputSchema extends OutputSchema>(
+  definition: TOutputSchema,
+): TOutputSchema => definition;
 
 /**
  * This function creates a trigger object that can be referenced

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import { connection, dynamicObjectInput, input, structuredObjectInput, trigger } from "..";
+import {
+  action,
+  component,
+  connection,
+  dynamicObjectInput,
+  input,
+  structuredObjectInput,
+  trigger,
+} from "..";
 import {
   cleanerFor,
   convertConnection,
@@ -753,5 +761,54 @@ describe("convertTrigger on-deploy", () => {
     expect(result.hasResolveOnDeployItems).toBe(true);
     expect(result.triggerResolverDefaultBatchSize).toBe(25);
     expect(typeof result.resolveOnDeployItems).toBe("function");
+  });
+});
+
+describe("convertComponent outputSchema", () => {
+  // `component()` is `convertComponent()`, i.e. the real publish path.
+  const convertedAction = (outputSchema?: unknown) =>
+    (
+      component({
+        key: "acme",
+        public: false,
+        display: { label: "Acme", description: "Acme", iconPath: "icon.png" },
+        actions: {
+          doThing: action({
+            display: { label: "Do Thing", description: "Does the thing" },
+            inputs: {},
+            ...(outputSchema ? { outputSchema } : {}),
+            perform: async () => ({ data: {} }),
+          } as any),
+        },
+      } as any).actions as any
+    ).doThing;
+
+  it("serializes an actionOutput schema to a JSON string", () => {
+    const schema = { type: "object", properties: { id: { type: "string" } } };
+    const { outputSchema } = convertedAction({ type: "actionOutput", schema });
+
+    expect(outputSchema).toEqual({ type: "actionOutput", schema: JSON.stringify(schema) });
+    expect(typeof outputSchema.schema).toBe("string");
+  });
+
+  it("flattens branchingOutput branchSchemas to a list of stringified name/schema pairs", () => {
+    const found = { type: "object", properties: { id: { type: "string" } } };
+    const notFound = { type: "object" };
+    const { outputSchema } = convertedAction({
+      type: "branchingOutput",
+      branchSchemas: { found, notFound },
+    });
+
+    expect(outputSchema).toEqual({
+      type: "branchingOutput",
+      branchSchemas: [
+        { name: "found", schema: JSON.stringify(found) },
+        { name: "notFound", schema: JSON.stringify(notFound) },
+      ],
+    });
+  });
+
+  it("omits outputSchema when the action declares none", () => {
+    expect(convertedAction()).not.toHaveProperty("outputSchema");
   });
 });

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -12,6 +12,7 @@ import {
   type InputFieldDefinition,
   type Inputs,
   type OnPremConnectionInput,
+  type OutputSchema,
   type TriggerDefinition,
   type TriggerOptionChoice,
   type TriggerPayload,
@@ -28,6 +29,7 @@ import type {
   Connection as ServerConnection,
   DataSource as ServerDataSource,
   Input as ServerInput,
+  ServerOutputSchema,
   Trigger as ServerTrigger,
 } from ".";
 import {
@@ -369,9 +371,22 @@ export const convertTemplateInput = (
   };
 };
 
+const convertOutputSchema = (outputSchema: OutputSchema): ServerOutputSchema => {
+  if (outputSchema.type === "actionOutput") {
+    return { type: "actionOutput", schema: JSON.stringify(outputSchema.schema) };
+  }
+  return {
+    type: "branchingOutput",
+    branchSchemas: Object.entries(outputSchema.branchSchemas).map(([name, schema]) => ({
+      name,
+      schema: JSON.stringify(schema),
+    })),
+  };
+};
+
 const convertAction = (
   actionKey: string,
-  { inputs = {}, perform, ...action }: ActionDefinition<Inputs, any, boolean, any>,
+  { inputs = {}, perform, outputSchema, ...action }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
 ): ServerAction => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
@@ -388,6 +403,7 @@ const convertAction = (
       inputCleaners,
       errorHandler: hooks?.error,
     }),
+    ...(outputSchema ? { outputSchema: convertOutputSchema(outputSchema) } : {}),
   };
 };
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -21,7 +21,7 @@ import type {
   TriggerResult as TriggerPerformResult,
   UserAttributes,
 } from "../types";
-import type { JsonSchema } from "../types/jsonforms/JsonSchema";
+import type { OutputSchema } from "../types/OutputSchema";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 interface DisplayDefinition {
@@ -82,8 +82,8 @@ export interface Action {
   dynamicBranchInput?: string;
   perform: ActionPerformFunction;
   examplePayload?: unknown;
-  /** JSON Schema describing the shape of this action's output `data` payload. */
-  outputSchema?: JsonSchema;
+  /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */
+  outputSchema?: OutputSchema;
 }
 
 export type ActionLoggerFunction = (...args: unknown[]) => void;

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -22,6 +22,7 @@ import type {
   UserAttributes,
 } from "../types";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
+import type { JsonSchema } from "../types/jsonforms/JsonSchema";
 
 interface DisplayDefinition {
   label: string;
@@ -81,6 +82,8 @@ export interface Action {
   dynamicBranchInput?: string;
   perform: ActionPerformFunction;
   examplePayload?: unknown;
+  /** JSON Schema describing the shape of this action's output `data` payload. */
+  output?: JsonSchema;
 }
 
 export type ActionLoggerFunction = (...args: unknown[]) => void;

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -21,8 +21,8 @@ import type {
   TriggerResult as TriggerPerformResult,
   UserAttributes,
 } from "../types";
-import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 import type { JsonSchema } from "../types/jsonforms/JsonSchema";
+import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 interface DisplayDefinition {
   label: string;
@@ -83,7 +83,7 @@ export interface Action {
   perform: ActionPerformFunction;
   examplePayload?: unknown;
   /** JSON Schema describing the shape of this action's output `data` payload. */
-  output?: JsonSchema;
+  outputSchema?: JsonSchema;
 }
 
 export type ActionLoggerFunction = (...args: unknown[]) => void;

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -21,7 +21,6 @@ import type {
   TriggerResult as TriggerPerformResult,
   UserAttributes,
 } from "../types";
-import type { OutputSchema } from "../types/OutputSchema";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 interface DisplayDefinition {
@@ -82,9 +81,19 @@ export interface Action {
   dynamicBranchInput?: string;
   perform: ActionPerformFunction;
   examplePayload?: unknown;
-  /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */
-  outputSchema?: OutputSchema;
+  /**
+   * The on-the-wire form of an action's `outputSchema`, as accepted by the
+   * `PublishComponent` mutation. JSON Schemas are serialized to strings and the
+   * branching variant's per-branch map is flattened to a `{ name, schema }`
+   * list (GraphQL input has no map type). Produced by `convertOutputSchema`
+   * from the author-facing `OutputSchema`.
+   */
+  outputSchema?: ServerOutputSchema;
 }
+
+export type ServerOutputSchema =
+  | { type: "actionOutput"; schema: string }
+  | { type: "branchingOutput"; branchSchemas: Array<{ name: string; schema: string }> };
 
 export type ActionLoggerFunction = (...args: unknown[]) => void;
 

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -59,5 +59,5 @@ export interface ActionDefinition<
    * output before a real execution has produced data. Descriptive only — it is
    * not enforced at runtime.
    */
-  output?: JsonSchema;
+  outputSchema?: JsonSchema;
 }

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -3,7 +3,7 @@ import type { ActionPerformReturn } from "./ActionPerformReturn";
 import type { ComponentManifestAction } from "./ComponentManifest";
 import type { ActionDisplayDefinition } from "./DisplayDefinition";
 import type { ConfigVarResultCollection, Inputs } from "./Inputs";
-import type { JsonSchema } from "./jsonforms/JsonSchema";
+import type { OutputSchema } from "./OutputSchema";
 
 /**
  * ActionDefinition is the type of the object that is passed in to `action` function to
@@ -54,10 +54,12 @@ export interface ActionDefinition<
   /** An example of the payload output by this action. */
   examplePayload?: Awaited<ReturnType<this["perform"]>>;
   /**
-   * A JSON Schema describing the shape of this action's output `data` payload.
-   * Used by the Prismatic UI to let integration authors reference this step's
-   * output before a real execution has produced data. Descriptive only — it is
-   * not enforced at runtime.
+   * Declares the shape of this action's output `data` as a JSON Schema, used by
+   * the Prismatic UI to let integration authors reference this step's output
+   * before a real execution has produced data. A discriminated union:
+   * `{ type: "actionOutput", schema }` for a single payload shape, or
+   * `{ type: "branchingOutput", branches }` for a per-branch map of shapes.
+   * Descriptive only — it is not enforced at runtime.
    */
-  outputSchema?: JsonSchema;
+  outputSchema?: OutputSchema;
 }

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -60,6 +60,11 @@ export interface ActionDefinition<
    * `{ type: "actionOutput", schema }` for a single payload shape, or
    * `{ type: "branchingOutput", branches }` for a per-branch map of shapes.
    * Descriptive only — it is not enforced at runtime.
+   *
+   * @remarks
+   * Describes the `data` payload only, not the full return envelope
+   * (`statusCode`, `contentType`, state fields). `branchingOutput` requires
+   * `staticBranchNames`; it is not supported with `dynamicBranchInput`.
    */
   outputSchema?: OutputSchema;
 }

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -3,6 +3,7 @@ import type { ActionPerformReturn } from "./ActionPerformReturn";
 import type { ComponentManifestAction } from "./ComponentManifest";
 import type { ActionDisplayDefinition } from "./DisplayDefinition";
 import type { ConfigVarResultCollection, Inputs } from "./Inputs";
+import type { JsonSchema } from "./jsonforms/JsonSchema";
 
 /**
  * ActionDefinition is the type of the object that is passed in to `action` function to
@@ -52,4 +53,11 @@ export interface ActionDefinition<
   dynamicBranchInput?: string;
   /** An example of the payload output by this action. */
   examplePayload?: Awaited<ReturnType<this["perform"]>>;
+  /**
+   * A JSON Schema describing the shape of this action's output `data` payload.
+   * Used by the Prismatic UI to let integration authors reference this step's
+   * output before a real execution has produced data. Descriptive only — it is
+   * not enforced at runtime.
+   */
+  output?: JsonSchema;
 }

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -58,7 +58,7 @@ export interface ActionDefinition<
    * the Prismatic UI to let integration authors reference this step's output
    * before a real execution has produced data. A discriminated union:
    * `{ type: "actionOutput", schema }` for a single payload shape, or
-   * `{ type: "branchingOutput", branches }` for a per-branch map of shapes.
+   * `{ type: "branchingOutput", branchSchemas }` for a per-branch map of shapes.
    * Descriptive only — it is not enforced at runtime.
    *
    * @remarks

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,7 +1,7 @@
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
-import type { JsonSchema } from "./jsonforms/JsonSchema";
+import type { OutputSchema } from "./OutputSchema";
 
 export interface ComponentManifest {
   key: string;
@@ -25,8 +25,8 @@ export interface ComponentManifestAction {
   perform: (values: any) => Promise<unknown>;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
-  /** JSON Schema describing the shape of this action's output `data` payload. */
-  outputSchema?: JsonSchema;
+  /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */
+  outputSchema?: OutputSchema;
 }
 
 export interface ComponentManifestTrigger {

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,6 +1,7 @@
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
+import type { JsonSchema } from "./jsonforms/JsonSchema";
 
 export interface ComponentManifest {
   key: string;
@@ -24,6 +25,8 @@ export interface ComponentManifestAction {
   perform: (values: any) => Promise<unknown>;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
+  /** JSON Schema describing the shape of this action's output `data` payload. */
+  output?: JsonSchema;
 }
 
 export interface ComponentManifestTrigger {

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -26,7 +26,7 @@ export interface ComponentManifestAction {
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
   /** JSON Schema describing the shape of this action's output `data` payload. */
-  output?: JsonSchema;
+  outputSchema?: JsonSchema;
 }
 
 export interface ComponentManifestTrigger {

--- a/packages/spectral/src/types/OutputSchema.ts
+++ b/packages/spectral/src/types/OutputSchema.ts
@@ -1,0 +1,30 @@
+import type { JsonSchema } from "./jsonforms/JsonSchema";
+
+/**
+ * Describes the shape of a non-branching action's output `data` payload as a
+ * JSON Schema. Used by the Prismatic UI to let integration authors reference a
+ * step's output before a real execution has produced data. Descriptive only —
+ * it is not enforced at runtime.
+ */
+export interface ActionOutputSchema {
+  type: "actionOutput";
+  schema: JsonSchema;
+}
+
+/**
+ * Describes the output `data` payload of a branching action, one JSON Schema
+ * per branch keyed by branch name. A branching action returns `{ branch, data }`,
+ * and the `data` shape may differ per branch, so each branch carries its own
+ * schema. Descriptive only — not enforced at runtime.
+ */
+export interface BranchingOutputSchema {
+  type: "branchingOutput";
+  branches: Record<string, JsonSchema>;
+}
+
+/**
+ * The output-schema contract declared on an action via `outputSchema`. A
+ * discriminated union on `type`: `actionOutput` for a single payload shape,
+ * `branchingOutput` for a per-branch map of payload shapes.
+ */
+export type OutputSchema = ActionOutputSchema | BranchingOutputSchema;

--- a/packages/spectral/src/types/OutputSchema.ts
+++ b/packages/spectral/src/types/OutputSchema.ts
@@ -16,10 +16,18 @@ export interface ActionOutputSchema {
  * per branch keyed by branch name. A branching action returns `{ branch, data }`,
  * and the `data` shape may differ per branch, so each branch carries its own
  * schema. Descriptive only — not enforced at runtime.
+ *
+ * @remarks
+ * Valid only for actions with `staticBranchNames` — a closed, build-time list.
+ * NOT supported with `dynamicBranchInput`, where branch names are computed at
+ * runtime and cannot be enumerated; publishing such a component is rejected
+ * server-side. (Unrelated to `dynamicObject` *inputs*, whose `configurations`
+ * are fully declared at build time — that's an input feature and does not
+ * affect `outputSchema`.)
  */
 export interface BranchingOutputSchema {
   type: "branchingOutput";
-  branches: Record<string, JsonSchema>;
+  branchSchemas: Record<string, JsonSchema>;
 }
 
 /**

--- a/packages/spectral/src/types/index.ts
+++ b/packages/spectral/src/types/index.ts
@@ -28,6 +28,7 @@ export * from "./Inputs";
 export * from "./InstanceAttributes";
 export * from "./IntegrationAttributes";
 export * from "./IntegrationDefinition";
+export * from "./OutputSchema";
 export * from "./PollingTriggerDefinition";
 export * from "./ScopedConfigVars";
 export * from "./ScopedConfigVars";

--- a/packages/spectral/src/types/index.ts
+++ b/packages/spectral/src/types/index.ts
@@ -31,7 +31,6 @@ export * from "./IntegrationDefinition";
 export * from "./OutputSchema";
 export * from "./PollingTriggerDefinition";
 export * from "./ScopedConfigVars";
-export * from "./ScopedConfigVars";
 export * from "./TriggerDefinition";
 export * from "./TriggerEventFunction";
 export * from "./TriggerPayload";


### PR DESCRIPTION
# What
Adds an optional `outputSchema` to action definitions, letting component authors declare the shape of an action's output `data` as a JSON Schema. 

`outputSchema` is a discriminated union:

```ts
type ActionOutputSchema    = { type: "actionOutput";    schema: JsonSchema }
type BranchingOutputSchema = { type: "branchingOutput"; branchSchemas: Record<string, JsonSchema> }
type OutputSchema = ActionOutputSchema | BranchingOutputSchema
```

This is descriptive-only, its emitted to the component manifest and consumed by the Designer's reference picker. It is not read or validated against at runtime.

