### PR TITLE
Allow collection on structuredObject inputs

### DIFF
--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -63,6 +63,48 @@ expectType<unknown>(structuredResult.name.last);
 // @ts-expect-error: structuredObject params only expose declared children.
 structuredResult.name.nonexistent;
 
+const collectionInputs = {
+  lines: structuredObjectInput({
+    label: "Lines",
+    collection: "valuelist",
+    inputs: {
+      amount: input({
+        type: "string",
+        label: "Amount",
+        clean: (value) => util.types.toNumber(value),
+      }),
+      description: input({ type: "string", label: "Description" }),
+    },
+  }),
+  attributes: structuredObjectInput({
+    label: "Attributes",
+    collection: "keyvaluelist",
+    inputs: {
+      amount: input({ type: "string", label: "Amount" }),
+    },
+  }),
+};
+
+const collectionResult: ActionInputParameters<typeof collectionInputs> = {
+  lines: [{ amount: 1, description: "desc" }],
+  attributes: [{ key: "a", value: { amount: "1" } }],
+};
+expectType<number>(collectionResult.lines[0].amount);
+expectType<unknown>(collectionResult.lines[0].description);
+// @ts-expect-error: a valuelist structuredObject param is an array of records, not a single record.
+collectionResult.lines.amount;
+expectType<string>(collectionResult.attributes[0].key);
+expectType<unknown>(collectionResult.attributes[0].value.amount);
+// @ts-expect-error: keyvaluelist structuredObject entry values only expose declared children.
+collectionResult.attributes[0].value.nonexistent;
+
+structuredObjectInput({
+  label: "Bad Collection",
+  // @ts-expect-error: collection must be "valuelist" or "keyvaluelist".
+  collection: "objectlist",
+  inputs: { a: input({ type: "string", label: "A" }) },
+});
+
 const dynamicInputs = {
   data: dynamicObjectInput({
     label: "Record Data",

--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -84,6 +84,41 @@ describe("getInputs — structuredObject", () => {
     expect(result.valueType).toBe("{ color: `red` | `blue` }");
   });
 
+  it("wraps a valuelist structuredObject as an array of the inline object type", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "lines",
+          type: "structuredObject",
+          collection: "valuelist",
+          inputs: [
+            baseInput({ key: "amount", type: "string" }),
+            baseInput({ key: "description", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("Array<{ amount: string; description: string }>");
+  });
+
+  it("wraps a keyvaluelist structuredObject as the record-or-pairs union of the inline object type", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "attributes",
+          type: "structuredObject",
+          collection: "keyvaluelist",
+          inputs: [baseInput({ key: "amount", type: "string" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      "Record<string, { amount: string }> | Array<{key: string, value: { amount: string }}>",
+    );
+  });
+
   it("wraps a valuelist string child as Array<string>", () => {
     const [result] = getInputs({
       inputs: [

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -101,7 +101,7 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {
   if (input.type === "structuredObject") {
-    return structuredObjectTypeString(input.inputs ?? []);
+    return wrapCollection(structuredObjectTypeString(input.inputs ?? []), input.collection);
   }
 
   if (input.type === "dynamicObject") {
@@ -189,7 +189,7 @@ const getLeafBaseType = (child: ServerTypeInput): string => {
 
 const getLeafTypeString = (child: ServerTypeInput): string => {
   if (child.type === "structuredObject") {
-    return structuredObjectTypeString(child.inputs ?? []);
+    return wrapCollection(structuredObjectTypeString(child.inputs ?? []), child.collection);
   }
 
   return wrapCollection(getLeafBaseType(child), child.collection);

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -78,6 +78,22 @@ describe("convertInput", () => {
     expect(converted.inputs).toBeUndefined();
   });
 
+  it("emits `collection` on a structuredObject input alongside nested children", () => {
+    const lines = structuredObjectInput({
+      label: "Lines",
+      collection: "valuelist",
+      inputs: {
+        amount: input({ type: "string", label: "Amount", required: true }),
+      },
+    });
+
+    const converted = convertInput("lines", lines);
+
+    expect(converted.type).toBe("structuredObject");
+    expect(converted.collection).toBe("valuelist");
+    expect(converted.inputs).toHaveLength(1);
+  });
+
   it("converts a dynamicObject input with configurations and nested children", () => {
     const data = dynamicObjectInput({
       label: "Record Data",
@@ -319,6 +335,70 @@ describe("cleanerFor", () => {
 
       expect(cleaner?.(undefined)).toBeUndefined();
       expect(cleaner?.(null)).toBeNull();
+    });
+
+    describe("with collection", () => {
+      const valuelistDefinition = structuredObjectInput({
+        label: "Lines",
+        collection: "valuelist",
+        inputs: {
+          amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+        },
+      });
+
+      it("cleans each element of a valuelist", () => {
+        const cleaner = cleanerFor(valuelistDefinition);
+        expect(cleaner?.([{ amount: "1" }, { amount: "2" }])).toStrictEqual([
+          { amount: 1 },
+          { amount: 2 },
+        ]);
+      });
+
+      it("passes through a non-array valuelist value unchanged", () => {
+        const cleaner = cleanerFor(valuelistDefinition);
+        expect(cleaner?.({ amount: "1" })).toStrictEqual({ amount: "1" });
+        expect(cleaner?.(undefined)).toBeUndefined();
+      });
+
+      it("cleans the record under each keyvaluelist entry's `value`", () => {
+        const cleaner = cleanerFor(
+          structuredObjectInput({
+            label: "Attributes",
+            collection: "keyvaluelist",
+            inputs: {
+              amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+            },
+          }),
+        );
+
+        expect(
+          cleaner?.([
+            { key: "a", value: { amount: "1" } },
+            { key: "b", value: { amount: "2" } },
+          ]),
+        ).toStrictEqual([
+          { key: "a", value: { amount: 1 } },
+          { key: "b", value: { amount: 2 } },
+        ]);
+      });
+
+      it("leaves malformed keyvaluelist entries untouched", () => {
+        const cleaner = cleanerFor(
+          structuredObjectInput({
+            label: "Attributes",
+            collection: "keyvaluelist",
+            inputs: {
+              amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+            },
+          }),
+        );
+
+        expect(cleaner?.(["bare-string", { noValueKey: true }])).toStrictEqual([
+          "bare-string",
+          { noValueKey: true },
+        ]);
+        expect(cleaner?.({ amount: "1" })).toStrictEqual({ amount: "1" });
+      });
     });
   });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -54,12 +54,24 @@ export const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined => 
       }),
       {},
     );
-    return (value: unknown) => {
-      if (!isPlainObject(value)) {
-        return value;
-      }
-      return cleanParams(value, childCleaners);
-    };
+    const cleanRecord = (value: unknown) =>
+      isPlainObject(value) ? cleanParams(value, childCleaners) : value;
+    if (input.collection === "valuelist") {
+      return (value: unknown) => (Array.isArray(value) ? value.map(cleanRecord) : value);
+    }
+    if (input.collection === "keyvaluelist") {
+      // Entries arrive as KeyValuePair envelopes; the object to clean
+      // lives under `value`.
+      return (value: unknown) =>
+        Array.isArray(value)
+          ? value.map((entry) =>
+              isPlainObject(entry) && "value" in entry
+                ? { ...entry, value: cleanRecord(entry.value) }
+                : entry,
+            )
+          : value;
+    }
+    return cleanRecord;
   }
 
   if (input.type === "dynamicObject") {

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -10,14 +10,16 @@ import type {
 } from "./Inputs";
 
 /** Resolves a single InputFieldDefinition's runtime value type.
- * - structuredObject: record of declared children's resolved value types.
+ * - structuredObject: record of declared children's resolved value types;
+ *   with `collection` set, a list (`valuelist`) or `KeyValuePair` list
+ *   (`keyvaluelist`) of that record.
  * - dynamicObject: discriminated union keyed by the selected configuration,
  *   with the configuration's resolved inputs nested under `values` to avoid
  *   collisions with the `configuration` discriminant key.
  * The depth caps (`LeafInputFieldDefinition`, `StructuredOrLeafInputFieldDefinition`)
  * prevent unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
-  ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
+  ? ExtractValue<{ [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }, T["collection"]>
   : T extends DynamicObjectInputField
     ? {
         [C in keyof T["configurations"]]: {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -417,6 +417,10 @@ export type StructuredObjectInputField = Omit<
 > & {
   /** Data type the input will collect. */
   type: "structuredObject";
+  /** Collection type of the input; when set, the input collects a list
+   * (`valuelist`) or keyed list (`keyvaluelist`) of objects instead of a
+   * single object. */
+  collection?: InputFieldCollection;
   /** Nested input fields keyed by their local key. */
   inputs: Record<string, LeafInputFieldDefinition>;
 };


### PR DESCRIPTION
# Problem

`structuredObject` inputs can only collect a single object. Collections of
structured objects (e.g. invoice line items) have no native representation.

# Approach

Allow `collection: "valuelist" | "keyvaluelist"` on `structuredObjectInput`,
mirroring how `collection` works on leaf input types:

- `StructuredObjectInputField` gains an optional `collection` member. The
  `structuredObjectInput` factory accepts it with no signature change.
- `ActionInputParameters` resolves a collection structuredObject through the
  existing `ExtractValue` helper: `valuelist` → an array of the child record,
  `keyvaluelist` → `KeyValuePair<record>[]`. Without `collection`, typing is
  unchanged.
- The auto-generated container cleaner recurses per element. For
  `keyvaluelist`, the record is cleaned under each entry's `value`
  (KeyValuePair envelope); malformed entries pass through untouched,
  matching the existing defensive style.
- CNI manifest generation wraps the structuredObject record with the same
  collection wrappers used for leaves (`Array<{...}>` /
  `Record<string, {...}> | Array<{key, value: {...}}>`), at both the
  top-level and child positions.
- No wire-shape change: `convertInput` already emitted `collection`
  unconditionally; it's now populated for structuredObject inputs.

This is for `structuredObject` only: `dynamicObject` intentionally does not accept `collection` (the platform
rejects collections on it).