### PR TITLE
feat: add structured and dynamic object types

### DIFF
--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -2,6 +2,7 @@ import {
   type ActionInputParameters,
   type ConditionalExpression,
   type Connection,
+  dynamicObjectInput,
   input,
   structuredObjectInput,
   util,
@@ -61,3 +62,96 @@ expectType<unknown>(structuredResult.name.first);
 expectType<unknown>(structuredResult.name.last);
 // @ts-expect-error: structuredObject params only expose declared children.
 structuredResult.name.nonexistent;
+
+const dynamicInputs = {
+  data: dynamicObjectInput({
+    label: "Record Data",
+    required: true,
+    configurations: {
+      contact: {
+        label: "Contact",
+        inputs: {
+          name: structuredObjectInput({
+            label: "Name",
+            inputs: {
+              first: input({ type: "string", label: "First", required: true }),
+              last: input({ type: "string", label: "Last", required: true }),
+            },
+          }),
+          email: input({ type: "string", label: "Email", required: true }),
+        },
+      },
+      account: {
+        label: "Account",
+        inputs: {
+          companyName: input({ type: "string", label: "Company Name", required: true }),
+        },
+      },
+    },
+  }),
+};
+
+const dynamicResult: ActionInputParameters<typeof dynamicInputs> = {
+  data: {
+    configuration: "contact",
+    values: { name: { first: "Ada", last: "Lovelace" }, email: "ada@example.com" },
+  },
+};
+if (dynamicResult.data.configuration === "contact") {
+  expectType<unknown>(dynamicResult.data.values.email);
+  expectType<unknown>(dynamicResult.data.values.name.first);
+  // @ts-expect-error: companyName is on the `account` variant, not `contact`.
+  dynamicResult.data.values.companyName;
+}
+if (dynamicResult.data.configuration === "account") {
+  expectType<unknown>(dynamicResult.data.values.companyName);
+  // @ts-expect-error: email is on the `contact` variant, not `account`.
+  dynamicResult.data.values.email;
+}
+// @ts-expect-error: only declared configuration keys are valid discriminants.
+if (dynamicResult.data.configuration === "nonexistent") {
+  /* unreachable */
+}
+
+dynamicObjectInput({
+  label: "Bad",
+  // @ts-expect-error: factory disallows callers from setting `type`.
+  type: "string",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: { email: input({ type: "string", label: "Email" }) },
+    },
+  },
+});
+
+dynamicObjectInput({
+  label: "Outer",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        // @ts-expect-error: dynamicObject configurations cannot contain a nested dynamicObject.
+        nested: dynamicObjectInput({
+          label: "Inner",
+          configurations: {
+            x: { label: "X", inputs: { y: input({ type: "string", label: "Y" }) } },
+          },
+        }),
+      },
+    },
+  },
+});
+
+structuredObjectInput({
+  label: "Parent",
+  inputs: {
+    // @ts-expect-error: structuredObject children cannot be a dynamicObject.
+    bad: dynamicObjectInput({
+      label: "Inner Dynamic",
+      configurations: {
+        x: { label: "X", inputs: { y: input({ type: "string", label: "Y" }) } },
+      },
+    }),
+  },
+});

--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -3,6 +3,7 @@ import {
   type ConditionalExpression,
   type Connection,
   input,
+  structuredObjectInput,
   util,
 } from "@prismatic-io/spectral";
 import { expectType } from "tsd";
@@ -42,3 +43,21 @@ expectType<{
 }>(result);
 expectType<Connection>(result.connection);
 expectType<ConditionalExpression[]>(result.conditional);
+
+const structuredInputs = {
+  name: structuredObjectInput({
+    label: "Name",
+    inputs: {
+      first: input({ type: "string", label: "First Name", required: true }),
+      last: input({ type: "string", label: "Last Name", required: true }),
+    },
+  }),
+};
+
+const structuredResult: ActionInputParameters<typeof structuredInputs> = {
+  name: { first: "Ada", last: "Lovelace" },
+};
+expectType<unknown>(structuredResult.name.first);
+expectType<unknown>(structuredResult.name.last);
+// @ts-expect-error: structuredObject params only expose declared children.
+structuredResult.name.nonexistent;

--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -155,3 +155,82 @@ structuredObjectInput({
     }),
   },
 });
+
+structuredObjectInput({
+  label: "Parent",
+  inputs: {
+    // @ts-expect-error: structuredObject children cannot be a connection.
+    cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+    // @ts-expect-error: structuredObject children cannot be a connection template.
+    tmpl: input({
+      type: "template",
+      key: "tmpl",
+      label: "Template",
+      templateValue: "",
+    }),
+  },
+});
+
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    salesforce: {
+      label: "Salesforce",
+      inputs: {
+        // @ts-expect-error: dynamicObject configurations cannot contain a connection child.
+        cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+        // @ts-expect-error: dynamicObject configurations cannot contain a connection template child.
+        tmpl: input({
+          type: "template",
+          key: "tmpl",
+          label: "Template",
+          templateValue: "",
+        }),
+      },
+    },
+  },
+});
+
+// Positive-compile probes for the depth-2 position: a structuredObject
+// living inside a dynamicObject configuration, whose leaves must still
+// accept ordinary scalar and conditional inputs. If
+// `LeafInputFieldDefinition` ever over-narrows, these factory calls
+// fail to satisfy the SO factory's generic constraint and the
+// regression surfaces here. Paired with the rejection directives above
+// so each directive is provably load-bearing on its precise position.
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        name: structuredObjectInput({
+          label: "Name",
+          inputs: {
+            first: input({ type: "string", label: "First" }),
+            count: input({ type: "string", label: "Count", collection: "valuelist" }),
+            cond: input({ type: "conditional", label: "Cond", collection: "valuelist" }),
+          },
+        }),
+      },
+    },
+  },
+});
+
+dynamicObjectInput({
+  label: "Target",
+  configurations: {
+    contact: {
+      label: "Contact",
+      inputs: {
+        name: structuredObjectInput({
+          label: "Name",
+          inputs: {
+            // @ts-expect-error: connection rejected at depth 2 (structuredObject inside dynamicObject configuration).
+            cred: input({ type: "connection", key: "cred", label: "Credentials" }),
+          },
+        }),
+      },
+    },
+  },
+});

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { action, component, input, pollingTrigger, structuredObjectInput, trigger } from ".";
+import {
+  action,
+  component,
+  dynamicObjectInput,
+  input,
+  pollingTrigger,
+  structuredObjectInput,
+  trigger,
+} from ".";
 import { convertTrigger } from "./serverTypes/convertComponent";
 import type { PerformFn } from "./serverTypes/perform";
 
@@ -283,5 +291,21 @@ describe("structuredObject inputs in a published component", () => {
         }),
       },
     });
+  });
+});
+
+describe("dynamicObject inputs in a published component", () => {
+  it("dynamicObjectInput factory forces type to 'dynamicObject'", () => {
+    const fromFactory = dynamicObjectInput({
+      label: "Record Data",
+      configurations: {
+        contact: {
+          label: "Contact",
+          inputs: { email: input({ type: "string", label: "Email" }) },
+        },
+      },
+    });
+    expect(fromFactory.type).toBe("dynamicObject");
+    expect(Object.keys(fromFactory.configurations)).toEqual(["contact"]);
   });
 });

--- a/packages/spectral/src/component-testing.test.ts
+++ b/packages/spectral/src/component-testing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { action, input, pollingTrigger, trigger } from ".";
+import { action, component, input, pollingTrigger, structuredObjectInput, trigger } from ".";
 import { convertTrigger } from "./serverTypes/convertComponent";
 import type { PerformFn } from "./serverTypes/perform";
 
@@ -199,5 +199,89 @@ describe("test convert trigger", () => {
         throw e;
       }
     }
