### PR TITLE
Add spectral support for inline action calling

### DIFF
--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -151,6 +151,12 @@ export const fetchComponentDataForManifest = async <
           },
           inputs: transformInputNodes(node.inputs.nodes),
           examplePayload: node.examplePayload,
+          ...(node.experimentalExamplePerformSupport
+            ? { experimentalExamplePerformSupport: node.experimentalExamplePerformSupport }
+            : {}),
+          ...(node.experimentalPerformSupport
+            ? { experimentalPerformSupport: node.experimentalPerformSupport }
+            : {}),
         };
       }
     });
@@ -265,6 +271,8 @@ async function getComponentActions(componentId: string, prismaticUrl: string, ac
                 }
               }
               examplePayload
+              experimentalExamplePerformSupport
+              experimentalPerformSupport
             }
             pageInfo {
               hasNextPage

--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -151,12 +151,8 @@ export const fetchComponentDataForManifest = async <
           },
           inputs: transformInputNodes(node.inputs.nodes),
           examplePayload: node.examplePayload,
-          ...(node.examplePerformSupport
-            ? { examplePerformSupport: node.examplePerformSupport }
-            : {}),
-          ...(node.performSupport
-            ? { performSupport: node.performSupport }
-            : {}),
+          ...(node.examplePerformSafety ? { examplePerformSafety: node.examplePerformSafety } : {}),
+          ...(node.performSafety ? { performSafety: node.performSafety } : {}),
         };
       }
     });
@@ -271,8 +267,8 @@ async function getComponentActions(componentId: string, prismaticUrl: string, ac
                 }
               }
               examplePayload
-              examplePerformSupport
-              performSupport
+              examplePerformSafety
+              performSafety
             }
             pageInfo {
               hasNextPage

--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -151,11 +151,11 @@ export const fetchComponentDataForManifest = async <
           },
           inputs: transformInputNodes(node.inputs.nodes),
           examplePayload: node.examplePayload,
-          ...(node.experimentalExamplePerformSupport
-            ? { experimentalExamplePerformSupport: node.experimentalExamplePerformSupport }
+          ...(node.examplePerformSupport
+            ? { examplePerformSupport: node.examplePerformSupport }
             : {}),
-          ...(node.experimentalPerformSupport
-            ? { experimentalPerformSupport: node.experimentalPerformSupport }
+          ...(node.performSupport
+            ? { performSupport: node.performSupport }
             : {}),
         };
       }
@@ -271,8 +271,8 @@ async function getComponentActions(componentId: string, prismaticUrl: string, ac
                 }
               }
               examplePayload
