### PR TITLE
Bring trigger-resolver pagination rename + shim removal to preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
     },
     "packages/spectral": {
       "name": "@prismatic-io/spectral",
-      "version": "10.18.9-preview.1",
+      "version": "10.19.0",
       "bin": {
         "component-manifest": "bin/component-manifest.js",
         "cni-component-manifest": "bin/cni-component-manifest.js",

--- a/packages/spectral-test/src/ActionInputParameters.test-d.ts
+++ b/packages/spectral-test/src/ActionInputParameters.test-d.ts
@@ -63,6 +63,48 @@ expectType<unknown>(structuredResult.name.last);
 // @ts-expect-error: structuredObject params only expose declared children.
 structuredResult.name.nonexistent;
 
+const collectionInputs = {
+  lines: structuredObjectInput({
+    label: "Lines",
+    collection: "valuelist",
+    inputs: {
+      amount: input({
+        type: "string",
+        label: "Amount",
+        clean: (value) => util.types.toNumber(value),
+      }),
+      description: input({ type: "string", label: "Description" }),
+    },
+  }),
+  attributes: structuredObjectInput({
+    label: "Attributes",
+    collection: "keyvaluelist",
+    inputs: {
+      amount: input({ type: "string", label: "Amount" }),
+    },
+  }),
+};
+
+const collectionResult: ActionInputParameters<typeof collectionInputs> = {
+  lines: [{ amount: 1, description: "desc" }],
+  attributes: [{ key: "a", value: { amount: "1" } }],
+};
+expectType<number>(collectionResult.lines[0].amount);
+expectType<unknown>(collectionResult.lines[0].description);
+// @ts-expect-error: a valuelist structuredObject param is an array of records, not a single record.
+collectionResult.lines.amount;
+expectType<string>(collectionResult.attributes[0].key);
+expectType<unknown>(collectionResult.attributes[0].value.amount);
+// @ts-expect-error: keyvaluelist structuredObject entry values only expose declared children.
+collectionResult.attributes[0].value.nonexistent;
+
+structuredObjectInput({
+  label: "Bad Collection",
+  // @ts-expect-error: collection must be "valuelist" or "keyvaluelist".
+  collection: "objectlist",
+  inputs: { a: input({ type: "string", label: "A" }) },
+});
+
 const dynamicInputs = {
   data: dynamicObjectInput({
     label: "Record Data",

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.18.8",
+  "version": "10.19.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": [
     "prismatic"

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/spectral",
-  "version": "10.18.9-preview.1",
+  "version": "10.19.0",
   "description": "Utility library for building Prismatic connectors and code-native integrations",
   "keywords": [
     "prismatic"

--- a/packages/spectral/src/generators/componentManifest/getInputs.test.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.test.ts
@@ -84,6 +84,41 @@ describe("getInputs — structuredObject", () => {
     expect(result.valueType).toBe("{ color: `red` | `blue` }");
   });
 
+  it("wraps a valuelist structuredObject as an array of the inline object type", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "lines",
+          type: "structuredObject",
+          collection: "valuelist",
+          inputs: [
+            baseInput({ key: "amount", type: "string" }),
+            baseInput({ key: "description", type: "string" }),
+          ],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe("Array<{ amount: string; description: string }>");
+  });
+
+  it("wraps a keyvaluelist structuredObject as the record-or-pairs union of the inline object type", () => {
+    const [result] = getInputs({
+      inputs: [
+        baseInput({
+          key: "attributes",
+          type: "structuredObject",
+          collection: "keyvaluelist",
+          inputs: [baseInput({ key: "amount", type: "string" })],
+        }),
+      ],
+    });
+
+    expect(result.valueType).toBe(
+      "Record<string, { amount: string }> | Array<{key: string, value: { amount: string }}>",
+    );
+  });
+
   it("wraps a valuelist string child as Array<string>", () => {
     const [result] = getInputs({
       inputs: [

--- a/packages/spectral/src/generators/componentManifest/getInputs.ts
+++ b/packages/spectral/src/generators/componentManifest/getInputs.ts
@@ -101,7 +101,7 @@ export const INPUT_TYPE_MAP: Record<InputFieldDefinition["type"], InputType> = {
 
 const getInputValueType = (input: ServerTypeInput): ValueType => {
   if (input.type === "structuredObject") {
-    return structuredObjectTypeString(input.inputs ?? []);
+    return wrapCollection(structuredObjectTypeString(input.inputs ?? []), input.collection);
   }
 
   if (input.type === "dynamicObject") {
@@ -189,7 +189,7 @@ const getLeafBaseType = (child: ServerTypeInput): string => {
 
 const getLeafTypeString = (child: ServerTypeInput): string => {
   if (child.type === "structuredObject") {
-    return structuredObjectTypeString(child.inputs ?? []);
+    return wrapCollection(structuredObjectTypeString(child.inputs ?? []), child.collection);
   }
 
   return wrapCollection(getLeafBaseType(child), child.collection);

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -155,7 +155,7 @@ export const flow = <
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
   T extends Flow<
     TInputs,
     TActionInputs,
@@ -164,7 +164,7 @@ export const flow = <
     TResult,
     TTriggerPayload,
     TItem,
-    TDiscoveryState
+    TPaginationState
   > = Flow<
     TInputs,
     TActionInputs,
@@ -173,15 +173,15 @@ export const flow = <
     TResult,
     TTriggerPayload,
     TItem,
-    TDiscoveryState
+    TPaginationState
   >,
 >(
-  // The intersection adds an explicit inference site for `TItem`/`TDiscoveryState` that the
+  // The intersection adds an explicit inference site for `TItem`/`TPaginationState` that the
   // `T extends Flow<...>` capture alone does not provide, while `T` still preserves the precise
   // literal type for the return value. They are inferred from a batched `trigger`'s
   // `items`/pagination-state types (see `batchFlowTrigger`).
   definition: T & {
-    trigger?: BatchTrigger<TItem, TDiscoveryState>;
+    trigger?: BatchTrigger<TItem, TPaginationState>;
   },
 ): T => definition;
 
@@ -189,17 +189,17 @@ export const flow = <
  * Builds a flow's batched `trigger` — the ergonomic way to define a batching flow. Instead of
  * writing `onTrigger`/`onDeployTrigger` (returning a full payload) plus `triggerResolver`/
  * `onDeployResolver` (to extract and paginate), each trigger fire returns `{ items,
- * discoveryState? }`: the records to dispatch and, when paginating, the cursor for the next
+ * paginationState? }`: the records to dispatch and, when paginating, the cursor for the next
  * page. spectral wraps the items into the wire payload and synthesizes the `resolveItems` and
- * `getNextDiscoveryState` that read them back — there is no separate pagination callback.
+ * `getNextPaginationState` that read them back — there is no separate pagination callback.
  *
  * Supply the item and pagination-state types explicitly —
  * `batchFlowTrigger<Order, { cursor: number }>({ ... })`. They flow through the whole flow:
- * the trigger fires return `Order[]`, `payload.discoveryState` reads back as `{ cursor: number }`,
+ * the trigger fires return `Order[]`, `payload.paginationState` reads back as `{ cursor: number }`,
  * and the flow's `onExecution` sees `params.onTrigger.results.body.data` typed as `Order | Order[]`.
  *
  * @typeParam TItem - the item type each batched execution receives.
- * @typeParam TPaginationState - the pagination state round-tripped via `payload.discoveryState`.
+ * @typeParam TPaginationState - the pagination state round-tripped via `payload.paginationState`.
  * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
  * @example
  * import { flow, batchFlowTrigger } from "@prismatic-io/spectral";
@@ -210,10 +210,10 @@ export const flow = <
  *   batchConfig: { batchSize: 50 },
  *   trigger: batchFlowTrigger<Order, { cursor: number }>({
  *     onTrigger: async (context, payload) => {
- *       const page = await fetchOrders(payload.discoveryState?.cursor);
+ *       const page = await fetchOrders(payload.paginationState?.cursor);
  *       return {
  *         items: page.orders,
- *         discoveryState: page.nextCursor ? { cursor: page.nextCursor } : null,
+ *         paginationState: page.nextCursor ? { cursor: page.nextCursor } : null,
  *       };
  *     },
  *   }),

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -188,9 +188,10 @@ export const flow = <
 /**
  * Builds a flow's batched `trigger` — the ergonomic way to define a batching flow. Instead of
  * writing `onTrigger`/`onDeployTrigger` (returning a full payload) plus `triggerResolver`/
- * `onDeployResolver` (to extract and paginate), the trigger fires return just their `items` and
- * the pagination callbacks live alongside them. spectral wraps the items into the wire payload
- * and synthesizes the `resolveItems` that reads them back.
+ * `onDeployResolver` (to extract and paginate), each trigger fire returns `{ items,
+ * discoveryState? }`: the records to dispatch and, when paginating, the cursor for the next
+ * page. spectral wraps the items into the wire payload and synthesizes the `resolveItems` and
+ * `getNextDiscoveryState` that read them back — there is no separate pagination callback.
  *
  * Supply the item and pagination-state types explicitly —
  * `batchFlowTrigger<Order, { cursor: number }>({ ... })`. They flow through the whole flow:
@@ -210,11 +211,10 @@ export const flow = <
  *   trigger: batchFlowTrigger<Order, { cursor: number }>({
  *     onTrigger: async (context, payload) => {
  *       const page = await fetchOrders(payload.discoveryState?.cursor);
- *       return { items: page.orders };
- *     },
- *     getNextOnTriggerPaginationState: (context, result) => {
- *       const next = result.payload.discoveryState?.cursor;
- *       return next === undefined ? null : { cursor: next };
+ *       return {
+ *         items: page.orders,
+ *         discoveryState: page.nextCursor ? { cursor: page.nextCursor } : null,
+ *       };
  *     },
  *   }),
  *   onExecution: async (context, params) => {

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -78,6 +78,22 @@ describe("convertInput", () => {
     expect(converted.inputs).toBeUndefined();
   });
 
+  it("emits `collection` on a structuredObject input alongside nested children", () => {
+    const lines = structuredObjectInput({
+      label: "Lines",
+      collection: "valuelist",
+      inputs: {
+        amount: input({ type: "string", label: "Amount", required: true }),
+      },
+    });
+
+    const converted = convertInput("lines", lines);
+
+    expect(converted.type).toBe("structuredObject");
+    expect(converted.collection).toBe("valuelist");
+    expect(converted.inputs).toHaveLength(1);
+  });
+
   it("converts a dynamicObject input with configurations and nested children", () => {
     const data = dynamicObjectInput({
       label: "Record Data",
@@ -319,6 +335,70 @@ describe("cleanerFor", () => {
 
       expect(cleaner?.(undefined)).toBeUndefined();
       expect(cleaner?.(null)).toBeNull();
+    });
+
+    describe("with collection", () => {
+      const valuelistDefinition = structuredObjectInput({
+        label: "Lines",
+        collection: "valuelist",
+        inputs: {
+          amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+        },
+      });
+
+      it("cleans each element of a valuelist", () => {
+        const cleaner = cleanerFor(valuelistDefinition);
+        expect(cleaner?.([{ amount: "1" }, { amount: "2" }])).toStrictEqual([
+          { amount: 1 },
+          { amount: 2 },
+        ]);
+      });
+
+      it("passes through a non-array valuelist value unchanged", () => {
+        const cleaner = cleanerFor(valuelistDefinition);
+        expect(cleaner?.({ amount: "1" })).toStrictEqual({ amount: "1" });
+        expect(cleaner?.(undefined)).toBeUndefined();
+      });
+
+      it("cleans the record under each keyvaluelist entry's `value`", () => {
+        const cleaner = cleanerFor(
+          structuredObjectInput({
+            label: "Attributes",
+            collection: "keyvaluelist",
+            inputs: {
+              amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+            },
+          }),
+        );
+
+        expect(
+          cleaner?.([
+            { key: "a", value: { amount: "1" } },
+            { key: "b", value: { amount: "2" } },
+          ]),
+        ).toStrictEqual([
+          { key: "a", value: { amount: 1 } },
+          { key: "b", value: { amount: 2 } },
+        ]);
+      });
+
+      it("leaves malformed keyvaluelist entries untouched", () => {
+        const cleaner = cleanerFor(
+          structuredObjectInput({
+            label: "Attributes",
+            collection: "keyvaluelist",
+            inputs: {
+              amount: input({ type: "string", label: "Amount", clean: (v) => Number(v) }),
+            },
+          }),
+        );
+
+        expect(cleaner?.(["bare-string", { noValueKey: true }])).toStrictEqual([
+          "bare-string",
+          { noValueKey: true },
+        ]);
+        expect(cleaner?.({ amount: "1" })).toStrictEqual({ amount: "1" });
+      });
     });
   });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -32,6 +32,7 @@ import type {
 } from ".";
 import {
   type CleanFn,
+  aliasPaginationState,
   cleanParams,
   createPerform,
   createPollingPerform,
@@ -196,16 +197,24 @@ const buildTriggerResolverFields = <
   if (!resolver) {
     return {};
   }
+  const { resolveItems, getNextPaginationState } = resolver;
   return {
-    ...(resolver.resolveItems
+    ...(resolveItems
       ? {
-          resolveTriggerItems: resolver.resolveItems,
+          resolveTriggerItems: (...[context, result]: Parameters<typeof resolveItems>) =>
+            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
           hasResolveTriggerItems: true,
         }
       : {}),
-    ...(resolver.getNextDiscoveryState
+    ...(getNextPaginationState
       ? {
-          getNextDiscoveryState: resolver.getNextDiscoveryState,
+          // Wire name stays `getNextDiscoveryState` (the backend contract); the author's
+          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
+          getNextDiscoveryState: (...[context, result]: Parameters<typeof getNextPaginationState>) =>
+            getNextPaginationState(context, {
+              ...result,
+              payload: aliasPaginationState(result.payload),
+            }),
           hasGetNextDiscoveryState: true,
         }
       : {}),
@@ -221,16 +230,26 @@ const buildOnDeployResolverFields = <
   if (!resolver) {
     return {};
   }
+  const { resolveItems, getNextPaginationState } = resolver;
   return {
-    ...(resolver.resolveItems
+    ...(resolveItems
       ? {
-          resolveOnDeployItems: resolver.resolveItems,
+          resolveOnDeployItems: (...[context, result]: Parameters<typeof resolveItems>) =>
+            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
           hasResolveOnDeployItems: true,
         }
       : {}),
-    ...(resolver.getNextDiscoveryState
+    ...(getNextPaginationState
       ? {
-          getOnDeployNextDiscoveryState: resolver.getNextDiscoveryState,
+          // Wire name stays `getOnDeployNextDiscoveryState` (the backend contract); the author's
+          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
+          getOnDeployNextDiscoveryState: (
+            ...[context, result]: Parameters<typeof getNextPaginationState>
+          ) =>
+            getNextPaginationState(context, {
+              ...result,
+              payload: aliasPaginationState(result.payload),
+            }),
           hasGetOnDeployNextDiscoveryState: true,
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -54,12 +54,24 @@ export const cleanerFor = (input: InputFieldDefinition): CleanFn | undefined => 
       }),
       {},
     );
-    return (value: unknown) => {
-      if (!isPlainObject(value)) {
-        return value;
-      }
-      return cleanParams(value, childCleaners);
-    };
+    const cleanRecord = (value: unknown) =>
+      isPlainObject(value) ? cleanParams(value, childCleaners) : value;
+    if (input.collection === "valuelist") {
+      return (value: unknown) => (Array.isArray(value) ? value.map(cleanRecord) : value);
+    }
+    if (input.collection === "keyvaluelist") {
+      // Entries arrive as KeyValuePair envelopes; the object to clean
+      // lives under `value`.
+      return (value: unknown) =>
+        Array.isArray(value)
+          ? value.map((entry) =>
+              isPlainObject(entry) && "value" in entry
+                ? { ...entry, value: cleanRecord(entry.value) }
+                : entry,
+            )
+          : value;
+    }
+    return cleanRecord;
   }
 
   if (input.type === "dynamicObject") {

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -32,7 +32,6 @@ import type {
 } from ".";
 import {
   type CleanFn,
-  aliasPaginationState,
   cleanParams,
   createPerform,
   createPollingPerform,
@@ -201,20 +200,13 @@ const buildTriggerResolverFields = <
   return {
     ...(resolveItems
       ? {
-          resolveTriggerItems: (...[context, result]: Parameters<typeof resolveItems>) =>
-            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
+          resolveTriggerItems: resolveItems,
           hasResolveTriggerItems: true,
         }
       : {}),
     ...(getNextPaginationState
       ? {
-          // Wire name stays `getNextDiscoveryState` (the backend contract); the author's
-          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
-          getNextDiscoveryState: (...[context, result]: Parameters<typeof getNextPaginationState>) =>
-            getNextPaginationState(context, {
-              ...result,
-              payload: aliasPaginationState(result.payload),
-            }),
+          getNextPaginationState,
           hasGetNextDiscoveryState: true,
         }
       : {}),
@@ -234,22 +226,13 @@ const buildOnDeployResolverFields = <
   return {
     ...(resolveItems
       ? {
-          resolveOnDeployItems: (...[context, result]: Parameters<typeof resolveItems>) =>
-            resolveItems(context, { ...result, payload: aliasPaginationState(result.payload) }),
+          resolveOnDeployItems: resolveItems,
           hasResolveOnDeployItems: true,
         }
       : {}),
     ...(getNextPaginationState
       ? {
-          // Wire name stays `getOnDeployNextDiscoveryState` (the backend contract); the author's
-          // `getNextPaginationState` reads the cursor as `paginationState` via the alias.
-          getOnDeployNextDiscoveryState: (
-            ...[context, result]: Parameters<typeof getNextPaginationState>
-          ) =>
-            getNextPaginationState(context, {
-              ...result,
-              payload: aliasPaginationState(result.payload),
-            }),
+          getOnDeployNextPaginationState: getNextPaginationState,
           hasGetOnDeployNextDiscoveryState: true,
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -147,7 +147,7 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("synthesizes the default resolveItems and getNextDiscoveryState on the trigger", () => {
+  it("synthesizes the default resolveItems and getNextPaginationState on the trigger", () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
@@ -174,23 +174,22 @@ describe("convertFlow with polling triggers", () => {
       result: { payload: { body: { data: unknown } } },
     ) => unknown[];
     expect(resolveTriggerItems({}, { payload: { body: { data: [7, 8, 9] } } })).toEqual([7, 8, 9]);
-    const getNextDiscoveryState = trigger.getNextDiscoveryState as (
+    const getNextPaginationState = trigger.getNextPaginationState as (
       ctx: unknown,
-      result: { payload: { discoveryState?: unknown } },
+      result: { payload: { paginationState?: unknown } },
     ) => unknown;
-    expect(getNextDiscoveryState({}, { payload: { discoveryState: { cursor: 2 } } })).toEqual({
+    expect(getNextPaginationState({}, { payload: { paginationState: { cursor: 2 } } })).toEqual({
       cursor: 2,
     });
-    expect(getNextDiscoveryState({}, { payload: {} })).toBeNull();
+    expect(getNextPaginationState({}, { payload: {} })).toBeNull();
   });
 
-  it("wraps the fire so items land at body.data and the returned cursor at discoveryState", async () => {
+  it("wraps the fire so items land at body.data and the returned cursor at paginationState", async () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async (_ctx, payload) => {
-          // Author reads the cursor as `paginationState` (aliased from the wire `discoveryState`).
           const cursor = payload.paginationState?.cursor ?? 0;
           return cursor >= 2
             ? { items: [cursor] }
@@ -211,17 +210,15 @@ describe("convertFlow with polling triggers", () => {
       ctx: unknown,
       payload: unknown,
       params: unknown,
-    ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
+    ) => Promise<{ payload: { body: { data: unknown }; paginationState: unknown } }>;
 
-    // The platform stamps the cursor onto the wire `discoveryState`; the author's returned
-    // `paginationState` is stamped back onto the wire `discoveryState` for the loop to read.
-    const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
+    const page1 = await perform({}, { paginationState: { cursor: 1 } }, {});
     expect(page1.payload.body.data).toEqual([1]);
-    expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
+    expect(page1.payload.paginationState).toEqual({ cursor: 2 });
 
-    const page2 = await perform({}, { discoveryState: { cursor: 2 } }, {});
+    const page2 = await perform({}, { paginationState: { cursor: 2 } }, {});
     expect(page2.payload.body.data).toEqual([2]);
-    expect(page2.payload.discoveryState).toBeNull();
+    expect(page2.payload.paginationState).toBeNull();
   });
 
   it("maps the on-deploy fire and pagination onto the synthesized trigger", () => {

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -147,13 +147,12 @@ describe("convertFlow with polling triggers", () => {
     );
   });
 
-  it("synthesizes the default resolveItems (reads payload.body.data) on the trigger", () => {
+  it("synthesizes the default resolveItems and getNextDiscoveryState on the trigger", () => {
     const batchedFlow = flow({
       ...baseFlowInput,
       batchConfig: { batchSize: 10 },
-      trigger: batchFlowTrigger<number>({
+      trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1, 2, 3] }),
-        getNextOnTriggerPaginationState: () => null,
       }),
     });
 
@@ -175,6 +174,51 @@ describe("convertFlow with polling triggers", () => {
       result: { payload: { body: { data: unknown } } },
     ) => unknown[];
     expect(resolveTriggerItems({}, { payload: { body: { data: [7, 8, 9] } } })).toEqual([7, 8, 9]);
+    const getNextDiscoveryState = trigger.getNextDiscoveryState as (
+      ctx: unknown,
+      result: { payload: { discoveryState?: unknown } },
+    ) => unknown;
+    expect(getNextDiscoveryState({}, { payload: { discoveryState: { cursor: 2 } } })).toEqual({
+      cursor: 2,
+    });
+    expect(getNextDiscoveryState({}, { payload: {} })).toBeNull();
+  });
+
+  it("wraps the fire so items land at body.data and the returned cursor at discoveryState", async () => {
+    const batchedFlow = flow({
+      ...baseFlowInput,
+      batchConfig: { batchSize: 10 },
+      trigger: batchFlowTrigger<number, { cursor: number }>({
+        onTrigger: async (_ctx, payload) => {
+          const cursor = payload.discoveryState?.cursor ?? 0;
+          return cursor >= 2
+            ? { items: [cursor] }
+            : { items: [cursor], discoveryState: { cursor: cursor + 1 } };
+        },
+      }),
+    });
+
+    const result = integration({
+      name: "Test",
+      flows: [batchedFlow],
+      configPages: {},
+      componentRegistry: {},
+    });
+
+    const trigger = Object.values(result.triggers)[0] as Record<string, unknown>;
+    const perform = trigger.perform as (
+      ctx: unknown,
+      payload: unknown,
+      params: unknown,
+    ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
+
+    const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
+    expect(page1.payload.body.data).toEqual([1]);
+    expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
+
+    const page2 = await perform({}, { discoveryState: { cursor: 2 } }, {});
+    expect(page2.payload.body.data).toEqual([2]);
+    expect(page2.payload.discoveryState).toBeNull();
   });
 
   it("maps the on-deploy fire and pagination onto the synthesized trigger", () => {
@@ -183,10 +227,9 @@ describe("convertFlow with polling triggers", () => {
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1] }),
-        onDeploy: async () => ({ items: [2] }),
-        getNextOnDeployPaginationState: (_ctx, result) => {
-          const cursor = result.payload.discoveryState?.cursor ?? 0;
-          return cursor >= 2 ? null : { cursor: cursor + 1 };
+        onDeploy: async (_ctx, payload) => {
+          const cursor = payload.discoveryState?.cursor ?? 0;
+          return cursor >= 2 ? { items: [2] } : { items: [2], discoveryState: { cursor: cursor + 1 } };
         },
       }),
     });

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -190,10 +190,11 @@ describe("convertFlow with polling triggers", () => {
       batchConfig: { batchSize: 10 },
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async (_ctx, payload) => {
-          const cursor = payload.discoveryState?.cursor ?? 0;
+          // Author reads the cursor as `paginationState` (aliased from the wire `discoveryState`).
+          const cursor = payload.paginationState?.cursor ?? 0;
           return cursor >= 2
             ? { items: [cursor] }
-            : { items: [cursor], discoveryState: { cursor: cursor + 1 } };
+            : { items: [cursor], paginationState: { cursor: cursor + 1 } };
         },
       }),
     });
@@ -212,6 +213,8 @@ describe("convertFlow with polling triggers", () => {
       params: unknown,
     ) => Promise<{ payload: { body: { data: unknown }; discoveryState: unknown } }>;
 
+    // The platform stamps the cursor onto the wire `discoveryState`; the author's returned
+    // `paginationState` is stamped back onto the wire `discoveryState` for the loop to read.
     const page1 = await perform({}, { discoveryState: { cursor: 1 } }, {});
     expect(page1.payload.body.data).toEqual([1]);
     expect(page1.payload.discoveryState).toEqual({ cursor: 2 });
@@ -228,8 +231,10 @@ describe("convertFlow with polling triggers", () => {
       trigger: batchFlowTrigger<number, { cursor: number }>({
         onTrigger: async () => ({ items: [1] }),
         onDeploy: async (_ctx, payload) => {
-          const cursor = payload.discoveryState?.cursor ?? 0;
-          return cursor >= 2 ? { items: [2] } : { items: [2], discoveryState: { cursor: cursor + 1 } };
+          const cursor = payload.paginationState?.cursor ?? 0;
+          return cursor >= 2
+            ? { items: [2] }
+            : { items: [2], paginationState: { cursor: cursor + 1 } };
         },
       }),
     });

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -78,7 +78,12 @@ import {
   type Input as ServerInput,
   type RequiredConfigVariable as ServerRequiredConfigVariable,
 } from "./integration";
-import { createCNIComponentRefPerform, createCNIPerform, createCNIPollingPerform } from "./perform";
+import {
+  aliasPaginationState,
+  createCNIComponentRefPerform,
+  createCNIPerform,
+  createCNIPollingPerform,
+} from "./perform";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 export const CONCURRENCY_LIMIT_MAX = 15;
@@ -108,9 +113,11 @@ const defaultResolveItems = (
 
 /**
  * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
- * `discoveryState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
- * `payload.discoveryState`. Reading it back (defaulting to `null`) is the whole pagination
- * loop: a non-null value re-invokes the fire, `null` ends it. Authors never write this.
+ * `paginationState`; the wrapper {@link normalizeBatchedFlow} builds stamps it onto the wire
+ * field `payload.discoveryState` (the name the backend's discovery loop reads). Reading it back
+ * (defaulting to `null`) is the whole loop: a non-null value re-invokes the fire, `null` ends it.
+ * Authors never write this. The wire name stays `discoveryState` — only the author surface uses
+ * `paginationState`.
  */
 const defaultGetNextDiscoveryState = (
   _context: ActionContext,
@@ -120,11 +127,12 @@ const defaultGetNextDiscoveryState = (
 /**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
- * conversion pipeline already understands. The trigger fires return `{ items, discoveryState? }`;
+ * conversion pipeline already understands. The trigger fires return `{ items, paginationState? }`;
  * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
  * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
- * items back) and `getNextDiscoveryState` (reads the cursor back). Flows without a `trigger`
- * pass through unchanged.
+ * items back) and `getNextDiscoveryState` (reads the cursor back). The author surface speaks
+ * `paginationState`; this wrapper is the boundary where it is translated to/from the wire
+ * `discoveryState`. Flows without a `trigger` pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -146,20 +154,24 @@ const normalizeBatchedFlow = <
 
   const { onTrigger, onDeploy } = trigger;
 
-  // Wrap a batched fire (returns `{ items, discoveryState?, response? }`) into a
+  // Wrap a batched fire (returns `{ items, paginationState?, response? }`) into a
   // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
-  // next-page cursor at `discoveryState` (defaulting `null` to terminate the loop). The
-  // incoming payload's `discoveryState` was already consumed by the fire, so overwriting it
-  // with the returned cursor is safe — `getNextDiscoveryState` reads it straight back.
+  // next-page cursor at the wire field `discoveryState` (defaulting `null` to terminate the
+  // loop). This is the author/wire boundary: the incoming wire `discoveryState` is aliased to
+  // `paginationState` for the fire to read, and the cursor it returns is stamped back onto the
+  // wire `discoveryState` for `getNextDiscoveryState` to read straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, discoveryState, response } = await fire(context as never, payload as never);
+      const { items, paginationState, response } = await fire(
+        context as never,
+        aliasPaginationState(payload) as never,
+      );
       return {
         payload: {
           ...payload,
           body: { data: items, contentType: "application/json" },
-          discoveryState: discoveryState ?? null,
+          discoveryState: paginationState ?? null,
         },
         ...(response ? { response } : {}),
       };

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -107,12 +107,24 @@ const defaultResolveItems = (
 ) => result.payload.body.data as unknown[];
 
 /**
+ * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
+ * `discoveryState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
+ * `payload.discoveryState`. Reading it back (defaulting to `null`) is the whole pagination
+ * loop: a non-null value re-invokes the fire, `null` ends it. Authors never write this.
+ */
+const defaultGetNextDiscoveryState = (
+  _context: ActionContext,
+  result: { payload: { discoveryState?: Record<string, unknown> | null } },
+) => result.payload.discoveryState ?? null;
+
+/**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
- * conversion pipeline already understands. The trigger fires return just `{ items }`; here we
- * wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: { data:
- * items } } }`, synthesize the default `resolveItems`, and map the pagination callbacks onto
- * the resolver `getNextDiscoveryState`. Flows without a `trigger` pass through unchanged.
+ * conversion pipeline already understands. The trigger fires return `{ items, discoveryState? }`;
+ * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
+ * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
+ * items back) and `getNextDiscoveryState` (reads the cursor back). Flows without a `trigger`
+ * pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -132,17 +144,23 @@ const normalizeBatchedFlow = <
     return flow;
   }
 
-  const { onTrigger, onDeploy, getNextOnTriggerPaginationState, getNextOnDeployPaginationState } =
-    trigger;
+  const { onTrigger, onDeploy } = trigger;
 
-  // Wrap a batched fire (returns `{ items, response? }`) into a TriggerPerformFunction that
-  // emits the wire payload shape (`body.data = items`), preserving the incoming payload fields.
+  // Wrap a batched fire (returns `{ items, discoveryState?, response? }`) into a
+  // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
+  // next-page cursor at `discoveryState` (defaulting `null` to terminate the loop). The
+  // incoming payload's `discoveryState` was already consumed by the fire, so overwriting it
+  // with the returned cursor is safe — `getNextDiscoveryState` reads it straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, response } = await fire(context as never, payload as never);
+      const { items, discoveryState, response } = await fire(context as never, payload as never);
       return {
-        payload: { ...payload, body: { data: items, contentType: "application/json" } },
+        payload: {
+          ...payload,
+          body: { data: items, contentType: "application/json" },
+          discoveryState: discoveryState ?? null,
+        },
         ...(response ? { response } : {}),
       };
     };
@@ -155,17 +173,13 @@ const normalizeBatchedFlow = <
     ...(onDeploy ? { onDeployTrigger: wrapFire(onDeploy) } : {}),
     triggerResolver: {
       resolveItems: defaultResolveItems,
-      ...(getNextOnTriggerPaginationState
-        ? { getNextDiscoveryState: getNextOnTriggerPaginationState }
-        : {}),
+      getNextDiscoveryState: defaultGetNextDiscoveryState,
     },
     ...(onDeploy
       ? {
           onDeployResolver: {
             resolveItems: defaultResolveItems,
-            ...(getNextOnDeployPaginationState
-              ? { getNextDiscoveryState: getNextOnDeployPaginationState }
-              : {}),
+            getNextDiscoveryState: defaultGetNextDiscoveryState,
           },
         }
       : {}),

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -78,12 +78,7 @@ import {
   type Input as ServerInput,
   type RequiredConfigVariable as ServerRequiredConfigVariable,
 } from "./integration";
-import {
-  aliasPaginationState,
-  createCNIComponentRefPerform,
-  createCNIPerform,
-  createCNIPollingPerform,
-} from "./perform";
+import { createCNIComponentRefPerform, createCNIPerform, createCNIPollingPerform } from "./perform";
 import type { CNIPollingPerformFunction, ComponentRefTriggerPerformFunction } from "./triggerTypes";
 
 export const CONCURRENCY_LIMIT_MAX = 15;
@@ -91,11 +86,11 @@ export const CONCURRENCY_LIMIT_MIN = 2;
 
 /**
  * The wire-shape resolver synthesized by {@link normalizeBatchedFlow} and read by the trigger
- * reducer. Mirrors the server `Trigger`'s `resolveTriggerItems`/`getNextDiscoveryState` slots.
+ * reducer. Mirrors the server `Trigger`'s `resolveTriggerItems`/`getNextPaginationState` slots.
  */
 interface WireResolver {
   resolveItems?: (context: ActionContext, result: { payload: TriggerPayload }) => unknown[];
-  getNextDiscoveryState?: (
+  getNextPaginationState?: (
     context: ActionContext,
     result: { payload: TriggerPayload },
   ) => Record<string, unknown> | null;
@@ -112,27 +107,24 @@ const defaultResolveItems = (
 ) => result.payload.body.data as unknown[];
 
 /**
- * Default `getNextDiscoveryState`: a batched fire returns the next page's cursor as
- * `paginationState`; the wrapper {@link normalizeBatchedFlow} builds stamps it onto the wire
- * field `payload.discoveryState` (the name the backend's discovery loop reads). Reading it back
- * (defaulting to `null`) is the whole loop: a non-null value re-invokes the fire, `null` ends it.
- * Authors never write this. The wire name stays `discoveryState` — only the author surface uses
- * `paginationState`.
+ * Default `getNextPaginationState`: a batched fire returns the next page's cursor as
+ * `paginationState`, which the wrapper {@link normalizeBatchedFlow} builds stamps onto
+ * `payload.paginationState`. Reading it back (defaulting to `null`) is the whole loop: a
+ * non-null value re-invokes the fire, `null` ends it. Authors never write this.
  */
-const defaultGetNextDiscoveryState = (
+const defaultGetNextPaginationState = (
   _context: ActionContext,
-  result: { payload: { discoveryState?: Record<string, unknown> | null } },
-) => result.payload.discoveryState ?? null;
+  result: { payload: { paginationState?: Record<string, unknown> | null } },
+) => result.payload.paginationState ?? null;
 
 /**
  * Expands a flow's batched `trigger` (built with `batchFlowTrigger`) into the flat
  * `onTrigger`/`onDeployTrigger`/`triggerResolver`/`onDeployResolver` shape the rest of the
  * conversion pipeline already understands. The trigger fires return `{ items, paginationState? }`;
  * here we wrap each into a `TriggerPerformFunction` that emits `{ payload: { …payload, body: {
- * data: items }, discoveryState } }`, then synthesize the default `resolveItems` (reads the
- * items back) and `getNextDiscoveryState` (reads the cursor back). The author surface speaks
- * `paginationState`; this wrapper is the boundary where it is translated to/from the wire
- * `discoveryState`. Flows without a `trigger` pass through unchanged.
+ * data: items }, paginationState } }`, then synthesize the default `resolveItems` (reads the
+ * items back) and `getNextPaginationState` (reads the cursor back). Flows without a `trigger`
+ * pass through unchanged.
  *
  * Returns the same `Flow` type it received; the synthesized `triggerResolver`/`onDeployResolver`
  * are wire-only fields (not on the author-facing `Flow`), read downstream via `"x" in flow` checks.
@@ -156,22 +148,18 @@ const normalizeBatchedFlow = <
 
   // Wrap a batched fire (returns `{ items, paginationState?, response? }`) into a
   // TriggerPerformFunction that emits the wire payload shape: items at `body.data` and the
-  // next-page cursor at the wire field `discoveryState` (defaulting `null` to terminate the
-  // loop). This is the author/wire boundary: the incoming wire `discoveryState` is aliased to
-  // `paginationState` for the fire to read, and the cursor it returns is stamped back onto the
-  // wire `discoveryState` for `getNextDiscoveryState` to read straight back.
+  // next-page cursor at `paginationState` (defaulting `null` to terminate the loop). The
+  // incoming payload's `paginationState` was already consumed by the fire, so overwriting it
+  // with the returned cursor is safe — `getNextPaginationState` reads it straight back.
   const wrapFire =
     (fire: NonNullable<BatchTrigger<unknown>["onTrigger"]>) =>
     async (context: ActionContext, payload: TriggerPayload) => {
-      const { items, paginationState, response } = await fire(
-        context as never,
-        aliasPaginationState(payload) as never,
-      );
+      const { items, paginationState, response } = await fire(context as never, payload as never);
       return {
         payload: {
           ...payload,
           body: { data: items, contentType: "application/json" },
-          discoveryState: paginationState ?? null,
+          paginationState: paginationState ?? null,
         },
         ...(response ? { response } : {}),
       };
@@ -185,13 +173,13 @@ const normalizeBatchedFlow = <
     ...(onDeploy ? { onDeployTrigger: wrapFire(onDeploy) } : {}),
     triggerResolver: {
       resolveItems: defaultResolveItems,
-      getNextDiscoveryState: defaultGetNextDiscoveryState,
+      getNextPaginationState: defaultGetNextPaginationState,
     },
     ...(onDeploy
       ? {
           onDeployResolver: {
             resolveItems: defaultResolveItems,
-            getNextDiscoveryState: defaultGetNextDiscoveryState,
+            getNextPaginationState: defaultGetNextPaginationState,
           },
         }
       : {}),
@@ -898,7 +886,7 @@ export const convertFlow = <
   const onDeployResolver = "onDeployResolver" in flow ? flow.onDeployResolver : undefined;
   const batchConfig = "batchConfig" in flow ? flow.batchConfig : undefined;
 
-  // Resolver behaviors (resolveItems/getNextDiscoveryState) are serialized onto the
+  // Resolver behaviors (resolveItems/getNextPaginationState) are serialized onto the
   // synthesized trigger below. On the flow wire we emit only `triggerResolver`, the single
   // config the platform reads (`trigger_resolver_batch_size` / `trigger_resolver_enabled`)
   // and shares between the normal and on-deploy fires. `batchConfig`/`onDeployResolver` are
@@ -1811,9 +1799,9 @@ const codeNativeIntegrationComponent = <
                     hasResolveTriggerItems: true,
                   }
                 : {}),
-              ...(triggerResolver.getNextDiscoveryState
+              ...(triggerResolver.getNextPaginationState
                 ? {
-                    getNextDiscoveryState: triggerResolver.getNextDiscoveryState,
+                    getNextPaginationState: triggerResolver.getNextPaginationState,
                     hasGetNextDiscoveryState: true,
                   }
                 : {}),
@@ -1838,9 +1826,9 @@ const codeNativeIntegrationComponent = <
                     hasResolveOnDeployItems: true,
                   }
                 : {}),
-              ...(onDeployResolver.getNextDiscoveryState
+              ...(onDeployResolver.getNextPaginationState
                 ? {
-                    getOnDeployNextDiscoveryState: onDeployResolver.getNextDiscoveryState,
+                    getOnDeployNextPaginationState: onDeployResolver.getNextPaginationState,
                     hasGetOnDeployNextDiscoveryState: true,
                   }
                 : {}),

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -201,7 +201,7 @@ export type TriggerEventFunction = (
 
 /**
  * Wire format the platform expects for a trigger. Note: function references
- * (perform, resolveTriggerItems, getNextDiscoveryState, ...) don't survive JSON
+ * (perform, resolveTriggerItems, getNextPaginationState, ...) don't survive JSON
  * serialization, so each callback has a paired `hasXxx: boolean` flag the
  * server reads to detect presence. Keep the flag and its callback in sync.
  *
@@ -267,7 +267,7 @@ export interface Trigger<
     result: TriggerBaseResult<TPayload>,
   ) => unknown[];
   hasResolveTriggerItems?: boolean;
-  getNextDiscoveryState?: (
+  getNextPaginationState?: (
     context: ActionContext<TConfigVars>,
     result: TriggerBaseResult<TPayload>,
   ) => Record<string, unknown> | null;
@@ -290,7 +290,7 @@ export interface Trigger<
     result: TriggerBaseResult<TPayload>,
   ) => unknown[];
   hasResolveOnDeployItems?: boolean;
-  getOnDeployNextDiscoveryState?: (
+  getOnDeployNextPaginationState?: (
     context: ActionContext<TConfigVars>,
     result: TriggerBaseResult<TPayload>,
   ) => Record<string, unknown> | null;

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -77,6 +77,21 @@ export const cleanParams = (
   }, {});
 };
 
+/**
+ * The platform stamps a paginated re-run's cursor onto the runtime payload's `discoveryState`
+ * — the wire field the backend owns and re-stamps each round. Author-facing trigger code reads
+ * the cursor as `paginationState`, so we expose that alias on the payload before any author
+ * perform/resolver runs. The wire `discoveryState` is left intact, so the backend's discovery
+ * loop is unaffected.
+ */
+export const aliasPaginationState = <T>(payload: T): T => {
+  if (!payload || typeof payload !== "object") {
+    return payload;
+  }
+  const { discoveryState } = payload as { discoveryState?: unknown };
+  return { ...(payload as Record<string, unknown>), paginationState: discoveryState } as T;
+};
+
 export const createPerform = (
   performFn: PerformFn,
   { inputCleaners, errorHandler }: CreatePerformProps,
@@ -110,7 +125,11 @@ export const createPerform = (
         invokeFlow: createInvokeFlow(context),
       };
 
-      const result = await performFn(actionContext, payload, cleanParams(params, inputCleaners));
+      const result = await performFn(
+        actionContext,
+        aliasPaginationState(payload),
+        cleanParams(params, inputCleaners),
+      );
 
       logDebugResults(actionContext);
 

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -77,21 +77,6 @@ export const cleanParams = (
   }, {});
 };
 
-/**
- * The platform stamps a paginated re-run's cursor onto the runtime payload's `discoveryState`
- * — the wire field the backend owns and re-stamps each round. Author-facing trigger code reads
- * the cursor as `paginationState`, so we expose that alias on the payload before any author
- * perform/resolver runs. The wire `discoveryState` is left intact, so the backend's discovery
- * loop is unaffected.
- */
-export const aliasPaginationState = <T>(payload: T): T => {
-  if (!payload || typeof payload !== "object") {
-    return payload;
-  }
-  const { discoveryState } = payload as { discoveryState?: unknown };
-  return { ...(payload as Record<string, unknown>), paginationState: discoveryState } as T;
-};
-
 export const createPerform = (
   performFn: PerformFn,
   { inputCleaners, errorHandler }: CreatePerformProps,
@@ -125,11 +110,7 @@ export const createPerform = (
         invokeFlow: createInvokeFlow(context),
       };
 
-      const result = await performFn(
-        actionContext,
-        aliasPaginationState(payload),
-        cleanParams(params, inputCleaners),
-      );
+      const result = await performFn(actionContext, payload, cleanParams(params, inputCleaners));
 
       logDebugResults(actionContext);
 

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -573,7 +573,7 @@ export const invokeFlow = async <
     TPayload
   >,
 >(
-  // `any` for TItem/TDiscoveryState/TTriggerPayload: the tester accepts a flow with any
+  // `any` for TItem/TPaginationState/TTriggerPayload: the tester accepts a flow with any
   // resolver item and cursor typing; it drives the flow dynamically and does not rely on
   // the precise `onExecution` param type.
   flow: Flow<TInputs, TActionInputs, TPayload, TAllowsBranching, TResult, any, any, any>,

--- a/packages/spectral/src/types/ActionInputParameters.ts
+++ b/packages/spectral/src/types/ActionInputParameters.ts
@@ -10,14 +10,16 @@ import type {
 } from "./Inputs";
 
 /** Resolves a single InputFieldDefinition's runtime value type.
- * - structuredObject: record of declared children's resolved value types.
+ * - structuredObject: record of declared children's resolved value types;
+ *   with `collection` set, a list (`valuelist`) or `KeyValuePair` list
+ *   (`keyvaluelist`) of that record.
  * - dynamicObject: discriminated union keyed by the selected configuration,
  *   with the configuration's resolved inputs nested under `values` to avoid
  *   collisions with the `configuration` discriminant key.
  * The depth caps (`LeafInputFieldDefinition`, `StructuredOrLeafInputFieldDefinition`)
  * prevent unbounded recursion. */
 type InputValue<T> = T extends StructuredObjectInputField
-  ? { [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }
+  ? ExtractValue<{ [K in keyof T["inputs"]]: InputValue<T["inputs"][K]> }, T["collection"]>
   : T extends DynamicObjectInputField
     ? {
         [C in keyof T["configurations"]]: {

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -417,6 +417,10 @@ export type StructuredObjectInputField = Omit<
 > & {
   /** Data type the input will collect. */
   type: "structuredObject";
+  /** Collection type of the input; when set, the input collects a list
+   * (`valuelist`) or keyed list (`keyvaluelist`) of objects instead of a
+   * single object. */
+  collection?: InputFieldCollection;
   /** Nested input fields keyed by their local key. */
   inputs: Record<string, LeafInputFieldDefinition>;
 };

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -64,7 +64,7 @@ export type IntegrationDefinition<
    * Flows for this integration. See
    * https://prismatic.io/docs/integrations/code-native/flows/
    *
-   * The trailing `any`s for `TItem`/`TDiscoveryState`/`TTriggerPayload` let flows with
+   * The trailing `any`s for `TItem`/`TPaginationState`/`TTriggerPayload` let flows with
    * different resolver item and cursor types live in one array. `integration` only holds
    * and serializes these flows (it never invokes `onExecution`), so the precise — and
    * per-flow distinct — `onExecution` param type does not need to be preserved here.
@@ -105,9 +105,10 @@ export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unkn
 
 /**
  * The page of records a batched trigger fire (`onTrigger`/`onDeploy`) returns. The author
- * returns the items plus, when paginating, the cursor for the next page, spectral
- * wraps the items into the wire trigger payload (`body.data`), stamps `discoveryState` onto it,
- * and synthesizes the resolver that reads both back. There is no separate pagination callback to define.
+ * returns the items plus, when paginating, the cursor for the next page. spectral wraps the
+ * items into the wire trigger payload (`body.data`), carries the `paginationState` to the next
+ * round, and synthesizes the resolver that reads both back. There is no separate pagination
+ * callback to define.
  */
 export interface BatchedTriggerReturn<
   TItem,
@@ -117,21 +118,21 @@ export interface BatchedTriggerReturn<
   items: TItem[];
   /**
    * Cursor for the next page. Return it to paginate — the fire is re-invoked with this object on
-   * `payload.discoveryState`. Omit or return `null` to stop. Compute it here from the fetch
+   * `payload.paginationState`. Omit or return `null` to stop. Compute it here from the fetch
    * response, where the next-page token is still in scope.
    */
-  discoveryState?: TPaginationState | null;
+  paginationState?: TPaginationState | null;
   /** Optional HTTP response to the request that invoked the integration. */
   response?: HttpResponse;
 }
 
 /**
  * A batched trigger built by {@link batchFlowTrigger}. Bundles the normal and on-deploy trigger
- * fires, each returning `{ items, discoveryState? }`. The two type parameters — supplied
+ * fires, each returning `{ items, paginationState? }`. The two type parameters — supplied
  * explicitly to `batchFlowTrigger<TItem, TPaginationState>(...)` — flow through to the rest of
  * the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
- * `TPaginationState` types both `payload.discoveryState` (read on the way in) and the
- * `discoveryState` each fire returns (the next page's cursor).
+ * `TPaginationState` types both `payload.paginationState` (read on the way in) and the
+ * `paginationState` each fire returns (the next page's cursor).
  */
 export interface BatchTrigger<
   TItem,
@@ -139,8 +140,8 @@ export interface BatchTrigger<
 > {
   /**
    * The trigger function for this flow. Fetches a page of records and returns them as `items`,
-   * plus the next page's `discoveryState` to paginate (omit/`null` to stop). Read the cursor for
-   * the current page from `payload.discoveryState`.
+   * plus the next page's `paginationState` to paginate (omit/`null` to stop). Read the cursor for
+   * the current page from `payload.paginationState`.
    */
   onTrigger: (
     context: ActionContext<ConfigVars>,
@@ -148,7 +149,7 @@ export interface BatchTrigger<
   ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
   /**
    * The on-deploy trigger fire, run once on initial instance deploy. Same shape as `onTrigger`;
-   * return `discoveryState` to paginate the backfill.
+   * return `paginationState` to paginate the backfill.
    */
   onDeploy?: (
     context: ActionContext<ConfigVars>,
@@ -203,7 +204,7 @@ export type FlowExecutionContextActions = FlowExecutionContext["components"];
  * union is deliberate — a function property living in a union member loses contextual
  * parameter typing, which would make `onExecution`'s `context`/`params` implicitly `any`.
  */
-interface BatchFields<TItem, TDiscoveryState extends Record<string, unknown>> {
+interface BatchFields<TItem, TPaginationState extends Record<string, unknown>> {
   /**
    * Batch-dispatch config for this flow. Items returned by the `trigger`'s fires are chunked
    * into batches of `batchSize`. For a CNI flow this value is authoritative (what's written
@@ -215,7 +216,7 @@ interface BatchFields<TItem, TDiscoveryState extends Record<string, unknown>> {
    * (`onTrigger`/`onDeploy`) return just `items`; spectral synthesizes the resolver that
    * extracts them and maps the pagination callbacks. Required when `batchConfig` is set.
    */
-  trigger: BatchTrigger<TItem, TDiscoveryState>;
+  trigger: BatchTrigger<TItem, TPaginationState>;
   /** A batched flow's trigger fires live inside `trigger`; the flat `onTrigger` is forbidden. */
   onTrigger?: never;
   /** A batched flow's on-deploy fire lives inside `trigger`; the flat `onDeployTrigger` is forbidden. */
@@ -233,8 +234,8 @@ interface NonBatchFields {
  * The discriminated union coupling `batchConfig` and the batched `trigger`. Intersected
  * into each flow variant at {@link Flow}.
  */
-type BatchDiscriminant<TItem, TDiscoveryState extends Record<string, unknown>> =
-  | BatchFields<TItem, TDiscoveryState>
+type BatchDiscriminant<TItem, TPaginationState extends Record<string, unknown>> =
+  | BatchFields<TItem, TPaginationState>
   | NonBatchFields;
 
 /** Base properties shared by all flow types. */
@@ -317,7 +318,7 @@ interface StandardFlow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > extends FlowBase<TTriggerPayload, TItem> {
   triggerType?: StandardTriggerType;
   /** Schedule configuration that defines the frequency with which this flow will be automatically executed. */
@@ -327,7 +328,7 @@ interface StandardFlow<
   /** Specifies the trigger function for this flow, which returns a payload and optional HTTP response. */
   onTrigger?:
     | TriggerReference
-    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult, TDiscoveryState>;
+    | TriggerPerformFunction<TInputs, ConfigVars, TAllowsBranching, TResult, TPaginationState>;
   /**
    * Function to execute on initial instance deploy, in addition to (and independent of) `onTrigger`.
    * Typically used to backfill baseline records for systems whose webhooks only emit future events.
@@ -337,7 +338,7 @@ interface StandardFlow<
     ConfigVars,
     TAllowsBranching,
     TResult,
-    TDiscoveryState
+    TPaginationState
   >;
 }
 
@@ -355,7 +356,7 @@ interface PollingFlow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > extends FlowBase<TTriggerPayload, TItem> {
   /**
    * Type of trigger for this flow. A "polling" trigger runs on a schedule
@@ -386,7 +387,7 @@ interface PollingFlow<
     ConfigVars,
     TAllowsBranching,
     TResult,
-    TDiscoveryState
+    TPaginationState
   >;
 }
 
@@ -402,7 +403,7 @@ export type Flow<
   >,
   TTriggerPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | (StandardFlow<
       TInputs,
@@ -411,9 +412,9 @@ export type Flow<
       TResult,
       TTriggerPayload,
       TItem,
-      TDiscoveryState
+      TPaginationState
     > &
-      BatchDiscriminant<TItem, TDiscoveryState>)
+      BatchDiscriminant<TItem, TPaginationState>)
   | (PollingFlow<
       TInputs,
       TActionInputs,
@@ -422,9 +423,9 @@ export type Flow<
       TResult,
       TTriggerPayload,
       TItem,
-      TDiscoveryState
+      TPaginationState
     > &
-      BatchDiscriminant<TItem, TDiscoveryState>);
+      BatchDiscriminant<TItem, TPaginationState>);
 
 export type FlowTriggerType = PollingTriggerType | StandardTriggerType;
 

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -13,11 +13,11 @@ import type { HttpResponse } from "./HttpResponse";
 import type { Inputs } from "./Inputs";
 import type { PollingTriggerPerformFunction } from "./PollingTriggerDefinition";
 import type { ScopedConfigVarMap } from "./ScopedConfigVars";
-import type { BatchConfig, WithDiscoveryState } from "./TriggerDefinition";
+import type { BatchConfig } from "./TriggerDefinition";
 import type { TriggerEventFunction } from "./TriggerEventFunction";
 import type { TriggerPayload } from "./TriggerPayload";
 import type { TriggerPerformFunction } from "./TriggerPerformFunction";
-import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
+import type { TriggerResult } from "./TriggerResult";
 
 /**
  * Defines attributes of a code-native integration. See
@@ -105,59 +105,55 @@ export type BatchedTriggerPayload<TPayload extends TriggerPayload, TItem> = unkn
 
 /**
  * The page of records a batched trigger fire (`onTrigger`/`onDeploy`) returns. The author
- * returns just the items; spectral wraps them into the wire trigger payload (`body.data`)
- * and synthesizes the resolver that extracts them. Returning `items` is the whole contract —
- * there is no `payload` to thread by hand.
+ * returns the items plus, when paginating, the cursor for the next page, spectral
+ * wraps the items into the wire trigger payload (`body.data`), stamps `discoveryState` onto it,
+ * and synthesizes the resolver that reads both back. There is no separate pagination callback to define.
  */
-export interface BatchedTriggerReturn<TItem> {
+export interface BatchedTriggerReturn<
+  TItem,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
+> {
   /** The records produced by this trigger fire. Chunked into batches of the flow's `batchConfig.batchSize`. */
   items: TItem[];
+  /**
+   * Cursor for the next page. Return it to paginate — the fire is re-invoked with this object on
+   * `payload.discoveryState`. Omit or return `null` to stop. Compute it here from the fetch
+   * response, where the next-page token is still in scope.
+   */
+  discoveryState?: TPaginationState | null;
   /** Optional HTTP response to the request that invoked the integration. */
   response?: HttpResponse;
 }
 
 /**
- * The pagination callback for a batched trigger fire. Returns the state for the next page,
- * or `null` to stop. A non-null return re-invokes the corresponding trigger with this object
- * stamped onto `payload.discoveryState`; the loop ends when it returns `null`.
- */
-export type BatchPaginationStateFunction<TPaginationState extends Record<string, unknown>> = (
-  context: ActionContext<ConfigVars>,
-  result: TriggerBaseResult<WithDiscoveryState<TriggerPayload, TPaginationState>>,
-) => TPaginationState | null;
-
-/**
  * A batched trigger built by {@link batchFlowTrigger}. Bundles the normal and on-deploy trigger
- * fires (each returning just `items`) with their pagination callbacks. The two type parameters
- * — supplied explicitly to `batchTrigger<TItem, TPaginationState>(...)` — flow through to the
- * rest of the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
- * `TPaginationState` types `payload.discoveryState` and the pagination callbacks' return.
+ * fires, each returning `{ items, discoveryState? }`. The two type parameters — supplied
+ * explicitly to `batchFlowTrigger<TItem, TPaginationState>(...)` — flow through to the rest of
+ * the flow: `TItem` types `onExecution`'s `params.onTrigger.results.body.data`, and
+ * `TPaginationState` types both `payload.discoveryState` (read on the way in) and the
+ * `discoveryState` each fire returns (the next page's cursor).
  */
 export interface BatchTrigger<
   TItem,
   TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /**
-   * The trigger function for this flow. Fetches a page of records and returns them as `items`.
-   * Re-invoked once per pagination round (see `getNextOnTriggerPaginationState`); read the
-   * cursor for the current page from `payload.discoveryState`.
+   * The trigger function for this flow. Fetches a page of records and returns them as `items`,
+   * plus the next page's `discoveryState` to paginate (omit/`null` to stop). Read the cursor for
+   * the current page from `payload.discoveryState`.
    */
   onTrigger: (
     context: ActionContext<ConfigVars>,
     payload: TriggerPayload<TPaginationState>,
-  ) => Promise<BatchedTriggerReturn<TItem>>;
+  ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
   /**
    * The on-deploy trigger fire, run once on initial instance deploy. Same shape as `onTrigger`;
-   * pair with `getNextOnDeployPaginationState` to paginate.
+   * return `discoveryState` to paginate the backfill.
    */
   onDeploy?: (
     context: ActionContext<ConfigVars>,
     payload: TriggerPayload<TPaginationState>,
-  ) => Promise<BatchedTriggerReturn<TItem>>;
-  /** Pagination for `onTrigger`: return the next page's state, or `null` to stop. */
-  getNextOnTriggerPaginationState?: BatchPaginationStateFunction<TPaginationState>;
-  /** Pagination for `onDeploy`: return the next page's state, or `null` to stop. */
-  getNextOnDeployPaginationState?: BatchPaginationStateFunction<TPaginationState>;
+  ) => Promise<BatchedTriggerReturn<TItem, TPaginationState>>;
 }
 
 export type FlowOnExecution<

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -19,16 +19,16 @@ export type TriggerResolverDecl<
   TConfigVars extends ConfigVarResultCollection,
   TPayload extends TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | { triggerResolverSupport?: "invalid" | undefined; triggerResolver?: undefined }
   | {
       triggerResolverSupport: "valid";
-      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     }
   | {
       triggerResolverSupport: "required";
-      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     };
 
 /**
@@ -48,12 +48,12 @@ export type OnDeployDecl<
   TAllowsBranching extends boolean,
   TResult extends TriggerResult<TAllowsBranching, TPayload>,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
   | { onDeployPerform?: undefined; onDeployResolver?: undefined }
   | {
       onDeployPerform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
-      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TDiscoveryState>;
+      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
     };
 
 const optionChoices = ["invalid", "valid", "required"] as const;
@@ -72,44 +72,44 @@ export const TriggerOptionChoices: TriggerOptionChoice[] = [...optionChoices];
  *
  *   perform ──▶ resolveItems ──▶ [batch of TItem] ──▶ onExecution
  *                    │
- *                    └─ getNextDiscoveryState ──▶ payload.discoveryState ──▶ next perform
+ *                    └─ getNextPaginationState ──▶ payload.paginationState ──▶ next perform
  *
  * @typeParam TItem - element produced by `resolveItems`. With `batchSize: 1`
  *   each execution receives one `TItem` as its trigger data; with `batchSize > 1`
  *   it receives a `TItem[]` slice.
- * @typeParam TDiscoveryState - the pagination cursor. Whatever
- *   `getNextDiscoveryState` returns is what the next round reads back on
- *   `payload.discoveryState` (see {@link TriggerPayload}). The `result.payload`
- *   passed to both callbacks has its `discoveryState` narrowed to this type, so
+ * @typeParam TPaginationState - the pagination cursor. Whatever
+ *   `getNextPaginationState` returns is what the next round reads back on
+ *   `payload.paginationState` (see {@link TriggerPayload}). The `result.payload`
+ *   passed to both callbacks has its `paginationState` narrowed to this type, so
  *   the cursor round-trip is checked end to end.
  */
 export interface TriggerResolverBehavior<
   TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
   TPayload extends TriggerPayload = TriggerPayload,
   TItem = unknown,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /** Extracts the items to dispatch from one trigger result. Receives the same context as the trigger's perform function. With `batchSize: 1` each item is delivered to its own execution; with `batchSize > 1` items are grouped into `TItem[]` slices. */
   resolveItems?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
+    result: TriggerBaseResult<WithPaginationState<TPayload, TPaginationState>>,
   ) => TItem[];
-  /** Returns the cursor for the next page, or `null` to stop. A non-null return re-invokes the trigger with this object stamped onto `payload.discoveryState`. */
-  getNextDiscoveryState?: (
+  /** Returns the cursor for the next page, or `null` to stop. A non-null return re-invokes the trigger with this object stamped onto `payload.paginationState`. */
+  getNextPaginationState?: (
     context: ActionContext<TConfigVars>,
-    result: TriggerBaseResult<WithDiscoveryState<TPayload, TDiscoveryState>>,
-  ) => TDiscoveryState | null;
+    result: TriggerBaseResult<WithPaginationState<TPayload, TPaginationState>>,
+  ) => TPaginationState | null;
 }
 
 /**
- * A trigger payload with its `discoveryState` field narrowed to `TDiscoveryState`,
+ * A trigger payload with its `paginationState` field narrowed to `TPaginationState`,
  * leaving every other field of `TPayload` intact. Lets a resolver type the cursor
  * it reads back independently of how the base payload was parameterized.
  */
-export type WithDiscoveryState<
+export type WithPaginationState<
   TPayload extends TriggerPayload,
-  TDiscoveryState extends Record<string, unknown>,
-> = Omit<TPayload, "discoveryState"> & { discoveryState?: TDiscoveryState };
+  TPaginationState extends Record<string, unknown>,
+> = Omit<TPayload, "paginationState"> & { paginationState?: TPaginationState };
 
 /**
  * The single batch-dispatch config shared by a trigger's `triggerResolver` and

--- a/packages/spectral/src/types/TriggerPayload.ts
+++ b/packages/spectral/src/types/TriggerPayload.ts
@@ -6,12 +6,12 @@ import type { UserAttributes } from "./UserAttributes";
 
 /** Represents a Trigger Payload, which is data passed into a Trigger to invoke an Integration execution.
  *
- * The optional `TDiscoveryState` parameter types the `discoveryState` field, so authors who
- * declare a pagination-state shape on their `getNextDiscoveryState` resolver can read back
+ * The optional `TPaginationState` parameter types the `paginationState` field, so authors who
+ * declare a pagination-state shape on their `getNextPaginationState` resolver can read back
  * the same shape on the next round's payload. Defaults to `Record<string, unknown>`.
  */
 export interface TriggerPayload<
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > {
   /** The headers sent in the webhook request. */
   headers: {
@@ -59,7 +59,7 @@ export interface TriggerPayload<
   /** Determines whether the execution will run in debug mode. */
   globalDebug: boolean;
   /** Managed by the execution when this trigger invocation is a paginated re-run.
-   *  Contains the object returned by `getNextDiscoveryState` from the previous round.
+   *  Contains the object returned by `getNextPaginationState` from the previous round.
    *  Absent on the initial invocation. */
-  discoveryState?: TDiscoveryState;
+  paginationState?: TPaginationState;
 }

--- a/packages/spectral/src/types/TriggerPerformFunction.ts
+++ b/packages/spectral/src/types/TriggerPerformFunction.ts
@@ -10,9 +10,9 @@ export type TriggerPerformFunction<
   TConfigVars extends ConfigVarResultCollection,
   TAllowsBranching extends boolean | undefined,
   TResult extends TriggerResult<TAllowsBranching, TriggerPayload>,
-  TDiscoveryState extends Record<string, unknown> = Record<string, unknown>,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > = (
   context: ActionContext<TConfigVars>,
-  payload: TriggerPayload<TDiscoveryState>,
+  payload: TriggerPayload<TPaginationState>,
   params: ActionInputParameters<TInputs>,
 ) => Promise<TResult>;


### PR DESCRIPTION
Branches off `preview`, merges latest `main`, then cherry-picks the trigger-resolver tail that `preview` was missing.

## Cherry-picked from `lh/trigger-resolver` (PR #462)
- `9a71595` Return discoveryState from batchFlowTrigger fires, dropping pagination callbacks
- `7b81fcb` Rename discoveryState (author surface → `paginationState`)
- `94f97d4` Remove paginationState → discoveryState shim