+  });
+});
+
+describe("structuredObject inputs in a published component", () => {
+  const createContact = action({
+    display: {
+      label: "Create Contact",
+      description: "Create a new contact",
+    },
+    inputs: {
+      name: structuredObjectInput({
+        label: "Name",
+        inputs: {
+          first: input({ type: "string", label: "First Name", required: true }),
+          last: input({ type: "string", label: "Last Name", required: true }),
+          prefix: input({ type: "string", label: "Prefix" }),
+        },
+      }),
+      email: input({ type: "string", label: "Email", required: true }),
+    },
+    perform: async (_context, _params) => Promise.resolve({ data: null }),
+  });
+
+  it("publishes the action with a structuredObject parent and nested children", () => {
+    const converted = component({
+      key: "crm",
+      public: false,
+      display: { label: "CRM", description: "Test CRM component", iconPath: "icon.png" },
+      actions: { createContact },
+    });
+
+    const action = converted.actions.createContact;
+    expect(action.inputs).toHaveLength(2);
+
+    const nameInput = action.inputs.find((i: { key: string }) => i.key === "name");
+    expect(nameInput).toMatchObject({
+      key: "name",
+      type: "structuredObject",
+      label: "Name",
+    });
+    expect(nameInput?.inputs).toHaveLength(3);
+    expect(nameInput?.inputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "first", type: "string", required: true }),
+        expect.objectContaining({ key: "last", type: "string", required: true }),
+        expect.objectContaining({ key: "prefix", type: "string" }),
+      ]),
+    );
+
+    const emailInput = action.inputs.find((i: { key: string }) => i.key === "email");
+    expect(emailInput).toMatchObject({ key: "email", type: "string", required: true });
+    expect(emailInput?.inputs).toBeUndefined();
+  });
+
+  it("structuredObjectInput factory forces type to 'structuredObject'", () => {
+    const fromFactory = structuredObjectInput({
+      label: "Address",
+      inputs: {
+        line1: input({ type: "string", label: "Line 1" }),
+      },
+    });
+    expect(fromFactory.type).toBe("structuredObject");
+    expect(fromFactory.label).toBe("Address");
+    expect(Object.keys(fromFactory.inputs)).toEqual(["line1"]);
+  });
+
+  it("rejects a stray `type` key and nested structuredObject children at compile time", () => {
+    structuredObjectInput({
+      label: "Bad",
+      // @ts-expect-error -- factory disallows callers from setting `type`.
+      type: "string",
+      inputs: { line1: input({ type: "string", label: "Line 1" }) },
+    });
+
+    structuredObjectInput({
+      label: "Outer",
+      inputs: {
+        // @ts-expect-error -- nesting is capped at one level by LeafInputFieldDefinition.
+        inner: structuredObjectInput({
+          label: "Inner",
+          inputs: { x: input({ type: "string", label: "X" }) },
+        }),
+      },
+    });
   });
 });