-              experimentalExamplePerformSupport
-              experimentalPerformSupport
+              examplePerformSupport
+              performSupport
             }
             pageInfo {
               hasNextPage

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -1,6 +1,6 @@
 import type { Action, Component, DataSource, Trigger, TriggerPayload } from "../../serverTypes";
 import type { ConfigVarResultCollection, Inputs } from "../../types";
-import type { ExperimentalPerformSupport } from "../../types/ActionDefinition";
+import type { PerformSupport } from "../../types/ActionDefinition";
 import type { TriggerResult } from "../../types/TriggerResult";
 
 export interface ComponentNode {
@@ -31,8 +31,8 @@ export interface ActionNode {
     nodes: InputNode[];
   };
   examplePayload: string | null;
-  experimentalExamplePerformSupport: ExperimentalPerformSupport | null;
-  experimentalPerformSupport: ExperimentalPerformSupport | null;
+  examplePerformSupport: PerformSupport | null;
+  performSupport: PerformSupport | null;
 }
 
 export interface ConnectionNode {
@@ -61,8 +61,8 @@ export type FormattedAction = Pick<
   | "display"
   | "inputs"
   | "examplePayload"
-  | "experimentalExamplePerformSupport"
-  | "experimentalPerformSupport"
+  | "examplePerformSupport"
+  | "performSupport"
 > & {
   /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
   outputSchema?: unknown;

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -57,12 +57,7 @@ export interface InputNode {
 
 export type FormattedAction = Pick<
   Action,
-  | "key"
-  | "display"
-  | "inputs"
-  | "examplePayload"
-  | "examplePerformSafety"
-  | "performSafety"
+  "key" | "display" | "inputs" | "examplePayload" | "examplePerformSafety" | "performSafety"
 > & {
   /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
   outputSchema?: unknown;

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -1,6 +1,6 @@
 import type { Action, Component, DataSource, Trigger, TriggerPayload } from "../../serverTypes";
 import type { ConfigVarResultCollection, Inputs } from "../../types";
-import type { PerformSupport } from "../../types/ActionDefinition";
+import type { PerformSafety } from "../../types/ActionDefinition";
 import type { TriggerResult } from "../../types/TriggerResult";
 
 export interface ComponentNode {
@@ -31,8 +31,8 @@ export interface ActionNode {
     nodes: InputNode[];
   };
   examplePayload: string | null;
-  examplePerformSupport: PerformSupport | null;
-  performSupport: PerformSupport | null;
+  examplePerformSafety: PerformSafety | null;
+  performSafety: PerformSafety | null;
 }
 
 export interface ConnectionNode {
@@ -61,8 +61,8 @@ export type FormattedAction = Pick<
   | "display"
   | "inputs"
   | "examplePayload"
-  | "examplePerformSupport"
-  | "performSupport"
+  | "examplePerformSafety"
+  | "performSafety"
 > & {
   /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
   outputSchema?: unknown;

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -1,5 +1,6 @@
 import type { Action, Component, DataSource, Trigger, TriggerPayload } from "../../serverTypes";
 import type { ConfigVarResultCollection, Inputs } from "../../types";
+import type { ExperimentalPerformSupport } from "../../types/ActionDefinition";
 import type { TriggerResult } from "../../types/TriggerResult";
 
 export interface ComponentNode {
@@ -30,6 +31,8 @@ export interface ActionNode {
     nodes: InputNode[];
   };
   examplePayload: string | null;
+  experimentalExamplePerformSupport: ExperimentalPerformSupport | null;
+  experimentalPerformSupport: ExperimentalPerformSupport | null;
 }
 
 export interface ConnectionNode {

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -52,7 +52,15 @@ export interface InputNode {
   onPremiseControlled: boolean;
 }
 
-export type FormattedAction = Pick<Action, "key" | "display" | "inputs" | "examplePayload"> & {
+export type FormattedAction = Pick<
+  Action,
+  | "key"
+  | "display"
+  | "inputs"
+  | "examplePayload"
+  | "experimentalExamplePerformSupport"
+  | "experimentalPerformSupport"
+> & {
   /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
   outputSchema?: unknown;
 };

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
+import type { ExperimentalPerformSupport } from "../../types/ActionDefinition";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -91,6 +92,12 @@ export const createActions = async <
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
           ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
+          ...(action.experimentalExamplePerformSupport
+            ? { experimentalExamplePerformSupport: action.experimentalExamplePerformSupport }
+            : {}),
+          ...(action.experimentalPerformSupport
+            ? { experimentalPerformSupport: action.experimentalPerformSupport }
+            : {}),
           componentKey: component.key,
         },
         imports,
@@ -150,6 +157,8 @@ interface RenderActionProps {
     inputs: Input[];
     examplePayload?: unknown;
     outputSchema?: unknown;
+    experimentalExamplePerformSupport?: ExperimentalPerformSupport;
+    experimentalPerformSupport?: ExperimentalPerformSupport;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
-import type { PerformSupport } from "../../types/ActionDefinition";
+import type { PerformSafety } from "../../types/ActionDefinition";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -92,12 +92,10 @@ export const createActions = async <
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
           ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
-          ...(action.examplePerformSupport
-            ? { examplePerformSupport: action.examplePerformSupport }
+          ...(action.examplePerformSafety
+            ? { examplePerformSafety: action.examplePerformSafety }
             : {}),
-          ...(action.performSupport
-            ? { performSupport: action.performSupport }
-            : {}),
+          ...(action.performSafety ? { performSafety: action.performSafety } : {}),
           componentKey: component.key,
         },
         imports,
@@ -157,8 +155,8 @@ interface RenderActionProps {
     inputs: Input[];
     examplePayload?: unknown;
     outputSchema?: unknown;
-    examplePerformSupport?: PerformSupport;
-    performSupport?: PerformSupport;
+    examplePerformSafety?: PerformSafety;
+    performSafety?: PerformSafety;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
-import type { ExperimentalPerformSupport } from "../../types/ActionDefinition";
+import type { PerformSupport } from "../../types/ActionDefinition";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -92,11 +92,11 @@ export const createActions = async <
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
           ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
-          ...(action.experimentalExamplePerformSupport
-            ? { experimentalExamplePerformSupport: action.experimentalExamplePerformSupport }
+          ...(action.examplePerformSupport
+            ? { examplePerformSupport: action.examplePerformSupport }
             : {}),
-          ...(action.experimentalPerformSupport
-            ? { experimentalPerformSupport: action.experimentalPerformSupport }
+          ...(action.performSupport
+            ? { performSupport: action.performSupport }
             : {}),
           componentKey: component.key,
         },
@@ -157,8 +157,8 @@ interface RenderActionProps {
     inputs: Input[];
     examplePayload?: unknown;
     outputSchema?: unknown;
-    experimentalExamplePerformSupport?: ExperimentalPerformSupport;
-    experimentalPerformSupport?: ExperimentalPerformSupport;
+    examplePerformSupport?: PerformSupport;
+    performSupport?: PerformSupport;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -28,10 +28,10 @@ export const <%= action.import %> = {
   <%_ if (action.outputSchema) { -%>
   outputSchema: <%- typeof action.outputSchema === 'string' ? action.outputSchema : JSON.stringify(action.outputSchema, null, 2) %>,
   <%_ } -%>
-  <%_ if (action.examplePerformSupport) { -%>
-  examplePerformSupport: "<%= action.examplePerformSupport %>",
+  <%_ if (action.examplePerformSafety) { -%>
+  examplePerformSafety: "<%= action.examplePerformSafety %>",
   <%_ } -%>
-  <%_ if (action.performSupport) { -%>
-  performSupport: "<%= action.performSupport %>",
+  <%_ if (action.performSafety) { -%>
+  performSafety: "<%= action.performSafety %>",
   <%_ } -%>
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -28,10 +28,10 @@ export const <%= action.import %> = {
   <%_ if (action.outputSchema) { -%>
   outputSchema: <%- typeof action.outputSchema === 'string' ? action.outputSchema : JSON.stringify(action.outputSchema, null, 2) %>,
   <%_ } -%>
-  <%_ if (action.experimentalExamplePerformSupport) { -%>
-  experimentalExamplePerformSupport: "<%= action.experimentalExamplePerformSupport %>",
+  <%_ if (action.examplePerformSupport) { -%>
+  examplePerformSupport: "<%= action.examplePerformSupport %>",
   <%_ } -%>
-  <%_ if (action.experimentalPerformSupport) { -%>
-  experimentalPerformSupport: "<%= action.experimentalPerformSupport %>",
+  <%_ if (action.performSupport) { -%>
+  performSupport: "<%= action.performSupport %>",
   <%_ } -%>
 } as const;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -28,4 +28,10 @@ export const <%= action.import %> = {
   <%_ if (action.outputSchema) { -%>
   outputSchema: <%- typeof action.outputSchema === 'string' ? action.outputSchema : JSON.stringify(action.outputSchema, null, 2) %>,
   <%_ } -%>
+  <%_ if (action.experimentalExamplePerformSupport) { -%>
+  experimentalExamplePerformSupport: "<%= action.experimentalExamplePerformSupport %>",
+  <%_ } -%>
+  <%_ if (action.experimentalPerformSupport) { -%>
+  experimentalPerformSupport: "<%= action.experimentalPerformSupport %>",
+  <%_ } -%>
 } as const;

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -10,6 +10,7 @@ import {
 } from "..";
 import {
   cleanerFor,
+  convertAction,
   convertConnection,
   convertInput,
   convertTemplateInput,
@@ -33,6 +34,70 @@ describe("convertConnection", () => {
     const convertedConnection = convertConnection(basicConnection);
     expect(convertedConnection.label).toBe(label);
     expect(convertedConnection.comments).toBe(description);
+  });
+});
+
+describe("convertAction", () => {
+  const baseDisplay = { label: "Do Thing", description: "Does a thing." };
+
+  it("wraps experimentalExamplePerform so it is invokable with input cleaning applied", async () => {
+    const examplePerform = vi.fn(async (_context: any, params: any) => ({
+      data: params,
+    }));
+
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {
+          count: input({ type: "string", label: "Count", clean: (v) => Number(v) }),
+        },
+        perform: async () => ({ data: null }),
+        experimentalExamplePerform: examplePerform,
+        experimentalExamplePerformSupport: "safe",
+      }),
+    );
+
+    expect(converted.experimentalExamplePerform).toBeDefined();
+    expect(typeof converted.experimentalExamplePerform).toBe("function");
+
+    const result = await converted.experimentalExamplePerform?.({} as any, { count: "42" });
+
+    // The cleaner ran ("42" -> 42) before reaching the author's example perform.
+    expect(examplePerform).toHaveBeenCalledWith(expect.anything(), { count: 42 });
+    expect(result).toStrictEqual({ data: { count: 42 } });
+  });
+
+  it("carries the support enums through to the server action", () => {
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {},
+        perform: async () => ({ data: null }),
+        experimentalPerformSupport: "auto",
+        experimentalExamplePerformSupport: "notAllowed",
+      }),
+    );
+
+    expect(converted.experimentalPerformSupport).toBe("auto");
+    expect(converted.experimentalExamplePerformSupport).toBe("notAllowed");
+  });
+
+  it("omits experimentalExamplePerform when the author does not define it", () => {
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {},
+        perform: async () => ({ data: null }),
+      }),
+    );
+
+    // Must be absent, not an unwrapped/throwing function leaked via the spread.
+    expect("experimentalExamplePerform" in converted).toBe(false);
+    expect(converted.experimentalExamplePerformSupport).toBeUndefined();
+    expect(converted.experimentalPerformSupport).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -4,6 +4,7 @@ import {
   component,
   connection,
   dynamicObjectInput,
+  ExperimentalPerformSupport,
   input,
   structuredObjectInput,
   trigger,
@@ -54,7 +55,7 @@ describe("convertAction", () => {
         },
         perform: async () => ({ data: null }),
         experimentalExamplePerform: examplePerform,
-        experimentalExamplePerformSupport: "safe",
+        experimentalExamplePerformSupport: "SAFE",
       }),
     );
 
@@ -68,20 +69,20 @@ describe("convertAction", () => {
     expect(result).toStrictEqual({ data: { count: 42 } });
   });
 
-  it("carries the support enums through to the server action", () => {
+  it("carries the support enums through to the server action (const companion)", () => {
     const converted = convertAction(
       "doThing",
       action({
         display: baseDisplay,
         inputs: {},
         perform: async () => ({ data: null }),
-        experimentalPerformSupport: "auto",
-        experimentalExamplePerformSupport: "notAllowed",
+        experimentalPerformSupport: ExperimentalPerformSupport.UNSAFE,
+        experimentalExamplePerformSupport: ExperimentalPerformSupport.NOT_ALLOWED,
       }),
     );
 
-    expect(converted.experimentalPerformSupport).toBe("auto");
-    expect(converted.experimentalExamplePerformSupport).toBe("notAllowed");
+    expect(converted.experimentalPerformSupport).toBe("UNSAFE");
+    expect(converted.experimentalExamplePerformSupport).toBe("NOT_ALLOWED");
   });
 
   it("omits experimentalExamplePerform when the author does not define it", () => {

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -4,8 +4,8 @@ import {
   component,
   connection,
   dynamicObjectInput,
-  ExperimentalPerformSupport,
   input,
+  PerformSupport,
   structuredObjectInput,
   trigger,
 } from "..";
@@ -41,7 +41,7 @@ describe("convertConnection", () => {
 describe("convertAction", () => {
   const baseDisplay = { label: "Do Thing", description: "Does a thing." };
 
-  it("wraps experimentalExamplePerform so it is invokable with input cleaning applied", async () => {
+  it("wraps examplePerform so it is invokable with input cleaning applied", async () => {
     const examplePerform = vi.fn(async (_context: any, params: any) => ({
       data: params,
     }));
@@ -54,15 +54,15 @@ describe("convertAction", () => {
           count: input({ type: "string", label: "Count", clean: (v) => Number(v) }),
         },
         perform: async () => ({ data: null }),
-        experimentalExamplePerform: examplePerform,
-        experimentalExamplePerformSupport: "SAFE",
+        examplePerform: examplePerform,
+        examplePerformSupport: "SAFE",
       }),
     );
 
-    expect(converted.experimentalExamplePerform).toBeDefined();
-    expect(typeof converted.experimentalExamplePerform).toBe("function");
+    expect(converted.examplePerform).toBeDefined();
+    expect(typeof converted.examplePerform).toBe("function");
 
-    const result = await converted.experimentalExamplePerform?.({} as any, { count: "42" });
+    const result = await converted.examplePerform?.({} as any, { count: "42" });
 
     // The cleaner ran ("42" -> 42) before reaching the author's example perform.
     expect(examplePerform).toHaveBeenCalledWith(expect.anything(), { count: 42 });
@@ -76,16 +76,16 @@ describe("convertAction", () => {
         display: baseDisplay,
         inputs: {},
         perform: async () => ({ data: null }),
-        experimentalPerformSupport: ExperimentalPerformSupport.UNSAFE,
-        experimentalExamplePerformSupport: ExperimentalPerformSupport.NOT_ALLOWED,
+        performSupport: PerformSupport.UNSAFE,
+        examplePerformSupport: PerformSupport.NOT_ALLOWED,
       }),
     );
 
-    expect(converted.experimentalPerformSupport).toBe("UNSAFE");
-    expect(converted.experimentalExamplePerformSupport).toBe("NOT_ALLOWED");
+    expect(converted.performSupport).toBe("UNSAFE");
+    expect(converted.examplePerformSupport).toBe("NOT_ALLOWED");
   });
 
-  it("omits experimentalExamplePerform when the author does not define it", () => {
+  it("omits examplePerform when the author does not define it", () => {
     const converted = convertAction(
       "doThing",
       action({
@@ -96,9 +96,9 @@ describe("convertAction", () => {
     );
 
     // Must be absent, not an unwrapped/throwing function leaked via the spread.
-    expect("experimentalExamplePerform" in converted).toBe(false);
-    expect(converted.experimentalExamplePerformSupport).toBeUndefined();
-    expect(converted.experimentalPerformSupport).toBeUndefined();
+    expect("examplePerform" in converted).toBe(false);
+    expect(converted.examplePerformSupport).toBeUndefined();
+    expect(converted.performSupport).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -55,7 +55,7 @@ describe("convertAction", () => {
         },
         perform: async () => ({ data: null }),
         examplePerform: examplePerform,
-        examplePerformSupport: "SAFE",
+        examplePerformSupport: PerformSupport.SAFE,
       }),
     );
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -5,7 +5,7 @@ import {
   connection,
   dynamicObjectInput,
   input,
-  PerformSupport,
+  PerformSafety,
   structuredObjectInput,
   trigger,
 } from "..";
@@ -55,7 +55,7 @@ describe("convertAction", () => {
         },
         perform: async () => ({ data: null }),
         examplePerform: examplePerform,
-        examplePerformSupport: PerformSupport.SAFE,
+        examplePerformSafety: PerformSafety.SAFE,
       }),
     );
 
@@ -69,20 +69,20 @@ describe("convertAction", () => {
     expect(result).toStrictEqual({ data: { count: 42 } });
   });
 
-  it("carries the support enums through to the server action (const companion)", () => {
+  it("carries the safety enums through to the server action (const companion)", () => {
     const converted = convertAction(
       "doThing",
       action({
         display: baseDisplay,
         inputs: {},
         perform: async () => ({ data: null }),
-        performSupport: PerformSupport.UNSAFE,
-        examplePerformSupport: PerformSupport.NOT_ALLOWED,
+        performSafety: PerformSafety.UNSAFE,
+        examplePerformSafety: PerformSafety.NOT_ALLOWED,
       }),
     );
 
-    expect(converted.performSupport).toBe("UNSAFE");
-    expect(converted.examplePerformSupport).toBe("NOT_ALLOWED");
+    expect(converted.performSafety).toBe("UNSAFE");
+    expect(converted.examplePerformSafety).toBe("NOT_ALLOWED");
   });
 
   it("omits examplePerform when the author does not define it", () => {
@@ -97,8 +97,8 @@ describe("convertAction", () => {
 
     // Must be absent, not an unwrapped/throwing function leaked via the spread.
     expect("examplePerform" in converted).toBe(false);
-    expect(converted.examplePerformSupport).toBeUndefined();
-    expect(converted.performSupport).toBeUndefined();
+    expect(converted.examplePerformSafety).toBeUndefined();
+    expect(converted.performSafety).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -410,9 +410,6 @@ export const convertAction = (
       errorHandler: hooks?.error,
     }),
     ...(outputSchema ? { outputSchema: convertOutputSchema(outputSchema) } : {}),
-    // Wrap the example perform the same way as `perform` (input cleaning + error
-    // handling). Destructured out of `...action` so a raw, unwrapped function never
-    // leaks onto the server action; only emitted when the author defines it.
     ...(experimentalExamplePerform
       ? {
           experimentalExamplePerform: createPerform(experimentalExamplePerform, {

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -384,9 +384,15 @@ const convertOutputSchema = (outputSchema: OutputSchema): ServerOutputSchema => 
   };
 };
 
-const convertAction = (
+export const convertAction = (
   actionKey: string,
-  { inputs = {}, perform, outputSchema, ...action }: ActionDefinition<Inputs, any, boolean, any>,
+  {
+    inputs = {},
+    perform,
+    outputSchema,
+    experimentalExamplePerform,
+    ...action
+  }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
 ): ServerAction => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
@@ -404,6 +410,17 @@ const convertAction = (
       errorHandler: hooks?.error,
     }),
     ...(outputSchema ? { outputSchema: convertOutputSchema(outputSchema) } : {}),
+    // Wrap the example perform the same way as `perform` (input cleaning + error
+    // handling). Destructured out of `...action` so a raw, unwrapped function never
+    // leaks onto the server action; only emitted when the author defines it.
+    ...(experimentalExamplePerform
+      ? {
+          experimentalExamplePerform: createPerform(experimentalExamplePerform, {
+            inputCleaners,
+            errorHandler: hooks?.error,
+          }),
+        }
+      : {}),
   };
 };
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -390,7 +390,7 @@ export const convertAction = (
     inputs = {},
     perform,
     outputSchema,
-    experimentalExamplePerform,
+    examplePerform,
     ...action
   }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
@@ -410,9 +410,9 @@ export const convertAction = (
       errorHandler: hooks?.error,
     }),
     ...(outputSchema ? { outputSchema: convertOutputSchema(outputSchema) } : {}),
-    ...(experimentalExamplePerform
+    ...(examplePerform
       ? {
-          experimentalExamplePerform: createPerform(experimentalExamplePerform, {
+          examplePerform: createPerform(examplePerform, {
             inputCleaners,
             errorHandler: hooks?.error,
           }),

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -9,13 +9,13 @@ import type {
   DataSourceType,
   DebugContext,
   ExecutionFrame,
-  PerformSupport,
   FlowAttributes,
   FlowInvoker,
   FlowSchemas,
   Inputs,
   InstanceAttributes,
   IntegrationAttributes,
+  PerformSafety,
   PollingTriggerPerformFunction,
   TriggerEventFunctionReturn,
   TriggerPerformFunction,
@@ -91,8 +91,8 @@ export interface Action {
    */
   outputSchema?: ServerOutputSchema;
   examplePerform?: ActionPerformFunction;
-  examplePerformSupport?: PerformSupport;
-  performSupport?: PerformSupport;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
 }
 
 export type ServerOutputSchema =

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -9,7 +9,7 @@ import type {
   DataSourceType,
   DebugContext,
   ExecutionFrame,
-  ExperimentalPerformSupport,
+  PerformSupport,
   FlowAttributes,
   FlowInvoker,
   FlowSchemas,
@@ -90,9 +90,9 @@ export interface Action {
    * from the author-facing `OutputSchema`.
    */
   outputSchema?: ServerOutputSchema;
-  experimentalExamplePerform?: ActionPerformFunction;
-  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
-  experimentalPerformSupport?: ExperimentalPerformSupport;
+  examplePerform?: ActionPerformFunction;
+  examplePerformSupport?: PerformSupport;
+  performSupport?: PerformSupport;
 }
 
 export type ServerOutputSchema =

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -9,6 +9,7 @@ import type {
   DataSourceType,
   DebugContext,
   ExecutionFrame,
+  ExperimentalPerformSupport,
   FlowAttributes,
   FlowInvoker,
   FlowSchemas,
@@ -89,6 +90,9 @@ export interface Action {
    * from the author-facing `OutputSchema`.
    */
   outputSchema?: ServerOutputSchema;
+  experimentalExamplePerform?: ActionPerformFunction;
+  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
+  experimentalPerformSupport?: ExperimentalPerformSupport;
 }
 
 export type ServerOutputSchema =

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Verifies what spectral serializes for the inline-action example-perform fields
+ * on publish — the converted server component `prism component publish` sends.
+ *
+ * Scope is conversion output only: which fields land on the wire, with what values.
+ * It does not verify runtime dispatch (SAFE vs. UNSAFE vs. NOT_ALLOWED choosing
+ * which perform runs) — the support flags are inert metadata spectral passes through
+ * verbatim, and the runner decides at execution time.
+ */
+import { renderFile } from "ejs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { helpers } from "../generators/componentManifest/helpers";
+import { action, component, input, PerformSupport, structuredObjectInput } from "../index";
+
+const display = (label: string) => ({ label, description: label });
+
+// Three input shapes exercised on every permutation.
+const connectionInput = input({ label: "Connection", type: "connection", required: true });
+const structuredInput = structuredObjectInput({
+  label: "Name",
+  inputs: {
+    first: input({ type: "string", label: "First", required: true }),
+    last: input({ type: "string", label: "Last", required: true }),
+  },
+});
+const collectionInput = input({ label: "Tags", type: "string", collection: "valuelist" });
+
+const sharedInputs = {
+  connection: connectionInput,
+  name: structuredInput,
+  tags: collectionInput,
+};
+
+const noop = async () => ({ data: null });
+const echo = async (_ctx: any, params: any) => ({ data: params });
+
+// Action permutations.
+const testComponent = component({
+  key: "inline-action-testbed",
+  public: false,
+  display: { ...display("Inline Action Testbed"), iconPath: "icon.png" },
+  actions: {
+    // A — no inline-calling fields.
+    plainAction: action({
+      display: display("Plain Action"),
+      inputs: sharedInputs,
+      perform: noop,
+    }),
+    // B — example perform + its support flag.
+    examplePerformAction: action({
+      display: display("Example Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      examplePerform: echo,
+      examplePerformSupport: PerformSupport.SAFE,
+    }),
+    // C — real perform marked runnable.
+    runnablePerformAction: action({
+      display: display("Runnable Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      performSupport: PerformSupport.UNSAFE,
+    }),
+    // D — real perform marked not runnable.
+    notAllowedPerformAction: action({
+      display: display("Not Allowed Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      performSupport: PerformSupport.NOT_ALLOWED,
+    }),
+  },
+});
+
+// Converted actions are keyed by action key.
+const actionsByKey = testComponent.actions as Record<string, any>;
+
+describe("inline action calling: publish-wire conversion output", () => {
+  it("A — plain action: no inline-calling fields leak onto the wire", () => {
+    const a = actionsByKey.plainAction;
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSupport).toBeUndefined();
+    expect(a.performSupport).toBeUndefined();
+  });
+
+  it("B — example perform is wrapped (invokable) and its support flag is carried", async () => {
+    const a = actionsByKey.examplePerformAction;
+    expect(typeof a.examplePerform).toBe("function");
+    expect(a.examplePerformSupport).toBe("SAFE");
+    // Only the field the author set is carried; no performSupport leaks in.
+    expect(a.performSupport).toBeUndefined();
+    // Wrapped fn is invokable and passes params through.
+    const result: any = await a.examplePerform?.({} as any, { tags: ["x"] });
+    expect(result.data.tags).toStrictEqual(["x"]);
+  });
+
+  it("C — real-perform UNSAFE flag carried; no separate example perform", () => {
+    const a = actionsByKey.runnablePerformAction;
+    expect(a.performSupport).toBe("UNSAFE");
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSupport).toBeUndefined();
+  });
+
+  it("D — real-perform NOT_ALLOWED flag carried verbatim; no example perform", () => {
+    const a = actionsByKey.notAllowedPerformAction;
+    expect(a.performSupport).toBe("NOT_ALLOWED");
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSupport).toBeUndefined();
+  });
+
+  it("the three input shapes survive conversion on every permutation", () => {
+    for (const key of [
+      "plainAction",
+      "examplePerformAction",
+      "runnablePerformAction",
+      "notAllowedPerformAction",
+    ]) {
+      const inputs = actionsByKey[key].inputs;
+      const byKey = Object.fromEntries(inputs.map((i: any) => [i.key, i]));
+      expect(byKey.connection.type).toBe("connection");
+      expect(byKey.name.type).toBe("structuredObject");
+      expect(byKey.name.inputs).toHaveLength(2); // nested children survived
+      expect(byKey.tags.collection).toBe("valuelist");
+    }
+  });
+});
+
+describe("inline action calling: component-manifest emit", () => {
+  const templatePath = path.join(
+    __dirname,
+    "../generators/componentManifest/templates/actions/action.ts.ejs",
+  );
+  const baseAction = {
+    typeInterface: "DoThing",
+    import: "doThing",
+    key: "doThing",
+    label: "Do Thing",
+    description: "Does a thing.",
+    inputs: [],
+    componentKey: "testbed",
+  };
+  const render = (extra: Record<string, unknown>) =>
+    renderFile(templatePath, { action: { ...baseAction, ...extra }, helpers, imports: {} });
+
+  it("emits both *Support scalars when present", async () => {
+    const out = await render({
+      examplePerformSupport: "SAFE",
+      performSupport: "UNSAFE",
+    });
+    expect(out).toContain('examplePerformSupport: "SAFE"');
+    expect(out).toContain('performSupport: "UNSAFE"');
+  });
+
+  it("emits a NOT_ALLOWED performSupport scalar verbatim", async () => {
+    const out = await render({ performSupport: "NOT_ALLOWED" });
+    expect(out).toContain('performSupport: "NOT_ALLOWED"');
+  });
+
+  it("omits the *Support scalars when absent (permutation A)", async () => {
+    const out = await render({});
+    expect(out).not.toContain("examplePerformSupport");
+    expect(out).not.toContain("performSupport");
+  });
+
+  it("never emits an examplePerform stub (invoked via the server action, not the manifest)", async () => {
+    const out = await render({
+      examplePerformSupport: "SAFE",
+      performSupport: "UNSAFE",
+    });
+    expect(out).not.toContain("examplePerform:");
+  });
+});

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -4,14 +4,14 @@
  *
  * Scope is conversion output only: which fields land on the wire, with what values.
  * It does not verify runtime dispatch (SAFE vs. UNSAFE vs. NOT_ALLOWED choosing
- * which perform runs) — the support flags are inert metadata spectral passes through
+ * which perform runs) — the safety flags are inert metadata spectral passes through
  * verbatim, and the runner decides at execution time.
  */
 import { renderFile } from "ejs";
 import path from "path";
 import { describe, expect, it } from "vitest";
 import { helpers } from "../generators/componentManifest/helpers";
-import { action, component, input, PerformSupport, structuredObjectInput } from "../index";
+import { action, component, input, PerformSafety, structuredObjectInput } from "../index";
 
 const display = (label: string) => ({ label, description: label });
 
@@ -47,27 +47,27 @@ const testComponent = component({
       inputs: sharedInputs,
       perform: noop,
     }),
-    // B — example perform + its support flag.
+    // B — example perform + its safety flag.
     examplePerformAction: action({
       display: display("Example Perform Action"),
       inputs: sharedInputs,
       perform: noop,
       examplePerform: echo,
-      examplePerformSupport: PerformSupport.SAFE,
+      examplePerformSafety: PerformSafety.SAFE,
     }),
     // C — real perform marked runnable.
     runnablePerformAction: action({
       display: display("Runnable Perform Action"),
       inputs: sharedInputs,
       perform: noop,
-      performSupport: PerformSupport.UNSAFE,
+      performSafety: PerformSafety.UNSAFE,
     }),
     // D — real perform marked not runnable.
     notAllowedPerformAction: action({
       display: display("Not Allowed Perform Action"),
       inputs: sharedInputs,
       perform: noop,
-      performSupport: PerformSupport.NOT_ALLOWED,
+      performSafety: PerformSafety.NOT_ALLOWED,
     }),
   },
 });
@@ -79,16 +79,16 @@ describe("inline action calling: publish-wire conversion output", () => {
   it("A — plain action: no inline-calling fields leak onto the wire", () => {
     const a = actionsByKey.plainAction;
     expect("examplePerform" in a).toBe(false);
-    expect(a.examplePerformSupport).toBeUndefined();
-    expect(a.performSupport).toBeUndefined();
+    expect(a.examplePerformSafety).toBeUndefined();
+    expect(a.performSafety).toBeUndefined();
   });
 
-  it("B — example perform is wrapped (invokable) and its support flag is carried", async () => {
+  it("B — example perform is wrapped (invokable) and its safety flag is carried", async () => {
     const a = actionsByKey.examplePerformAction;
     expect(typeof a.examplePerform).toBe("function");
-    expect(a.examplePerformSupport).toBe("SAFE");
-    // Only the field the author set is carried; no performSupport leaks in.
-    expect(a.performSupport).toBeUndefined();
+    expect(a.examplePerformSafety).toBe("SAFE");
+    // Only the field the author set is carried; no performSafety leaks in.
+    expect(a.performSafety).toBeUndefined();
     // Wrapped fn is invokable and passes params through.
     const result: any = await a.examplePerform?.({} as any, { tags: ["x"] });
     expect(result.data.tags).toStrictEqual(["x"]);
@@ -96,16 +96,16 @@ describe("inline action calling: publish-wire conversion output", () => {
 
   it("C — real-perform UNSAFE flag carried; no separate example perform", () => {
     const a = actionsByKey.runnablePerformAction;
-    expect(a.performSupport).toBe("UNSAFE");
+    expect(a.performSafety).toBe("UNSAFE");
     expect("examplePerform" in a).toBe(false);
-    expect(a.examplePerformSupport).toBeUndefined();
+    expect(a.examplePerformSafety).toBeUndefined();
   });
 
   it("D — real-perform NOT_ALLOWED flag carried verbatim; no example perform", () => {
     const a = actionsByKey.notAllowedPerformAction;
-    expect(a.performSupport).toBe("NOT_ALLOWED");
+    expect(a.performSafety).toBe("NOT_ALLOWED");
     expect("examplePerform" in a).toBe(false);
-    expect(a.examplePerformSupport).toBeUndefined();
+    expect(a.examplePerformSafety).toBeUndefined();
   });
 
   it("the three input shapes survive conversion on every permutation", () => {
@@ -142,30 +142,30 @@ describe("inline action calling: component-manifest emit", () => {
   const render = (extra: Record<string, unknown>) =>
     renderFile(templatePath, { action: { ...baseAction, ...extra }, helpers, imports: {} });
 
-  it("emits both *Support scalars when present", async () => {
+  it("emits both *Safety scalars when present", async () => {
     const out = await render({
-      examplePerformSupport: "SAFE",
-      performSupport: "UNSAFE",
+      examplePerformSafety: "SAFE",
+      performSafety: "UNSAFE",
     });
-    expect(out).toContain('examplePerformSupport: "SAFE"');
-    expect(out).toContain('performSupport: "UNSAFE"');
+    expect(out).toContain('examplePerformSafety: "SAFE"');
+    expect(out).toContain('performSafety: "UNSAFE"');
   });
 
-  it("emits a NOT_ALLOWED performSupport scalar verbatim", async () => {
-    const out = await render({ performSupport: "NOT_ALLOWED" });
-    expect(out).toContain('performSupport: "NOT_ALLOWED"');
+  it("emits a NOT_ALLOWED performSafety scalar verbatim", async () => {
+    const out = await render({ performSafety: "NOT_ALLOWED" });
+    expect(out).toContain('performSafety: "NOT_ALLOWED"');
   });
 
-  it("omits the *Support scalars when absent (permutation A)", async () => {
+  it("omits the *Safety scalars when absent (permutation A)", async () => {
     const out = await render({});
-    expect(out).not.toContain("examplePerformSupport");
-    expect(out).not.toContain("performSupport");
+    expect(out).not.toContain("examplePerformSafety");
+    expect(out).not.toContain("performSafety");
   });
 
   it("never emits an examplePerform stub (invoked via the server action, not the manifest)", async () => {
     const out = await render({
-      examplePerformSupport: "SAFE",
-      performSupport: "UNSAFE",
+      examplePerformSafety: "SAFE",
+      performSafety: "UNSAFE",
     });
     expect(out).not.toContain("examplePerform:");
   });

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -29,6 +29,15 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
+  experimentalExamplePerform?: ActionPerformFunction<
+    TInputs,
+    TConfigVars,
+    Record<string, Record<string, ComponentManifestAction>>,
+    TAllowsBranching,
+    TReturn
+  >;
+  experimentalExamplePerformSupport?: "safe" | "auto" | "notAllowed";
+  experimentalPerformSupport?: "safe" | "auto" | "notAllowed";
   /**
    * The inputs to present a low-code integration builder. Values of these inputs
    * are passed to the `perform` function when the action is invoked.

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -10,14 +10,14 @@ import type { OutputSchema } from "./OutputSchema";
  * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
  * Values are SCREAMING_SNAKE to match the backend GraphQL enum member names verbatim.
  */
-export const ExperimentalPerformSupport = {
+export const PerformSupport = {
   SAFE: "SAFE",
   UNSAFE: "UNSAFE",
   NOT_ALLOWED: "NOT_ALLOWED",
 } as const;
 
-export type ExperimentalPerformSupport =
-  (typeof ExperimentalPerformSupport)[keyof typeof ExperimentalPerformSupport];
+export type PerformSupport =
+  (typeof PerformSupport)[keyof typeof PerformSupport];
 
 /**
  * ActionDefinition is the type of the object that is passed in to `action` function to
@@ -43,15 +43,15 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
-  experimentalExamplePerform?: ActionPerformFunction<
+  examplePerform?: ActionPerformFunction<
     TInputs,
     TConfigVars,
     Record<string, Record<string, ComponentManifestAction>>,
     TAllowsBranching,
     TReturn
   >;
-  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
-  experimentalPerformSupport?: ExperimentalPerformSupport;
+  examplePerformSupport?: PerformSupport;
+  performSupport?: PerformSupport;
   /**
    * The inputs to present a low-code integration builder. Values of these inputs
    * are passed to the `perform` function when the action is invoked.

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -6,18 +6,9 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { OutputSchema } from "./OutputSchema";
 
 /**
- * Declares whether an action's `perform` (or `experimentalExamplePerform`) may be
- * invoked inline to populate reference data in the Designer/EWB. `SAFE` means the
- * author attests it is safe to run as-is; `UNSAFE` means running it has side effects /
- * is not safe to invoke automatically; `NOT_ALLOWED` opts out entirely.
- *
- * Values are SCREAMING_SNAKE_CASE to match the backend GraphQL enum member names
- * verbatim — these strings are published and read back through GraphQL, where a
- * graphene Enum serializes by member name (not value), and spectral does no enum
- * value mapping. Experimental — the name set and semantics may change before this graduates.
- *
- * Exposed as a const companion so authors can reference `ExperimentalPerformSupport.SAFE`
- * instead of the raw string; the plain literal `"SAFE"` is still accepted everywhere.
+ * Whether an action may be invoked inline to populate reference data in the Designer/EWB:
+ * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
+ * Values are SCREAMING_SNAKE to match the backend GraphQL enum member names verbatim.
  */
 export const ExperimentalPerformSupport = {
   SAFE: "SAFE",

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -7,11 +7,26 @@ import type { OutputSchema } from "./OutputSchema";
 
 /**
  * Declares whether an action's `perform` (or `experimentalExamplePerform`) may be
- * invoked inline to populate reference data in the Designer/EWB. `safe` means the
- * author attests it is safe to run as-is; `auto` lets the platform decide; `notAllowed`
- * opts out. Experimental — the name set and semantics may change before this graduates.
+ * invoked inline to populate reference data in the Designer/EWB. `SAFE` means the
+ * author attests it is safe to run as-is; `UNSAFE` means running it has side effects /
+ * is not safe to invoke automatically; `NOT_ALLOWED` opts out entirely.
+ *
+ * Values are SCREAMING_SNAKE_CASE to match the backend GraphQL enum member names
+ * verbatim — these strings are published and read back through GraphQL, where a
+ * graphene Enum serializes by member name (not value), and spectral does no enum
+ * value mapping. Experimental — the name set and semantics may change before this graduates.
+ *
+ * Exposed as a const companion so authors can reference `ExperimentalPerformSupport.SAFE`
+ * instead of the raw string; the plain literal `"SAFE"` is still accepted everywhere.
  */
-export type ExperimentalPerformSupport = "safe" | "auto" | "notAllowed";
+export const ExperimentalPerformSupport = {
+  SAFE: "SAFE",
+  UNSAFE: "UNSAFE",
+  NOT_ALLOWED: "NOT_ALLOWED",
+} as const;
+
+export type ExperimentalPerformSupport =
+  (typeof ExperimentalPerformSupport)[keyof typeof ExperimentalPerformSupport];
 
 /**
  * ActionDefinition is the type of the object that is passed in to `action` function to

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -6,9 +6,8 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { OutputSchema } from "./OutputSchema";
 
 /**
- * Whether an action may be invoked inline to populate reference data in the Designer/EWB:
+ * Whether an action may be invoked inline to populate reference data in the Prismatic UI:
  * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
- * Values are SCREAMING_SNAKE to match the backend GraphQL enum member names verbatim.
  */
 export const PerformSupport = {
   SAFE: "SAFE",

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -6,17 +6,16 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { OutputSchema } from "./OutputSchema";
 
 /**
- * Whether an action may be invoked inline to populate reference data in the Prismatic UI:
+ * Whether a perform is safe to invoke inline (to populate reference data in the Prismatic UI):
  * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
  */
-export const PerformSupport = {
+export const PerformSafety = {
   SAFE: "SAFE",
   UNSAFE: "UNSAFE",
   NOT_ALLOWED: "NOT_ALLOWED",
 } as const;
 
-export type PerformSupport =
-  (typeof PerformSupport)[keyof typeof PerformSupport];
+export type PerformSafety = (typeof PerformSafety)[keyof typeof PerformSafety];
 
 /**
  * ActionDefinition is the type of the object that is passed in to `action` function to
@@ -49,8 +48,8 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
-  examplePerformSupport?: PerformSupport;
-  performSupport?: PerformSupport;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
   /**
    * The inputs to present a low-code integration builder. Values of these inputs
    * are passed to the `perform` function when the action is invoked.

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -6,6 +6,14 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { OutputSchema } from "./OutputSchema";
 
 /**
+ * Declares whether an action's `perform` (or `experimentalExamplePerform`) may be
+ * invoked inline to populate reference data in the Designer/EWB. `safe` means the
+ * author attests it is safe to run as-is; `auto` lets the platform decide; `notAllowed`
+ * opts out. Experimental — the name set and semantics may change before this graduates.
+ */
+export type ExperimentalPerformSupport = "safe" | "auto" | "notAllowed";
+
+/**
  * ActionDefinition is the type of the object that is passed in to `action` function to
  * define a component action. See
  * https://prismatic.io/docs/custom-connectors/actions/
@@ -36,8 +44,8 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
-  experimentalExamplePerformSupport?: "safe" | "auto" | "notAllowed";
-  experimentalPerformSupport?: "safe" | "auto" | "notAllowed";
+  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
+  experimentalPerformSupport?: ExperimentalPerformSupport;
   /**
    * The inputs to present a low-code integration builder. Values of these inputs
    * are passed to the `perform` function when the action is invoked.

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,4 +1,4 @@
-import type { ExperimentalPerformSupport } from "./ActionDefinition";
+import type { PerformSupport } from "./ActionDefinition";
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
@@ -26,9 +26,9 @@ export interface ComponentManifestAction {
   perform: (values: any) => Promise<unknown>;
   // Typed for completeness; the manifest generator emits no stub for it (it's invoked via
   // the published server action, not the manifest).
-  experimentalExamplePerform?: (values: any) => Promise<unknown>;
-  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
-  experimentalPerformSupport?: ExperimentalPerformSupport;
+  examplePerform?: (values: any) => Promise<unknown>;
+  examplePerformSupport?: PerformSupport;
+  performSupport?: PerformSupport;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
   /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -24,13 +24,8 @@ interface BaseInput {
 export interface ComponentManifestAction {
   key?: string;
   perform: (values: any) => Promise<unknown>;
-  /**
-   * Present only on manifests whose source carries an example perform. The generated
-   * manifest does not synthesize a delegating stub for it (there is no runtime
-   * `context.components` channel to delegate to, unlike `perform`); the example perform
-   * is invoked via the published server action. The `*Support` flags are the part the
-   * frontend reads from the manifest.
-   */
+  // Typed for completeness; the manifest generator emits no stub for it (it's invoked via
+  // the published server action, not the manifest).
   experimentalExamplePerform?: (values: any) => Promise<unknown>;
   experimentalExamplePerformSupport?: ExperimentalPerformSupport;
   experimentalPerformSupport?: ExperimentalPerformSupport;

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,3 +1,4 @@
+import type { ExperimentalPerformSupport } from "./ActionDefinition";
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
@@ -23,6 +24,16 @@ interface BaseInput {
 export interface ComponentManifestAction {
   key?: string;
   perform: (values: any) => Promise<unknown>;
+  /**
+   * Present only on manifests whose source carries an example perform. The generated
+   * manifest does not synthesize a delegating stub for it (there is no runtime
+   * `context.components` channel to delegate to, unlike `perform`); the example perform
+   * is invoked via the published server action. The `*Support` flags are the part the
+   * frontend reads from the manifest.
+   */
+  experimentalExamplePerform?: (values: any) => Promise<unknown>;
+  experimentalExamplePerformSupport?: ExperimentalPerformSupport;
+  experimentalPerformSupport?: ExperimentalPerformSupport;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
   /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,4 +1,4 @@
-import type { PerformSupport } from "./ActionDefinition";
+import type { PerformSafety } from "./ActionDefinition";
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
@@ -27,8 +27,8 @@ export interface ComponentManifestAction {
   // Typed for completeness; the manifest generator emits no stub for it (it's invoked via
   // the published server action, not the manifest).
   examplePerform?: (values: any) => Promise<unknown>;
-  examplePerformSupport?: PerformSupport;
-  performSupport?: PerformSupport;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
   /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */


### PR DESCRIPTION
# What

This adds support on the spectral side for inline action calling which lets the integration builder invoke an action's perform (or mock experimentalExamplePerform) from the Designer/EWB to populate live reference data.

# Changes

Author Facing type changes
- `ExperimentalPerformSupport` exposed along with a const companion which allows for authors to use either `ExperimentalPerformSupport.SAFE` or the string `"SAFE"` and get typechecking with both.
- Values are `"SAFE" | "UNSAFE" | "NOT_ALLOWED"` to match the backend graphQL enum type.

Publish-wire conversion
- `convertAction` wraps `experimentalExamplePerform` via`createPerform` to add input cleaning and error handling and mirroring `perform`. Its destructured out of the `...action` spread so the raw function doesn't leak onto the wire when it isn't wrapped. 
- The published `Action` wire type declares `experimentalExamplePerform` & both `experimentalExamplePerformSupport` and `experimentalPerformSupport` enums.

Component manifest
- `ComponentManifestAction` adds the two `*Support` scalars into the manifest so the frontend knows they are inline invokable. 
- `experimentalExamplePerform` is added to `ComponentManifestAction` type only. The generator doesn't emit a value or stub for it because its invoked by the published server action rather than the manifest.

CNI Component Manifest
- Threads the two `*Support` flags through the graphQL fetch path so components fetched from the API surface them.