--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+import type { ServerTypeInput } from "./getInputs";
+import { getInputs } from "./getInputs";
+
+const baseInput = (
+  overrides: Partial<ServerTypeInput> & { key: string; type: string },
+): ServerTypeInput => ({ label: overrides.key, required: false, ...overrides }) as ServerTypeInput;
+
+describe("getInputs — structuredObject", () => {
+  it("emits an inline object type from declared children", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "person",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "first", type: "string" }),
+            baseInput({ key: "last", type: "string" }),
+            baseInput({ key: "active", type: "boolean" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ first: string; last: string; active: boolean }");
+  });
+
+  it("quotes non-identifier child keys", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "my-field", type: "string" }),
+            baseInput({ key: "normal", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe('{ "my-field": string; normal: string }');
+  });
+
+  it("uses inline import() syntax for import-object leaf types (e.g. connection)", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "config",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "conn", type: "connection" }),
+            baseInput({ key: "name", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ conn: import("@prismatic-io/spectral/dist/types").Connection; name: string }',
+    );
+  });
+
+  it("narrows leaf children that have a model to a literal union", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "config",
+          type: "structuredObject",
+          inputs: [
+            baseInput({
+              key: "color",
+              type: "string",
+              model: [
+                { label: "Red", value: "red" },
+                { label: "Blue", value: "blue" },
+              ],
+            } as unknown as ServerTypeInput),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ color: `red` | `blue` }");
+  });
+
+  it("wraps a valuelist string child as Array<string>", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [
+            baseInput({ key: "tags", type: "string", collection: "valuelist" }),
+            baseInput({ key: "title", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("{ tags: Array<string>; title: string }");
+  });
+
+  it("wraps a keyvaluelist string child as the record-or-pairs union", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [baseInput({ key: "headers", type: "string", collection: "keyvaluelist" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      "{ headers: Record<string, string> | Array<{key: string, value: string}> }",
+    );
+  });
+
+  it("wraps a valuelist import-object child as Array<import(...).Type>", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "rec",
+          type: "structuredObject",
+          inputs: [baseInput({ key: "conns", type: "connection", collection: "valuelist" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ conns: Array<import("@prismatic-io/spectral/dist/types").Connection> }',
+    );
+  });
+
+  it("falls back to StructuredObject import when inputs are empty", () => {
+    const [result] = getInputs({
+      inputs: [baseInput({ key: "empty", type: "structuredObject", inputs: [] })],
+    });
+
+    expect(result.valueType).toBe('import("@prismatic-io/spectral/dist/types").StructuredObject');
+  });
+});
+
+describe("getInputs — dynamicObject", () => {
+  it("emits a discriminated union from configurations", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          inputs: [
+            baseInput({
+              key: "contact",
+              type: "structuredObject",
+              inputs: [
+                baseInput({ key: "firstName", type: "string" }),
+                baseInput({ key: "lastName", type: "string" }),
+              ],
+            }),
+            baseInput({
+              key: "account",
+              type: "structuredObject",
+              inputs: [baseInput({ key: "companyName", type: "string" })],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "contact"; values: { firstName: string; lastName: string } } | { configuration: "account"; values: { companyName: string } }',
+    );
+  });
+
+  it("handles a configuration whose inputs include a structuredObject child", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          inputs: [
+            baseInput({
+              key: "contact",
+              type: "structuredObject",
+              inputs: [
+                baseInput({
+                  key: "name",
+                  type: "structuredObject",
+                  inputs: [
+                    baseInput({ key: "first", type: "string" }),
+                    baseInput({ key: "last", type: "string" }),
+                  ],
+                }),
+                baseInput({ key: "email", type: "string" }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "contact"; values: { name: { first: string; last: string }; email: string } }',
+    );
+  });
+
+  it("uses StructuredObject import for a configuration with no inputs", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "record",
+          type: "dynamicObject",
+          inputs: [
+            baseInput({ key: "empty", type: "structuredObject", inputs: [] }),
+            baseInput({
+              key: "hasFields",
+              type: "structuredObject",
+              inputs: [baseInput({ key: "name", type: "string" })],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      '{ configuration: "empty"; values: import("@prismatic-io/spectral/dist/types").StructuredObject } | { configuration: "hasFields"; values: { name: string } }',
+    );
+  });
+
+  it("falls back to DynamicObject import when configurations are empty", () => {
+    const [result] = getInputs({
+      inputs: [baseInput({ key: "empty", type: "dynamicObject", inputs: [] })],
+    });
+
+    expect(result.valueType).toBe('import("@prismatic-io/spectral/dist/types").DynamicObject');
+  });
+});

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -98,6 +98,9 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   timestamp: "string",
   flow: "string",
   template: "string",
+  // TODO: emit a typed record matching the declared children once the
+  // code-native action-calling type generator handles structuredObject.
+  structuredObject: "unknown",
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -25,15 +25,6 @@ interface GetInputsProps {
   docBlock?: (input: ServerTypeInput) => string;
 }
 
-const getDefaultValue = (value: ServerTypeInput["default"], isCollection: boolean) => {
-  if (value === undefined || value === "") {
-    return isCollection ? [] : value;
-  }
-
-  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
-  return escapeSpecialCharacters(stringValue);
-};
-
 export const getInputs = ({ inputs, docBlock = DOC_BLOCK_DEFAULT }: GetInputsProps): Input[] => {
   return inputs.reduce((acc, input) => {
     if (
@@ -98,16 +89,27 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   timestamp: "string",
   flow: "string",
   template: "string",
-  // TODO: emit a typed record matching the declared children once the
-  // code-native action-calling type generator handles structuredObject.
-  structuredObject: "unknown",
-  // TODO: emit a precise discriminated-union type matching the declared
-  // configurations once the CNI manifest generator handles dynamicObject.
-  dynamicObject: "unknown",
+  structuredObject: {
+    module: "@prismatic-io/spectral/dist/types",
+    type: "StructuredObject",
+  },
+  dynamicObject: {
+    module: "@prismatic-io/spectral/dist/types",
+    type: "DynamicObject",
+  },
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {
+  if (input.type === "structuredObject") {
+    return structuredObjectTypeString(input.inputs ?? []);
+  }
+
+  if (input.type === "dynamicObject") {
+    return dynamicObjectTypeString(input.inputs ?? []);
+  }
+
   const inputType = INPUT_TYPE_MAP[input.type as InputFieldDefinition["type"]];
+
   const valueType = input.model
     ? input.model
         .map((choice) => {
@@ -139,4 +141,90 @@ const getInputValueType = (input: ServerTypeInput): ValueType => {
   }
 
   return valueType;
+};
+
+const getDefaultValue = (value: ServerTypeInput["default"], isCollection: boolean) => {
+  if (value === undefined || value === "") {
+    return isCollection ? [] : value;
+  }
+
+  const stringValue = typeof value === "string" ? value : JSON.stringify(value);
+
+  return escapeSpecialCharacters(stringValue);
+};
+
+const isValidIdentifier = (key: string) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key);
+
+const wrapCollection = (valueType: string, collection: ServerTypeInput["collection"]): string => {
+  if (collection === "valuelist") {
+    return `Array<${valueType}>`;
+  }
+
+  if (collection === "keyvaluelist") {
+    return `Record<string, ${valueType}> | Array<{key: string, value: ${valueType}}>`;
+  }
+  
+  return valueType;
+};
+
+const getLeafBaseType = (child: ServerTypeInput): string => {
+  if (child.model?.length) {
+    return child.model
+      .map(({ value }) => `\`${value.replaceAll("\r", "\\r").replaceAll("\n", "\\n")}\``)
+      .join(" | ");
+  }
+
+  const mapped = INPUT_TYPE_MAP[child.type as InputFieldDefinition["type"]];
+
+  if (!mapped) {
+    return "unknown";
+  }
+
+  if (typeof mapped === "string") {
+    return mapped;
+  }
+
+  return `import("${mapped.module}").${mapped.type}`;
+};
+
+const getLeafTypeString = (child: ServerTypeInput): string => {
+  if (child.type === "structuredObject") {
+    return structuredObjectTypeString(child.inputs ?? []);
+  }
+
+  return wrapCollection(getLeafBaseType(child), child.collection);
+};
+
+const SPECTRAL_TYPES_MODULE = "@prismatic-io/spectral/dist/types";
+
+const structuredObjectTypeString = (inputs: ServerTypeInput[]): string => {
+  if (!inputs.length) {
+    return `import("${SPECTRAL_TYPES_MODULE}").StructuredObject`;
+  }
+
+  const fields = inputs
+    .map((child) => {
+      const key = isValidIdentifier(child.key) ? child.key : JSON.stringify(child.key);
+
+      return `${key}: ${getLeafTypeString(child)}`;
+    })
+    .join("; ");
+
+  return `{ ${fields} }`;
+};
+
+const dynamicObjectTypeString = (configurations: ServerTypeInput[]): string => {
+  if (!configurations.length) {
+    return `import("${SPECTRAL_TYPES_MODULE}").DynamicObject`;
+  }
+
+  return configurations
+    .map((config) => {
+      const valuesType = config.inputs?.length
+        ? structuredObjectTypeString(config.inputs)
+        : `import("${SPECTRAL_TYPES_MODULE}").StructuredObject`;
+
+      return `{ configuration: ${JSON.stringify(config.key)}; values: ${valuesType} }`;
+    })
+    .join(" | ");
 };

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -163,7 +163,7 @@ const wrapCollection = (valueType: string, collection: ServerTypeInput["collecti
   if (collection === "keyvaluelist") {
     return `Record<string, ${valueType}> | Array<{key: string, value: ${valueType}}>`;
   }
-  
+
   return valueType;
 };
 

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -101,6 +101,9 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
   // TODO: emit a typed record matching the declared children once the
   // code-native action-calling type generator handles structuredObject.
   structuredObject: "unknown",
+  // TODO: emit a precise discriminated-union type matching the declared
+  // configurations once the CNI manifest generator handles dynamicObject.
+  dynamicObject: "unknown",
 };
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -711,7 +711,7 @@ export const structuredObjectInput = <
  *   configurations: {
  *     contact: {
  *       label: "Contact",
- *       description: "Create a new contact",
+ *       comments: "Create a new contact",
  *       inputs: {
  *         name: structuredObjectInput({
  *           label: "Name",
@@ -725,7 +725,7 @@ export const structuredObjectInput = <
  *     },
  *     account: {
  *       label: "Account",
- *       description: "Create a new account",
+ *       comments: "Create a new account",
  *       inputs: {
  *         companyName: input({ type: "string", label: "Company Name", required: true }),
  *       },

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -20,6 +20,7 @@ import type {
   DataSourceDefinition,
   DataSourceType,
   DefaultConnectionDefinition,
+  DynamicObjectInputField,
   Flow,
   InputFieldDefinition,
   Inputs,
@@ -693,6 +694,52 @@ export const structuredObjectInput = <
 ): T & { type: "structuredObject" } => ({
   ...definition,
   type: "structuredObject" as const,
+});
+
+/**
+ * Presents a discriminated set of input configurations; the integration builder
+ * picks a configuration and its inputs become available. Configurations may
+ * contain leaf inputs and structuredObject inputs but not nested dynamicObjects
+ * (the type signature enforces this at compile time).
+ *
+ * @example
+ * import { input, structuredObjectInput, dynamicObjectInput } from "@prismatic-io/spectral";
+ *
+ * const recordData = dynamicObjectInput({
+ *   label: "Record Data",
+ *   required: true,
+ *   configurations: {
+ *     contact: {
+ *       label: "Contact",
+ *       description: "Create a new contact",
+ *       inputs: {
+ *         name: structuredObjectInput({
+ *           label: "Name",
+ *           inputs: {
+ *             first: input({ type: "string", label: "First Name", required: true }),
+ *             last: input({ type: "string", label: "Last Name", required: true }),
+ *           },
+ *         }),
+ *         email: input({ type: "string", label: "Email", required: true }),
+ *       },
+ *     },
+ *     account: {
+ *       label: "Account",
+ *       description: "Create a new account",
+ *       inputs: {
+ *         companyName: input({ type: "string", label: "Company Name", required: true }),
+ *       },
+ *     },
+ *   },
+ * });
+ */
+export const dynamicObjectInput = <
+  T extends Omit<DynamicObjectInputField, "type"> & { type?: never },
+>(
+  definition: T,
+): T & { type: "dynamicObject" } => ({
+  ...definition,
+  type: "dynamicObject" as const,
 });
 
 /**

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -28,6 +28,7 @@ import type {
   OnPremConnectionDefinition,
   OrganizationActivatedConnectionConfigVar,
   StandardConfigVar,
+  StructuredObjectInputField,
   TriggerDefinition,
   TriggerPayload,
   TriggerResult,
@@ -668,6 +669,31 @@ export const dataSource = <
  * });
  */
 export const input = <T extends InputFieldDefinition>(definition: T): T => definition;
+
+/**
+ * Groups related primitive inputs under a single named container. Children
+ * may not themselves be structuredObject inputs (the type signature enforces
+ * this at compile time).
+ *
+ * @example
+ * import { input, structuredObjectInput } from "@prismatic-io/spectral";
+ *
+ * const name = structuredObjectInput({
+ *   label: "Name",
+ *   inputs: {
+ *     first: input({ type: "string", label: "First Name", required: true }),
+ *     last: input({ type: "string", label: "Last Name", required: true }),
+ *   },
+ * });
+ */
+export const structuredObjectInput = <
+  T extends Omit<StructuredObjectInputField, "type"> & { type?: never },
+>(
+  definition: T,
+): T & { type: "structuredObject" } => ({
+  ...definition,
+  type: "structuredObject" as const,
+});
 
 /**
  * This function creates a connection that can be used by a code-native integration

--- a/packages/spectral/src/serverTypes/context.ts
+++ b/packages/spectral/src/serverTypes/context.ts
@@ -32,8 +32,6 @@ type ComponentActionInvokeFunction = <
   values: TValues,
 ) => Promise<unknown>;
 
-type ComponentMethods = Record<string, Record<string, ComponentManifestAction["perform"]>>;
-
 export function createCNIContext<
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TComponentActions extends Record<string, ComponentManifest["actions"]> = Record<

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connection, input } from "..";
+import { connection, input, structuredObjectInput } from "..";
 import { convertConnection, convertInput, convertTemplateInput } from "./convertComponent";
 
 describe("convertConnection", () => {
@@ -37,6 +37,40 @@ describe("convertInput", () => {
 
     expect(convertedInput.key).toBe(basicInputWithDataSourceKey);
     expect(convertedInput.dataSource).toBe(dataSourceKey);
+  });
+
+  it("converts a structuredObject input with nested children", () => {
+    const name = structuredObjectInput({
+      label: "Name",
+      inputs: {
+        first: input({ type: "string", label: "First Name", required: true }),
+        last: input({ type: "string", label: "Last Name", required: true }),
+        prefix: input({ type: "string", label: "Prefix" }),
+      },
+    });
+
+    const converted = convertInput("name", name);
+
+    expect(converted.key).toBe("name");
+    expect(converted.type).toBe("structuredObject");
+    expect(converted.inputs).toHaveLength(3);
+    expect(converted.inputs?.[0]).toMatchObject({
+      key: "first",
+      type: "string",
+      label: "First Name",
+      required: true,
+    });
+    expect(converted.inputs?.[2]).toMatchObject({
+      key: "prefix",
+      type: "string",
+      label: "Prefix",
+    });
+  });
+
+  it("does not emit `inputs` on a non-structuredObject input", () => {
+    const basicInput = input({ type: "string", label: "Basic" });
+    const converted = convertInput("basic", basicInput);
+    expect(converted.inputs).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -80,7 +80,7 @@ describe("convertInput", () => {
       configurations: {
         contact: {
           label: "Contact",
-          description: "Create a new contact",
+          comments: "Create a new contact",
           inputs: {
             name: structuredObjectInput({
               label: "Name",
@@ -94,7 +94,7 @@ describe("convertInput", () => {
         },
         account: {
           label: "Account",
-          description: "Create a new account",
+          comments: "Create a new account",
           inputs: {
             companyName: input({ type: "string", label: "Company Name", required: true }),
           },
@@ -107,14 +107,14 @@ describe("convertInput", () => {
     expect(converted.key).toBe("data");
     expect(converted.type).toBe("dynamicObject");
     expect(converted.required).toBe(true);
-    expect(converted.configurations).toHaveLength(2);
+    expect(converted.inputs).toHaveLength(2);
 
-    const contact = converted.configurations?.find((c) => c.key === "contact");
+    const contact = converted.inputs?.find((c) => c.key === "contact");
     expect(contact).toMatchObject({
       key: "contact",
-      type: "configuration",
+      type: "structuredObject",
       label: "Contact",
-      description: "Create a new contact",
+      comments: "Create a new contact",
     });
     expect(contact?.inputs).toHaveLength(2);
     const contactName = contact?.inputs?.find((i) => i.key === "name");
@@ -126,19 +126,19 @@ describe("convertInput", () => {
       required: true,
     });
 
-    const account = converted.configurations?.find((c) => c.key === "account");
+    const account = converted.inputs?.find((c) => c.key === "account");
+    expect(account).toMatchObject({
+      key: "account",
+      type: "structuredObject",
+      label: "Account",
+      comments: "Create a new account",
+    });
     expect(account?.inputs).toHaveLength(1);
     expect(account?.inputs?.[0]).toMatchObject({
       key: "companyName",
       type: "string",
       required: true,
     });
-  });
-
-  it("does not emit `configurations` on a non-dynamicObject input", () => {
-    const basicInput = input({ type: "string", label: "Basic" });
-    const converted = convertInput("basic", basicInput);
-    expect(converted.configurations).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { connection, input, structuredObjectInput } from "..";
+import { connection, dynamicObjectInput, input, structuredObjectInput } from "..";
 import { convertConnection, convertInput, convertTemplateInput } from "./convertComponent";
 
 describe("convertConnection", () => {
@@ -71,6 +71,74 @@ describe("convertInput", () => {
     const basicInput = input({ type: "string", label: "Basic" });
     const converted = convertInput("basic", basicInput);
     expect(converted.inputs).toBeUndefined();
+  });
+
+  it("converts a dynamicObject input with configurations and nested children", () => {
+    const data = dynamicObjectInput({
+      label: "Record Data",
+      required: true,
+      configurations: {
+        contact: {
+          label: "Contact",
+          description: "Create a new contact",
+          inputs: {
+            name: structuredObjectInput({
+              label: "Name",
+              inputs: {
+                first: input({ type: "string", label: "First Name", required: true }),
+                last: input({ type: "string", label: "Last Name", required: true }),
+              },
+            }),
+            email: input({ type: "string", label: "Email", required: true }),
+          },
+        },
+        account: {
+          label: "Account",
+          description: "Create a new account",
+          inputs: {
+            companyName: input({ type: "string", label: "Company Name", required: true }),
+          },
+        },
+      },
+    });
+
+    const converted = convertInput("data", data);
+
+    expect(converted.key).toBe("data");
+    expect(converted.type).toBe("dynamicObject");
+    expect(converted.required).toBe(true);
+    expect(converted.configurations).toHaveLength(2);
+
+    const contact = converted.configurations?.find((c) => c.key === "contact");
+    expect(contact).toMatchObject({
+      key: "contact",
+      type: "configuration",
+      label: "Contact",
+      description: "Create a new contact",
+    });
+    expect(contact?.inputs).toHaveLength(2);
+    const contactName = contact?.inputs?.find((i) => i.key === "name");
+    expect(contactName).toMatchObject({ key: "name", type: "structuredObject" });
+    expect(contactName?.inputs).toHaveLength(2);
+    expect(contactName?.inputs?.[0]).toMatchObject({
+      key: "first",
+      type: "string",
+      required: true,
+    });
+
+    const account = converted.configurations?.find((c) => c.key === "account");
+    expect(account?.inputs).toHaveLength(1);
+    expect(account?.inputs?.[0]).toMatchObject({
+      key: "companyName",
+      type: "string",
+      required: true,
+    });
+  });
+
+  it("does not emit `configurations` on a non-dynamicObject input", () => {
+    const basicInput = input({ type: "string", label: "Basic" });
+    const converted = convertInput("basic", basicInput);
+    expect(converted.configurations).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { connection, dynamicObjectInput, input, structuredObjectInput } from "..";
-import { convertConnection, convertInput, convertTemplateInput } from "./convertComponent";
+import {
+  cleanerFor,
+  convertConnection,
+  convertInput,
+  convertTemplateInput,
+} from "./convertComponent";
 
 describe("convertConnection", () => {
   const label = "My Basic Connection";
@@ -235,5 +240,222 @@ describe("convertTemplateInput", () => {
     expected,
   }) => {
     expect(() => convertTemplateInput(key, templateInput, inputs)).toThrow(expected);
+  });
+});
+
+describe("cleanerFor", () => {
+  it("returns the declared clean function for a leaf input", () => {
+    const cleaner = cleanerFor(input({ type: "string", label: "Age", clean: (v) => Number(v) }));
+    expect(cleaner?.("42")).toBe(42);
+  });
+
+  it("returns undefined for a leaf input with no clean function", () => {
+    expect(cleanerFor(input({ type: "string", label: "Name" }))).toBeUndefined();
+  });
+
+  describe("structuredObject", () => {
+    it("invokes each child's clean function", () => {
+      const firstClean = vi.fn((v: unknown) => `first:${v}`);
+      const lastClean = vi.fn((v: unknown) => `last:${v}`);
+
+      const cleaner = cleanerFor(
+        structuredObjectInput({
+          label: "Name",
+          inputs: {
+            first: input({ type: "string", label: "First", clean: firstClean }),
+            last: input({ type: "string", label: "Last", clean: lastClean }),
+          },
+        }),
+      );
+
+      expect(cleaner).toBeDefined();
+      expect(cleaner?.({ first: "Bob", last: "Smith" })).toStrictEqual({
+        first: "first:Bob",
+        last: "last:Smith",
+      });
+      expect(firstClean).toHaveBeenCalledWith("Bob");
+      expect(lastClean).toHaveBeenCalledWith("Smith");
+    });
+
+    it("leaves children without a clean function untouched", () => {
+      const cleaner = cleanerFor(
+        structuredObjectInput({
+          label: "Mixed",
+          inputs: {
+            cleaned: input({ type: "string", label: "Cleaned", clean: (v) => `!${v}` }),
+            raw: input({ type: "string", label: "Raw" }),
+          },
+        }),
+      );
+
+      expect(cleaner?.({ cleaned: "a", raw: "b" })).toStrictEqual({
+        cleaned: "!a",
+        raw: "b",
+      });
+    });
+
+    it("always exists on conversion even when no child declares clean", () => {
+      const cleaner = cleanerFor(
+        structuredObjectInput({
+          label: "Plain",
+          inputs: {
+            a: input({ type: "string", label: "A" }),
+            b: input({ type: "string", label: "B" }),
+          },
+        }),
+      );
+
+      expect(cleaner).toBeDefined();
+      expect(cleaner?.({ a: "x", b: "y" })).toStrictEqual({ a: "x", b: "y" });
+    });
+
+    it("passes through non-object values unchanged", () => {
+      const cleaner = cleanerFor(
+        structuredObjectInput({
+          label: "Name",
+          inputs: { first: input({ type: "string", label: "First", clean: (v) => v }) },
+        }),
+      );
+
+      expect(cleaner?.(undefined)).toBeUndefined();
+      expect(cleaner?.(null)).toBeNull();
+    });
+  });
+
+  describe("dynamicObject", () => {
+    it("invokes each child's clean function for the selected configuration", () => {
+      const emailClean = vi.fn((v: unknown) => `email:${v}`);
+      const companyClean = vi.fn((v: unknown) => `co:${v}`);
+
+      const cleaner = cleanerFor(
+        dynamicObjectInput({
+          label: "Record",
+          configurations: {
+            contact: {
+              label: "Contact",
+              inputs: {
+                email: input({ type: "string", label: "Email", clean: emailClean }),
+              },
+            },
+            account: {
+              label: "Account",
+              inputs: {
+                companyName: input({ type: "string", label: "Company", clean: companyClean }),
+              },
+            },
+          },
+        }),
+      );
+
+      expect(cleaner).toBeDefined();
+      expect(cleaner?.({ configuration: "contact", values: { email: "a@b.co" } })).toStrictEqual({
+        configuration: "contact",
+        values: { email: "email:a@b.co" },
+      });
+      expect(emailClean).toHaveBeenCalledWith("a@b.co");
+      expect(companyClean).not.toHaveBeenCalled();
+    });
+
+    it("delegates to a nested structuredObject child's children", () => {
+      const firstClean = vi.fn((v: unknown) => `first:${v}`);
+      const lastClean = vi.fn((v: unknown) => `last:${v}`);
+
+      const cleaner = cleanerFor(
+        dynamicObjectInput({
+          label: "Record",
+          configurations: {
+            contact: {
+              label: "Contact",
+              inputs: {
+                name: structuredObjectInput({
+                  label: "Name",
+                  inputs: {
+                    first: input({ type: "string", label: "First", clean: firstClean }),
+                    last: input({ type: "string", label: "Last", clean: lastClean }),
+                  },
+                }),
+                email: input({ type: "string", label: "Email" }),
+              },
+            },
+          },
+        }),
+      );
+
+      const result = cleaner?.({
+        configuration: "contact",
+        values: {
+          name: { first: "Ada", last: "Lovelace" },
+          email: "ada@example.com",
+        },
+      });
+
+      expect(result).toStrictEqual({
+        configuration: "contact",
+        values: {
+          name: { first: "first:Ada", last: "last:Lovelace" },
+          email: "ada@example.com",
+        },
+      });
+      expect(firstClean).toHaveBeenCalledWith("Ada");
+      expect(lastClean).toHaveBeenCalledWith("Lovelace");
+    });
+
+    it("always exists on conversion even when no descendant declares clean", () => {
+      const cleaner = cleanerFor(
+        dynamicObjectInput({
+          label: "Record",
+          configurations: {
+            contact: {
+              label: "Contact",
+              inputs: { email: input({ type: "string", label: "Email" }) },
+            },
+          },
+        }),
+      );
+
+      expect(cleaner).toBeDefined();
+      expect(cleaner?.({ configuration: "contact", values: { email: "a@b.co" } })).toStrictEqual({
+        configuration: "contact",
+        values: { email: "a@b.co" },
+      });
+    });
+
+    it("passes through values for an unknown configuration", () => {
+      const emailClean = vi.fn((v: unknown) => `email:${v}`);
+      const cleaner = cleanerFor(
+        dynamicObjectInput({
+          label: "Record",
+          configurations: {
+            contact: {
+              label: "Contact",
+              inputs: { email: input({ type: "string", label: "Email", clean: emailClean }) },
+            },
+          },
+        }),
+      );
+
+      expect(cleaner?.({ configuration: "mystery", values: { email: "a@b.co" } })).toStrictEqual({
+        configuration: "mystery",
+        values: { email: "a@b.co" },
+      });
+      expect(emailClean).not.toHaveBeenCalled();
+    });
+
+    it("passes through non-object values unchanged", () => {
+      const cleaner = cleanerFor(
+        dynamicObjectInput({
+          label: "Record",
+          configurations: {
+            contact: {
+              label: "Contact",
+              inputs: { email: input({ type: "string", label: "Email", clean: (v) => v }) },
+            },
+          },
+        }),
+      );
+
+      expect(cleaner?.(undefined)).toBeUndefined();
+      expect(cleaner?.(null)).toBeNull();
+    });
   });
 });

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -31,14 +31,72 @@ import type {
 } from ".";
 import {
   type CleanFn,
+  cleanParams,
   createPerform,
   createPollingPerform,
   type InputCleaners,
   type PerformFn,
 } from "./perform";
 
-const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined =>
-  "clean" in input ? (input.clean as CleanFn) : undefined;
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+/** Auto-generated cleaner for structuredObject/dynamicObject containers.
+ * Recursively delegates to each child's clean function. Developers do not
+ * declare a top-level clean on these containers — the conversion always
+ * supplies one so nested clean functions are applied at runtime. */
+export const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined => {
+  if (input.type === "structuredObject") {
+    const childCleaners = Object.entries(input.inputs).reduce<InputCleaners>(
+      (acc, [childKey, childDef]) => ({
+        ...acc,
+        [childKey]: cleanerFor(childDef as InputFieldDefinition),
+      }),
+      {},
+    );
+    return (value: unknown) => {
+      if (!isPlainObject(value)) {
+        return value;
+      }
+      return cleanParams(value, childCleaners);
+    };
+  }
+
+  if (input.type === "dynamicObject") {
+    const configCleaners: Record<string, InputCleaners> = {};
+    for (const [configKey, configDef] of Object.entries(input.configurations)) {
+      configCleaners[configKey] = Object.entries(configDef.inputs).reduce<InputCleaners>(
+        (acc, [childKey, childDef]) => ({
+          ...acc,
+          [childKey]: cleanerFor(childDef as InputFieldDefinition),
+        }),
+        {},
+      );
+    }
+    return (value: unknown) => {
+      if (!isPlainObject(value)) {
+        return value;
+      }
+      const { configuration, values } = value as {
+        configuration?: unknown;
+        values?: unknown;
+      };
+      if (typeof configuration !== "string") {
+        return value;
+      }
+      const cleaners = configCleaners[configuration];
+      if (!cleaners) {
+        return { configuration, values };
+      }
+      return {
+        configuration,
+        values: isPlainObject(values) ? cleanParams(values, cleaners) : values,
+      };
+    };
+  }
+
+  return "clean" in input ? (input.clean as CleanFn) : undefined;
+};
 
 export const convertInput = (
   key: string,

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -29,20 +29,47 @@ import type {
   Input as ServerInput,
   Trigger as ServerTrigger,
 } from ".";
-import { createPerform, createPollingPerform, type InputCleaners, type PerformFn } from "./perform";
+import {
+  type CleanFn,
+  createPerform,
+  createPollingPerform,
+  type InputCleaners,
+  type PerformFn,
+} from "./perform";
+
+const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined =>
+  "clean" in input ? (input.clean as CleanFn) : undefined;
 
 export const convertInput = (
   key: string,
-  {
+  definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
+): ServerInput => {
+  // Cast: union members don't all carry `default`/`collection`/`inputs`;
+  // runtime guards below handle the differences.
+  const {
     default: defaultValue,
     type,
     label,
     collection,
+    inputs: childInputs,
     ...rest
-  }: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
-): ServerInput => {
+  } = definition as {
+    default?: unknown;
+    type: InputFieldDefinition["type"] | "template";
+    label: string | { key: string; value: string };
+    collection?: "valuelist" | "keyvaluelist";
+    inputs?: Record<string, InputFieldDefinition>;
+    [key: string]: unknown;
+  };
   const keyLabel =
     collection === "keyvaluelist" && typeof label === "object" ? label.key : undefined;
+
+  const nestedInputs =
+    type === "structuredObject" && childInputs
+      ? Object.entries(childInputs).map(([childKey, childDef]) =>
+          convertInput(childKey, childDef as InputFieldDefinition),
+        )
+      : undefined;
 
   return {
     ...omit(rest, [
@@ -57,7 +84,8 @@ export const convertInput = (
     collection,
     label: typeof label === "string" ? label : label.value,
     keyLabel,
-    onPremiseControlled: ("onPremControlled" in rest && rest.onPremControlled) || undefined,
+    onPremiseControlled: rest.onPremControlled === true ? true : undefined,
+    inputs: nestedInputs,
   };
 };
 
@@ -131,7 +159,7 @@ const convertAction = (
 ): ServerAction => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
   const inputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 
@@ -167,7 +195,6 @@ export const convertTrigger = <
   const webhookLifecycleHandlers =
     "webhookLifecycleHandlers" in trigger ? trigger.webhookLifecycleHandlers : undefined;
   const inputs: Inputs = trigger.inputs ?? {};
-  const isPollingTrigger = isPollingTriggerDefinition(trigger);
 
   const triggerInputKeys = Object.keys(inputs);
   const convertedTriggerInputs = Object.entries(inputs).map(([key, value]) => {
@@ -175,7 +202,7 @@ export const convertTrigger = <
   });
 
   const triggerInputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 
@@ -184,8 +211,7 @@ export const convertTrigger = <
   let convertedActionInputs: Array<ServerInput> = [];
   let performToUse: PerformFn;
 
-  if (isPollingTrigger) {
-    // Pull inputs up from the action and make them available on the trigger
+  if (isPollingTriggerDefinition(trigger)) {
     const { pollAction: action } = trigger;
     let actionInputCleaners: InputCleaners = {};
     scheduleSupport = "required";
@@ -199,14 +225,17 @@ export const convertTrigger = <
             );
           }
 
-          accum.push(convertInput(key, value));
+          accum.push(convertInput(key, value as InputFieldDefinition));
           return accum;
         },
         [],
       );
 
       actionInputCleaners = Object.entries(action.inputs).reduce<InputCleaners>(
-        (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+        (result, [key, value]) => ({
+          ...result,
+          [key]: cleanerFor(value as InputFieldDefinition),
+        }),
         {},
       );
     }
@@ -246,7 +275,7 @@ export const convertTrigger = <
         : scheduleSupport === "invalid"
           ? "valid"
           : "invalid",
-    ...(isPollingTrigger ? { isPollingTrigger: true } : {}),
+    ...(isPollingTriggerDefinition(trigger) ? { isPollingTrigger: true } : {}),
   };
 
   if (onInstanceDeploy) {
@@ -293,7 +322,7 @@ const convertDataSource = (
 ): ServerDataSource => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
   const inputCleaners = Object.entries(inputs).reduce<InputCleaners>(
-    (result, [key, { clean }]) => ({ ...result, [key]: clean }),
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
     {},
   );
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -44,8 +44,7 @@ export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
-  // Cast: union members don't all carry `default`/`collection`/`inputs`/`configurations`;
-  // runtime guards below handle the differences.
+  // Cast: the field union is wider than any single member; runtime guards below handle it.
   const {
     default: defaultValue,
     type,
@@ -64,7 +63,7 @@ export const convertInput = (
       string,
       {
         label: string | { key: string; value: string };
-        description?: string;
+        comments?: string;
         inputs: Record<string, InputFieldDefinition>;
       }
     >;
@@ -78,20 +77,17 @@ export const convertInput = (
       ? Object.entries(childInputs).map(([childKey, childDef]) =>
           convertInput(childKey, childDef as InputFieldDefinition),
         )
-      : undefined;
-
-  const convertedConfigurations =
-    type === "dynamicObject" && configurations
-      ? Object.entries(configurations).map(([configKey, configDef]) => ({
-          key: configKey,
-          type: "configuration",
-          label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
-          description: configDef.description,
-          inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
-            convertInput(childKey, childDef as InputFieldDefinition),
-          ),
-        }))
-      : undefined;
+      : type === "dynamicObject" && configurations
+        ? Object.entries(configurations).map(([configKey, configDef]) => ({
+            key: configKey,
+            type: "structuredObject",
+            label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
+            comments: configDef.comments,
+            inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
+              convertInput(childKey, childDef as InputFieldDefinition),
+            ),
+          }))
+        : undefined;
 
   return {
     ...omit(rest, [
@@ -108,7 +104,6 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
-    configurations: convertedConfigurations,
   };
 };
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -44,7 +44,7 @@ export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
 ): ServerInput => {
-  // Cast: union members don't all carry `default`/`collection`/`inputs`;
+  // Cast: union members don't all carry `default`/`collection`/`inputs`/`configurations`;
   // runtime guards below handle the differences.
   const {
     default: defaultValue,
@@ -52,6 +52,7 @@ export const convertInput = (
     label,
     collection,
     inputs: childInputs,
+    configurations,
     ...rest
   } = definition as {
     default?: unknown;
@@ -59,6 +60,14 @@ export const convertInput = (
     label: string | { key: string; value: string };
     collection?: "valuelist" | "keyvaluelist";
     inputs?: Record<string, InputFieldDefinition>;
+    configurations?: Record<
+      string,
+      {
+        label: string | { key: string; value: string };
+        description?: string;
+        inputs: Record<string, InputFieldDefinition>;
+      }
+    >;
     [key: string]: unknown;
   };
   const keyLabel =
@@ -69,6 +78,19 @@ export const convertInput = (
       ? Object.entries(childInputs).map(([childKey, childDef]) =>
           convertInput(childKey, childDef as InputFieldDefinition),
         )
+      : undefined;
+
+  const convertedConfigurations =
+    type === "dynamicObject" && configurations
+      ? Object.entries(configurations).map(([configKey, configDef]) => ({
+          key: configKey,
+          type: "configuration",
+          label: typeof configDef.label === "string" ? configDef.label : configDef.label.value,
+          description: configDef.description,
+          inputs: Object.entries(configDef.inputs).map(([childKey, childDef]) =>
+            convertInput(childKey, childDef as InputFieldDefinition),
+          ),
+        }))
       : undefined;
 
   return {
@@ -86,6 +108,7 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
+    configurations: convertedConfigurations,
   };
 };
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,6 +364,8 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
+  /** Nested child inputs; populated only when `type === "structuredObject"`. */
+  inputs?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,8 +364,13 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  /** Nested child inputs; populated only when `type === "structuredObject"`. */
+  description?: string;
+  /** Nested child inputs; populated when `type === "structuredObject"` or for
+   * a `configuration` entry inside a `dynamicObject`'s `configurations`. */
   inputs?: Input[];
+  /** Configurations of a `dynamicObject` input. Each entry has
+   * `type: "configuration"` and carries its own `inputs`. */
+  configurations?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -364,13 +364,9 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
-  description?: string;
-  /** Nested child inputs; populated when `type === "structuredObject"` or for
-   * a `configuration` entry inside a `dynamicObject`'s `configurations`. */
+  /** Nested children. For `structuredObject`, the declared inputs; for
+   * `dynamicObject`, one `structuredObject` per configuration. */
   inputs?: Input[];
-  /** Configurations of a `dynamicObject` input. Each entry has
-   * `type: "configuration"` and carries its own `inputs`. */
-  configurations?: Input[];
 }
 
 export * from "./asyncContext";

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -5,7 +5,22 @@ import type {
   InputFieldCollection,
   Inputs,
   KeyValuePair,
+  StructuredObjectInputField,
 } from "./Inputs";
+
+/** Resolves a single InputFieldDefinition's runtime value type. structuredObject
+ * resolves to `unknown` until the per-field record-type recursion lands. */
+type InputValue<T> = T extends StructuredObjectInputField
+  ? unknown
+  : T extends { clean: InputCleanFunction<any> }
+    ? ReturnType<T["clean"]>
+    : T extends { type: "connection"; collection?: InputFieldCollection }
+      ? ExtractValue<Connection, T["collection"]>
+      : T extends { type: "conditional"; collection?: InputFieldCollection }
+        ? ExtractValue<ConditionalExpression, T["collection"]>
+        : T extends { default?: unknown; collection?: InputFieldCollection }
+          ? ExtractValue<T["default"], T["collection"]>
+          : unknown;
 
 /**
  * Collection of input parameters.
@@ -13,13 +28,7 @@ import type {
  * references to previous steps' outputs.
  */
 export type ActionInputParameters<TInputs extends Inputs> = {
-  [Property in keyof TInputs]: TInputs[Property]["clean"] extends InputCleanFunction<any>
-    ? ReturnType<TInputs[Property]["clean"]>
-    : TInputs[Property]["type"] extends "connection"
-      ? ExtractValue<Connection, TInputs[Property]["collection"]>
-      : TInputs[Property]["type"] extends "conditional"
-        ? ExtractValue<ConditionalExpression, TInputs[Property]["collection"]>
-        : ExtractValue<TInputs[Property]["default"], TInputs[Property]["collection"]>;
+  [Property in keyof TInputs]: InputValue<TInputs[Property]>;
 };
 
 export type ExtractValue<

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -8,10 +8,11 @@ import type {
   StructuredObjectInputField,
 } from "./Inputs";
 
-/** Resolves a single InputFieldDefinition's runtime value type. structuredObject
- * resolves to `unknown` until the per-field record-type recursion lands. */
+/** Resolves a single InputFieldDefinition's runtime value type. A structuredObject
+ * resolves to a record of its declared children's resolved value types; the
+ * depth-1 nesting cap (`LeafInputFieldDefinition`) prevents unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
-  ? unknown
+  ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
   : T extends { clean: InputCleanFunction<any> }
     ? ReturnType<T["clean"]>
     : T extends { type: "connection"; collection?: InputFieldCollection }

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -1,6 +1,7 @@
 import type { ConditionalExpression } from "./conditional-logic";
 import type {
   Connection,
+  DynamicObjectInputField,
   InputCleanFunction,
   InputFieldCollection,
   Inputs,
@@ -8,20 +9,35 @@ import type {
   StructuredObjectInputField,
 } from "./Inputs";
 
-/** Resolves a single InputFieldDefinition's runtime value type. A structuredObject
- * resolves to a record of its declared children's resolved value types; the
- * depth-1 nesting cap (`LeafInputFieldDefinition`) prevents unbounded recursion. */
+/** Resolves a single InputFieldDefinition's runtime value type.
+ * - structuredObject: record of declared children's resolved value types.
+ * - dynamicObject: discriminated union keyed by the selected configuration,
+ *   with the configuration's resolved inputs nested under `values` to avoid
+ *   collisions with the `configuration` discriminant key.
+ * The depth caps (`LeafInputFieldDefinition`, `StructuredOrLeafInputFieldDefinition`)
+ * prevent unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
   ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
-  : T extends { clean: InputCleanFunction<any> }
-    ? ReturnType<T["clean"]>
-    : T extends { type: "connection"; collection?: InputFieldCollection }
-      ? ExtractValue<Connection, T["collection"]>
-      : T extends { type: "conditional"; collection?: InputFieldCollection }
-        ? ExtractValue<ConditionalExpression, T["collection"]>
-        : T extends { default?: unknown; collection?: InputFieldCollection }
-          ? ExtractValue<T["default"], T["collection"]>
-          : unknown;
+  : T extends DynamicObjectInputField
+    ? {
+        [C in keyof T["configurations"]]: {
+          configuration: C;
+          values: {
+            [K in keyof T["configurations"][C]["inputs"]]: InputValue<
+              T["configurations"][C]["inputs"][K]
+            >;
+          };
+        };
+      }[keyof T["configurations"]]
+    : T extends { clean: InputCleanFunction<any> }
+      ? ReturnType<T["clean"]>
+      : T extends { type: "connection"; collection?: InputFieldCollection }
+        ? ExtractValue<Connection, T["collection"]>
+        : T extends { type: "conditional"; collection?: InputFieldCollection }
+          ? ExtractValue<ConditionalExpression, T["collection"]>
+          : T extends { default?: unknown; collection?: InputFieldCollection }
+            ? ExtractValue<T["default"], T["collection"]>
+            : unknown;
 
 /**
  * Collection of input parameters.

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -415,7 +415,7 @@ export interface DynamicObjectConfiguration {
   /** Name of this configuration to present in the UI. */
   label: { key: string; value: string } | string;
   /** Additional text to give guidance to the user when this configuration is selected. */
-  description?: string;
+  comments?: string;
   /** Inputs that become available when this configuration is selected. May
    * include leaf inputs and structuredObject inputs; nested dynamicObjects
    * are rejected at the type level. */

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -93,6 +93,7 @@ export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = 
   flow: "",
   template: "",
   structuredObject: undefined,
+  dynamicObject: undefined,
 };
 
 export type Inputs = Record<string, InputFieldDefinition>;
@@ -141,7 +142,8 @@ export type InputFieldDefinition =
   | DateInputField
   | DateTimeInputField
   | FlowInputField
-  | StructuredObjectInputField;
+  | StructuredObjectInputField
+  | DynamicObjectInputField;
 
 export type InputCleanFunction<TValue, TResult = TValue> = (value: TValue) => TResult;
 
@@ -382,9 +384,20 @@ export type DateTimeInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/** `InputFieldDefinition` minus `StructuredObjectInputField`; used to cap
- * structuredObject nesting at one level. */
-export type LeafInputFieldDefinition = Exclude<InputFieldDefinition, StructuredObjectInputField>;
+/** `InputFieldDefinition` minus container input types; used to cap
+ * structuredObject nesting at one level and to enforce leaf-only positions. */
+export type LeafInputFieldDefinition = Exclude<
+  InputFieldDefinition,
+  StructuredObjectInputField | DynamicObjectInputField
+>;
+
+/** `InputFieldDefinition` minus `DynamicObjectInputField`; used inside a
+ * dynamicObject's `configurations.<key>.inputs` to allow leaves *and*
+ * structuredObject children while still rejecting nested dynamicObjects. */
+export type StructuredOrLeafInputFieldDefinition = Exclude<
+  InputFieldDefinition,
+  DynamicObjectInputField
+>;
 
 /** Groups related primitive inputs under a single named container.
  * Nesting is capped at one level. */
@@ -393,6 +406,32 @@ export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
   type: "structuredObject";
   /** Nested input fields keyed by their local key. */
   inputs: Record<string, LeafInputFieldDefinition>;
+};
+
+/** A single configuration within a dynamicObject. Each configuration declares
+ * a labeled set of inputs that become available when this configuration is
+ * selected at runtime. */
+export interface DynamicObjectConfiguration {
+  /** Name of this configuration to present in the UI. */
+  label: { key: string; value: string } | string;
+  /** Additional text to give guidance to the user when this configuration is selected. */
+  description?: string;
+  /** Inputs that become available when this configuration is selected. May
+   * include leaf inputs and structuredObject inputs; nested dynamicObjects
+   * are rejected at the type level. */
+  inputs: Record<string, StructuredOrLeafInputFieldDefinition>;
+}
+
+/** Presents a discriminated set of input groups; the user picks a configuration
+ * at integration-build time and that configuration's inputs become available.
+ * Nesting is capped: configurations may contain structuredObject children
+ * (depth-1) but never another dynamicObject. */
+export type DynamicObjectInputField = Omit<BaseInputField, "dataSource"> & {
+  /** Data type the input will collect. */
+  type: "dynamicObject";
+  /** Available configurations keyed by their local key (used as the
+   * runtime discriminant). */
+  configurations: Record<string, DynamicObjectConfiguration>;
 };
 
 /** Defines a single Choice option for a InputField. */

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -388,23 +388,29 @@ export type DateTimeInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/** `InputFieldDefinition` minus container input types; used to cap
- * structuredObject nesting at one level and to enforce leaf-only positions. */
+/** `InputFieldDefinition` minus container input types and connection
+ * pickers. Connections resolve to config-var references outside the
+ * parent's value tree, so they're only valid at the top level — never as
+ * a child of a structuredObject or a dynamicObject configuration. */
 export type LeafInputFieldDefinition = Exclude<
   InputFieldDefinition,
-  StructuredObjectInputField | DynamicObjectInputField
+  | StructuredObjectInputField
+  | DynamicObjectInputField
+  | ConnectionInputField
+  | ConnectionTemplateInputField
 >;
 
-/** `InputFieldDefinition` minus `DynamicObjectInputField`; used inside a
- * dynamicObject's `configurations.<key>.inputs` to allow leaves *and*
- * structuredObject children while still rejecting nested dynamicObjects. */
-export type StructuredOrLeafInputFieldDefinition = Exclude<
-  InputFieldDefinition,
-  DynamicObjectInputField
->;
+/** `LeafInputFieldDefinition` plus `StructuredObjectInputField`; used
+ * inside a dynamicObject's `configurations.<key>.inputs` to allow leaves
+ * and structuredObject children while still rejecting nested
+ * dynamicObjects and connection pickers. */
+export type StructuredOrLeafInputFieldDefinition =
+  | LeafInputFieldDefinition
+  | StructuredObjectInputField;
 
 /** Groups related primitive inputs under a single named container.
- * Nesting is capped at one level. */
+ * Nesting is capped at one level. Connection pickers are rejected as
+ * children — they may only appear at the top level. */
 export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
   /** Data type the input will collect. */
   type: "structuredObject";
@@ -420,9 +426,7 @@ export interface DynamicObjectConfiguration {
   label: { key: string; value: string } | string;
   /** Additional text to give guidance to the user when this configuration is selected. */
   comments?: string;
-  /** Inputs that become available when this configuration is selected. May
-   * include leaf inputs and structuredObject inputs; nested dynamicObjects
-   * are rejected at the type level. */
+  /** Inputs that become available when this configuration is selected. */
   inputs: Record<string, StructuredOrLeafInputFieldDefinition>;
 }
 

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -72,6 +72,10 @@ export type DynamicObjectSelection = string;
 
 export type DynamicFieldSelection = string;
 
+export type StructuredObject = Record<string, unknown>;
+
+export type DynamicObject = Record<string, unknown>;
+
 /** InputField type enumeration. */
 export type InputFieldType = InputFieldDefinition["type"];
 export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -92,6 +92,7 @@ export const InputFieldDefaultMap: Record<InputFieldType, string | undefined> = 
   timestamp: "",
   flow: "",
   template: "",
+  structuredObject: undefined,
 };
 
 export type Inputs = Record<string, InputFieldDefinition>;
@@ -139,7 +140,8 @@ export type InputFieldDefinition =
   | DynamicFieldSelectionInputField
   | DateInputField
   | DateTimeInputField
-  | FlowInputField;
+  | FlowInputField
+  | StructuredObjectInputField;
 
 export type InputCleanFunction<TValue, TResult = TValue> = (value: TValue) => TResult;
 
@@ -379,6 +381,19 @@ export type DateTimeInputField = BaseInputField & {
   /** Clean function. */
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
+
+/** `InputFieldDefinition` minus `StructuredObjectInputField`; used to cap
+ * structuredObject nesting at one level. */
+export type LeafInputFieldDefinition = Exclude<InputFieldDefinition, StructuredObjectInputField>;
+
+/** Groups related primitive inputs under a single named container.
+ * Nesting is capped at one level. */
+export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
+  /** Data type the input will collect. */
+  type: "structuredObject";
+  /** Nested input fields keyed by their local key. */
+  inputs: Record<string, LeafInputFieldDefinition>;
+};
 
 /** Defines a single Choice option for a InputField. */
 export interface InputFieldChoice {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -411,7 +411,10 @@ export type StructuredOrLeafInputFieldDefinition =
 /** Groups related primitive inputs under a single named container.
  * Nesting is capped at one level. Connection pickers are rejected as
  * children — they may only appear at the top level. */
-export type StructuredObjectInputField = Omit<BaseInputField, "dataSource"> & {
+export type StructuredObjectInputField = Omit<
+  BaseInputField,
+  "dataSource" | "example" | "placeholder" | "required"
+> & {
   /** Data type the input will collect. */
   type: "structuredObject";
   /** Nested input fields keyed by their local key. */
@@ -434,7 +437,10 @@ export interface DynamicObjectConfiguration {
  * at integration-build time and that configuration's inputs become available.
  * Nesting is capped: configurations may contain structuredObject children
  * (depth-1) but never another dynamicObject. */
-export type DynamicObjectInputField = Omit<BaseInputField, "dataSource"> & {
+export type DynamicObjectInputField = Omit<
+  BaseInputField,
+  "dataSource" | "example" | "placeholder"
+> & {
   /** Data type the input will collect. */
   type: "dynamicObject";
   /** Available configurations keyed by their local key (used as the


### PR DESCRIPTION
# What

This MR represents a series of stories that build up structured and dynamic object inputs within spectral. This has previously been published to `preview`  with the latest npm package `spectral-v10.18.7-preview.5`. After merging this, structured and dynamic object inputs will be ready for general use.

# Why

Structured objects allow for grouping related inputs together such as contact information which helps organize inputs. Dynamic objects allow for setting up pre-configured configurations that are groups of inputs for different purposes. You might have one configuration for `createContact` with one set of inputs and a second configuration for `createTransaction` with a different set of inputs that the same action is capable of doing. During the integration design, select the preferred configuration and the associated inputs for that will go along with it.