### PR TITLE
Add support for inline action calling

### DIFF
--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -151,6 +151,8 @@ export const fetchComponentDataForManifest = async <
           },
           inputs: transformInputNodes(node.inputs.nodes),
           examplePayload: node.examplePayload,
+          ...(node.examplePerformSafety ? { examplePerformSafety: node.examplePerformSafety } : {}),
+          ...(node.performSafety ? { performSafety: node.performSafety } : {}),
         };
       }
     });
@@ -265,6 +267,8 @@ async function getComponentActions(componentId: string, prismaticUrl: string, ac
                 }
               }
               examplePayload
+              examplePerformSafety
+              performSafety
             }
             pageInfo {
               hasNextPage

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -1,6 +1,12 @@
-import type { Action, Component, DataSource, Trigger, TriggerPayload } from "../../serverTypes";
+import type {
+  Action,
+  Component,
+  DataSource,
+  PerformSafety,
+  Trigger,
+  TriggerPayload,
+} from "../../serverTypes";
 import type { ConfigVarResultCollection, Inputs } from "../../types";
-import type { PerformSafety } from "../../types/ActionDefinition";
 import type { TriggerResult } from "../../types/TriggerResult";
 
 export interface ComponentNode {

--- a/packages/spectral/src/generators/cniComponentManifest/types.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/types.ts
@@ -1,5 +1,6 @@
 import type { Action, Component, DataSource, Trigger, TriggerPayload } from "../../serverTypes";
 import type { ConfigVarResultCollection, Inputs } from "../../types";
+import type { PerformSafety } from "../../types/ActionDefinition";
 import type { TriggerResult } from "../../types/TriggerResult";
 
 export interface ComponentNode {
@@ -30,6 +31,8 @@ export interface ActionNode {
     nodes: InputNode[];
   };
   examplePayload: string | null;
+  examplePerformSafety: PerformSafety | null;
+  performSafety: PerformSafety | null;
 }
 
 export interface ConnectionNode {
@@ -52,7 +55,10 @@ export interface InputNode {
   onPremiseControlled: boolean;
 }
 
-export type FormattedAction = Pick<Action, "key" | "display" | "inputs" | "examplePayload"> & {
+export type FormattedAction = Pick<
+  Action,
+  "key" | "display" | "inputs" | "examplePayload" | "examplePerformSafety" | "performSafety"
+> & {
   /** Emitted verbatim into the generated manifest; shape mirrors `examplePayload`. */
   outputSchema?: unknown;
 };

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { fromServerPerformSafety } from "../../serverTypes/performSafety";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
 import type { PerformSafety } from "../../types/ActionDefinition";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
@@ -93,9 +94,11 @@ export const createActions = async <
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
           ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
           ...(action.examplePerformSafety
-            ? { examplePerformSafety: action.examplePerformSafety }
+            ? { examplePerformSafety: fromServerPerformSafety(action.examplePerformSafety) }
             : {}),
-          ...(action.performSafety ? { performSafety: action.performSafety } : {}),
+          ...(action.performSafety
+            ? { performSafety: fromServerPerformSafety(action.performSafety) }
+            : {}),
           componentKey: component.key,
         },
         imports,

--- a/packages/spectral/src/generators/componentManifest/createActions.ts
+++ b/packages/spectral/src/generators/componentManifest/createActions.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import type { ConfigVarResultCollection, Inputs, TriggerPayload, TriggerResult } from "../../types";
+import type { PerformSafety } from "../../types/ActionDefinition";
 import type { ComponentForManifest } from "../cniComponentManifest/types";
 import { createImport } from "../utils/createImport";
 import { createTemplate } from "../utils/createTemplate";
@@ -91,6 +92,10 @@ export const createActions = async <
           inputs,
           ...(action.examplePayload ? { examplePayload: action.examplePayload } : {}),
           ...(action.outputSchema ? { outputSchema: action.outputSchema } : {}),
+          ...(action.examplePerformSafety
+            ? { examplePerformSafety: action.examplePerformSafety }
+            : {}),
+          ...(action.performSafety ? { performSafety: action.performSafety } : {}),
           componentKey: component.key,
         },
         imports,
@@ -150,6 +155,8 @@ interface RenderActionProps {
     inputs: Input[];
     examplePayload?: unknown;
     outputSchema?: unknown;
+    examplePerformSafety?: PerformSafety;
+    performSafety?: PerformSafety;
     componentKey: string;
   };
   dryRun: boolean;

--- a/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/actions/action.ts.ejs
@@ -28,4 +28,10 @@ export const <%= action.import %> = {
   <%_ if (action.outputSchema) { -%>
   outputSchema: <%- typeof action.outputSchema === 'string' ? action.outputSchema : JSON.stringify(action.outputSchema, null, 2) %>,
   <%_ } -%>
+  <%_ if (action.examplePerformSafety) { -%>
+  examplePerformSafety: "<%= action.examplePerformSafety %>",
+  <%_ } -%>
+  <%_ if (action.performSafety) { -%>
+  performSafety: "<%= action.performSafety %>",
+  <%_ } -%>
 } as const;

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -76,12 +76,12 @@ describe("convertAction", () => {
         display: baseDisplay,
         inputs: {},
         perform: async () => ({ data: null }),
-        performSafety: PerformSafety.UNSAFE,
+        performSafety: PerformSafety.SAFE,
         examplePerformSafety: PerformSafety.NOT_ALLOWED,
       }),
     );
 
-    expect(converted.performSafety).toBe("UNSAFE");
+    expect(converted.performSafety).toBe("SAFE");
     expect(converted.examplePerformSafety).toBe("NOT_ALLOWED");
   });
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -17,6 +17,22 @@ import {
   convertTemplateInput,
   convertTrigger,
 } from "./convertComponent";
+import { fromServerPerformSafety, toServerPerformSafety } from "./performSafety";
+
+describe("performSafety wire conversion", () => {
+  it("converts author values to GraphQL enum names and back", () => {
+    expect(toServerPerformSafety("safe")).toBe("SAFE");
+    expect(toServerPerformSafety("notAllowed")).toBe("NOT_ALLOWED");
+    expect(fromServerPerformSafety("SAFE")).toBe(PerformSafety.SAFE);
+    expect(fromServerPerformSafety("NOT_ALLOWED")).toBe(PerformSafety.NOT_ALLOWED);
+  });
+
+  it("round-trips every PerformSafety member", () => {
+    for (const value of Object.values(PerformSafety)) {
+      expect(fromServerPerformSafety(toServerPerformSafety(value))).toBe(value);
+    }
+  });
+});
 
 describe("convertConnection", () => {
   const label = "My Basic Connection";
@@ -69,7 +85,7 @@ describe("convertAction", () => {
     expect(result).toStrictEqual({ data: { count: 42 } });
   });
 
-  it("carries the safety enums through to the server action (const companion)", () => {
+  it("converts the safety values to their wire form (enum names)", () => {
     const converted = convertAction(
       "doThing",
       action({
@@ -77,7 +93,8 @@ describe("convertAction", () => {
         inputs: {},
         perform: async () => ({ data: null }),
         performSafety: PerformSafety.SAFE,
-        examplePerformSafety: PerformSafety.NOT_ALLOWED,
+        // Plain-string authoring must typecheck alongside the const companion.
+        examplePerformSafety: "notAllowed",
       }),
     );
 

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -5,11 +5,13 @@ import {
   connection,
   dynamicObjectInput,
   input,
+  PerformSafety,
   structuredObjectInput,
   trigger,
 } from "..";
 import {
   cleanerFor,
+  convertAction,
   convertConnection,
   convertInput,
   convertTemplateInput,
@@ -33,6 +35,70 @@ describe("convertConnection", () => {
     const convertedConnection = convertConnection(basicConnection);
     expect(convertedConnection.label).toBe(label);
     expect(convertedConnection.comments).toBe(description);
+  });
+});
+
+describe("convertAction", () => {
+  const baseDisplay = { label: "Do Thing", description: "Does a thing." };
+
+  it("wraps examplePerform so it is invokable with input cleaning applied", async () => {
+    const examplePerform = vi.fn(async (_context: any, params: any) => ({
+      data: params,
+    }));
+
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {
+          count: input({ type: "string", label: "Count", clean: (v) => Number(v) }),
+        },
+        perform: async () => ({ data: null }),
+        examplePerform: examplePerform,
+        examplePerformSafety: PerformSafety.SAFE,
+      }),
+    );
+
+    expect(converted.examplePerform).toBeDefined();
+    expect(typeof converted.examplePerform).toBe("function");
+
+    const result = await converted.examplePerform?.({} as any, { count: "42" });
+
+    // The cleaner ran ("42" -> 42) before reaching the author's example perform.
+    expect(examplePerform).toHaveBeenCalledWith(expect.anything(), { count: 42 });
+    expect(result).toStrictEqual({ data: { count: 42 } });
+  });
+
+  it("carries the safety enums through to the server action (const companion)", () => {
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {},
+        perform: async () => ({ data: null }),
+        performSafety: PerformSafety.UNSAFE,
+        examplePerformSafety: PerformSafety.NOT_ALLOWED,
+      }),
+    );
+
+    expect(converted.performSafety).toBe("UNSAFE");
+    expect(converted.examplePerformSafety).toBe("NOT_ALLOWED");
+  });
+
+  it("omits examplePerform when the author does not define it", () => {
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {},
+        perform: async () => ({ data: null }),
+      }),
+    );
+
+    // Must be absent, not an unwrapped/throwing function leaked via the spread.
+    expect("examplePerform" in converted).toBe(false);
+    expect(converted.examplePerformSafety).toBeUndefined();
+    expect(converted.performSafety).toBeUndefined();
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -384,9 +384,15 @@ const convertOutputSchema = (outputSchema: OutputSchema): ServerOutputSchema => 
   };
 };
 
-const convertAction = (
+export const convertAction = (
   actionKey: string,
-  { inputs = {}, perform, outputSchema, ...action }: ActionDefinition<Inputs, any, boolean, any>,
+  {
+    inputs = {},
+    perform,
+    outputSchema,
+    examplePerform,
+    ...action
+  }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
 ): ServerAction => {
   const convertedInputs = Object.entries(inputs).map(([key, value]) => convertInput(key, value));
@@ -404,6 +410,14 @@ const convertAction = (
       errorHandler: hooks?.error,
     }),
     ...(outputSchema ? { outputSchema: convertOutputSchema(outputSchema) } : {}),
+    ...(examplePerform
+      ? {
+          examplePerform: createPerform(examplePerform, {
+            inputCleaners,
+            errorHandler: hooks?.error,
+          }),
+        }
+      : {}),
   };
 };
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -40,6 +40,7 @@ import {
   type InputCleaners,
   type PerformFn,
 } from "./perform";
+import { toServerPerformSafety } from "./performSafety";
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -391,6 +392,8 @@ export const convertAction = (
     perform,
     outputSchema,
     examplePerform,
+    performSafety,
+    examplePerformSafety,
     ...action
   }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
@@ -417,6 +420,10 @@ export const convertAction = (
             errorHandler: hooks?.error,
           }),
         }
+      : {}),
+    ...(performSafety ? { performSafety: toServerPerformSafety(performSafety) } : {}),
+    ...(examplePerformSafety
+      ? { examplePerformSafety: toServerPerformSafety(examplePerformSafety) }
       : {}),
   };
 };

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -15,6 +15,7 @@ import type {
   Inputs,
   InstanceAttributes,
   IntegrationAttributes,
+  PerformSafety,
   PollingTriggerPerformFunction,
   TriggerEventFunctionReturn,
   TriggerPerformFunction,
@@ -89,6 +90,9 @@ export interface Action {
    * from the author-facing `OutputSchema`.
    */
   outputSchema?: ServerOutputSchema;
+  examplePerform?: ActionPerformFunction;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
 }
 
 export type ServerOutputSchema =

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -15,7 +15,6 @@ import type {
   Inputs,
   InstanceAttributes,
   IntegrationAttributes,
-  PerformSafety,
   PollingTriggerPerformFunction,
   TriggerEventFunctionReturn,
   TriggerPerformFunction,
@@ -98,6 +97,13 @@ export interface Action {
 export type ServerOutputSchema =
   | { type: "actionOutput"; schema: string }
   | { type: "branchingOutput"; branchSchemas: Array<{ name: string; schema: string }> };
+
+/**
+ * On-the-wire form of the author-facing `PerformSafety`. The platform exposes
+ * the field as the `ActionPerformSafety` GraphQL enum, which serializes member
+ * names. Converted to and from the author-facing camelCase.
+ */
+export type PerformSafety = "SAFE" | "NOT_ALLOWED";
 
 export type ActionLoggerFunction = (...args: unknown[]) => void;
 

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -4,8 +4,9 @@
  *
  * Scope is conversion output only: which fields land on the wire, with what values.
  * It does not verify runtime dispatch (SAFE vs. NOT_ALLOWED choosing
- * which perform runs) — the safety flags are inert metadata spectral passes through
- * verbatim, and the runner decides at execution time.
+ * which perform runs) — the safety flags are inert metadata, converted from the
+ * author-facing camelCase values to the platform's GraphQL enum names, and the
+ * runner decides at execution time.
  */
 import { renderFile } from "ejs";
 import path from "path";
@@ -101,7 +102,7 @@ describe("inline action calling: publish-wire conversion output", () => {
     expect(a.examplePerformSafety).toBeUndefined();
   });
 
-  it("D — real-perform NOT_ALLOWED flag carried verbatim; no example perform", () => {
+  it("D — real-perform notAllowed converts to NOT_ALLOWED; no example perform", () => {
     const a = actionsByKey.notAllowedPerformAction;
     expect(a.performSafety).toBe("NOT_ALLOWED");
     expect("examplePerform" in a).toBe(false);
@@ -144,16 +145,16 @@ describe("inline action calling: component-manifest emit", () => {
 
   it("emits both *Safety scalars when present", async () => {
     const out = await render({
-      examplePerformSafety: "SAFE",
-      performSafety: "NOT_ALLOWED",
+      examplePerformSafety: "safe",
+      performSafety: "notAllowed",
     });
-    expect(out).toContain('examplePerformSafety: "SAFE"');
-    expect(out).toContain('performSafety: "NOT_ALLOWED"');
+    expect(out).toContain('examplePerformSafety: "safe"');
+    expect(out).toContain('performSafety: "notAllowed"');
   });
 
-  it("emits a NOT_ALLOWED performSafety scalar verbatim", async () => {
-    const out = await render({ performSafety: "NOT_ALLOWED" });
-    expect(out).toContain('performSafety: "NOT_ALLOWED"');
+  it("emits a notAllowed performSafety scalar", async () => {
+    const out = await render({ performSafety: "notAllowed" });
+    expect(out).toContain('performSafety: "notAllowed"');
   });
 
   it("omits the *Safety scalars when absent (permutation A)", async () => {
@@ -164,8 +165,8 @@ describe("inline action calling: component-manifest emit", () => {
 
   it("never emits an examplePerform stub (invoked via the server action, not the manifest)", async () => {
     const out = await render({
-      examplePerformSafety: "SAFE",
-      performSafety: "NOT_ALLOWED",
+      examplePerformSafety: "safe",
+      performSafety: "notAllowed",
     });
     expect(out).not.toContain("examplePerform:");
   });

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Verifies what spectral serializes for the inline-action example-perform fields
+ * on publish — the converted server component `prism component publish` sends.
+ *
+ * Scope is conversion output only: which fields land on the wire, with what values.
+ * It does not verify runtime dispatch (SAFE vs. UNSAFE vs. NOT_ALLOWED choosing
+ * which perform runs) — the safety flags are inert metadata spectral passes through
+ * verbatim, and the runner decides at execution time.
+ */
+import { renderFile } from "ejs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { helpers } from "../generators/componentManifest/helpers";
+import { action, component, input, PerformSafety, structuredObjectInput } from "../index";
+
+const display = (label: string) => ({ label, description: label });
+
+// Three input shapes exercised on every permutation.
+const connectionInput = input({ label: "Connection", type: "connection", required: true });
+const structuredInput = structuredObjectInput({
+  label: "Name",
+  inputs: {
+    first: input({ type: "string", label: "First", required: true }),
+    last: input({ type: "string", label: "Last", required: true }),
+  },
+});
+const collectionInput = input({ label: "Tags", type: "string", collection: "valuelist" });
+
+const sharedInputs = {
+  connection: connectionInput,
+  name: structuredInput,
+  tags: collectionInput,
+};
+
+const noop = async () => ({ data: null });
+const echo = async (_ctx: any, params: any) => ({ data: params });
+
+// Action permutations.
+const testComponent = component({
+  key: "inline-action-testbed",
+  public: false,
+  display: { ...display("Inline Action Testbed"), iconPath: "icon.png" },
+  actions: {
+    // A — no inline-calling fields.
+    plainAction: action({
+      display: display("Plain Action"),
+      inputs: sharedInputs,
+      perform: noop,
+    }),
+    // B — example perform + its safety flag.
+    examplePerformAction: action({
+      display: display("Example Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      examplePerform: echo,
+      examplePerformSafety: PerformSafety.SAFE,
+    }),
+    // C — real perform marked runnable.
+    runnablePerformAction: action({
+      display: display("Runnable Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      performSafety: PerformSafety.UNSAFE,
+    }),
+    // D — real perform marked not runnable.
+    notAllowedPerformAction: action({
+      display: display("Not Allowed Perform Action"),
+      inputs: sharedInputs,
+      perform: noop,
+      performSafety: PerformSafety.NOT_ALLOWED,
+    }),
+  },
+});
+
+// Converted actions are keyed by action key.
+const actionsByKey = testComponent.actions as Record<string, any>;
+
+describe("inline action calling: publish-wire conversion output", () => {
+  it("A — plain action: no inline-calling fields leak onto the wire", () => {
+    const a = actionsByKey.plainAction;
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSafety).toBeUndefined();
+    expect(a.performSafety).toBeUndefined();
+  });
+
+  it("B — example perform is wrapped (invokable) and its safety flag is carried", async () => {
+    const a = actionsByKey.examplePerformAction;
+    expect(typeof a.examplePerform).toBe("function");
+    expect(a.examplePerformSafety).toBe("SAFE");
+    // Only the field the author set is carried; no performSafety leaks in.
+    expect(a.performSafety).toBeUndefined();
+    // Wrapped fn is invokable and passes params through.
+    const result: any = await a.examplePerform?.({} as any, { tags: ["x"] });
+    expect(result.data.tags).toStrictEqual(["x"]);
+  });
+
+  it("C — real-perform UNSAFE flag carried; no separate example perform", () => {
+    const a = actionsByKey.runnablePerformAction;
+    expect(a.performSafety).toBe("UNSAFE");
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSafety).toBeUndefined();
+  });
+
+  it("D — real-perform NOT_ALLOWED flag carried verbatim; no example perform", () => {
+    const a = actionsByKey.notAllowedPerformAction;
+    expect(a.performSafety).toBe("NOT_ALLOWED");
+    expect("examplePerform" in a).toBe(false);
+    expect(a.examplePerformSafety).toBeUndefined();
+  });
+
+  it("the three input shapes survive conversion on every permutation", () => {
+    for (const key of [
+      "plainAction",
+      "examplePerformAction",
+      "runnablePerformAction",
+      "notAllowedPerformAction",
+    ]) {
+      const inputs = actionsByKey[key].inputs;
+      const byKey = Object.fromEntries(inputs.map((i: any) => [i.key, i]));
+      expect(byKey.connection.type).toBe("connection");
+      expect(byKey.name.type).toBe("structuredObject");
+      expect(byKey.name.inputs).toHaveLength(2); // nested children survived
+      expect(byKey.tags.collection).toBe("valuelist");
+    }
+  });
+});
+
+describe("inline action calling: component-manifest emit", () => {
+  const templatePath = path.join(
+    __dirname,
+    "../generators/componentManifest/templates/actions/action.ts.ejs",
+  );
+  const baseAction = {
+    typeInterface: "DoThing",
+    import: "doThing",
+    key: "doThing",
+    label: "Do Thing",
+    description: "Does a thing.",
+    inputs: [],
+    componentKey: "testbed",
+  };
+  const render = (extra: Record<string, unknown>) =>
+    renderFile(templatePath, { action: { ...baseAction, ...extra }, helpers, imports: {} });
+
+  it("emits both *Safety scalars when present", async () => {
+    const out = await render({
+      examplePerformSafety: "SAFE",
+      performSafety: "UNSAFE",
+    });
+    expect(out).toContain('examplePerformSafety: "SAFE"');
+    expect(out).toContain('performSafety: "UNSAFE"');
+  });
+
+  it("emits a NOT_ALLOWED performSafety scalar verbatim", async () => {
+    const out = await render({ performSafety: "NOT_ALLOWED" });
+    expect(out).toContain('performSafety: "NOT_ALLOWED"');
+  });
+
+  it("omits the *Safety scalars when absent (permutation A)", async () => {
+    const out = await render({});
+    expect(out).not.toContain("examplePerformSafety");
+    expect(out).not.toContain("performSafety");
+  });
+
+  it("never emits an examplePerform stub (invoked via the server action, not the manifest)", async () => {
+    const out = await render({
+      examplePerformSafety: "SAFE",
+      performSafety: "UNSAFE",
+    });
+    expect(out).not.toContain("examplePerform:");
+  });
+});

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -3,7 +3,7 @@
  * on publish — the converted server component `prism component publish` sends.
  *
  * Scope is conversion output only: which fields land on the wire, with what values.
- * It does not verify runtime dispatch (SAFE vs. UNSAFE vs. NOT_ALLOWED choosing
+ * It does not verify runtime dispatch (SAFE vs. NOT_ALLOWED choosing
  * which perform runs) — the safety flags are inert metadata spectral passes through
  * verbatim, and the runner decides at execution time.
  */
@@ -60,7 +60,7 @@ const testComponent = component({
       display: display("Runnable Perform Action"),
       inputs: sharedInputs,
       perform: noop,
-      performSafety: PerformSafety.UNSAFE,
+      performSafety: PerformSafety.SAFE,
     }),
     // D — real perform marked not runnable.
     notAllowedPerformAction: action({
@@ -94,9 +94,9 @@ describe("inline action calling: publish-wire conversion output", () => {
     expect(result.data.tags).toStrictEqual(["x"]);
   });
 
-  it("C — real-perform UNSAFE flag carried; no separate example perform", () => {
+  it("C — real-perform SAFE flag carried; no separate example perform", () => {
     const a = actionsByKey.runnablePerformAction;
-    expect(a.performSafety).toBe("UNSAFE");
+    expect(a.performSafety).toBe("SAFE");
     expect("examplePerform" in a).toBe(false);
     expect(a.examplePerformSafety).toBeUndefined();
   });
@@ -145,10 +145,10 @@ describe("inline action calling: component-manifest emit", () => {
   it("emits both *Safety scalars when present", async () => {
     const out = await render({
       examplePerformSafety: "SAFE",
-      performSafety: "UNSAFE",
+      performSafety: "NOT_ALLOWED",
     });
     expect(out).toContain('examplePerformSafety: "SAFE"');
-    expect(out).toContain('performSafety: "UNSAFE"');
+    expect(out).toContain('performSafety: "NOT_ALLOWED"');
   });
 
   it("emits a NOT_ALLOWED performSafety scalar verbatim", async () => {
@@ -165,7 +165,7 @@ describe("inline action calling: component-manifest emit", () => {
   it("never emits an examplePerform stub (invoked via the server action, not the manifest)", async () => {
     const out = await render({
       examplePerformSafety: "SAFE",
-      performSafety: "UNSAFE",
+      performSafety: "NOT_ALLOWED",
     });
     expect(out).not.toContain("examplePerform:");
   });

--- a/packages/spectral/src/serverTypes/performSafety.ts
+++ b/packages/spectral/src/serverTypes/performSafety.ts
@@ -1,0 +1,10 @@
+import camelCase from "lodash/camelCase";
+import snakeCase from "lodash/snakeCase";
+import type { PerformSafety } from "../types";
+import type { PerformSafety as ServerPerformSafety } from ".";
+
+export const toServerPerformSafety = (value: PerformSafety): ServerPerformSafety =>
+  snakeCase(value).toUpperCase() as ServerPerformSafety;
+
+export const fromServerPerformSafety = (value: ServerPerformSafety): PerformSafety =>
+  camelCase(value) as PerformSafety;

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -7,11 +7,10 @@ import type { OutputSchema } from "./OutputSchema";
 
 /**
  * Whether a perform is safe to invoke inline (to populate reference data in the Prismatic UI):
- * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
+ * `SAFE` to run as-is, `NOT_ALLOWED` to opt out.
  */
 export const PerformSafety = {
   SAFE: "SAFE",
-  UNSAFE: "UNSAFE",
   NOT_ALLOWED: "NOT_ALLOWED",
 } as const;
 

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -6,6 +6,18 @@ import type { ConfigVarResultCollection, Inputs } from "./Inputs";
 import type { OutputSchema } from "./OutputSchema";
 
 /**
+ * Whether a perform is safe to invoke inline (to populate reference data in the Prismatic UI):
+ * `SAFE` to run as-is, `UNSAFE` if running has side effects, `NOT_ALLOWED` to opt out.
+ */
+export const PerformSafety = {
+  SAFE: "SAFE",
+  UNSAFE: "UNSAFE",
+  NOT_ALLOWED: "NOT_ALLOWED",
+} as const;
+
+export type PerformSafety = (typeof PerformSafety)[keyof typeof PerformSafety];
+
+/**
  * ActionDefinition is the type of the object that is passed in to `action` function to
  * define a component action. See
  * https://prismatic.io/docs/custom-connectors/actions/
@@ -29,6 +41,15 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
+  examplePerform?: ActionPerformFunction<
+    TInputs,
+    TConfigVars,
+    Record<string, Record<string, ComponentManifestAction>>,
+    TAllowsBranching,
+    TReturn
+  >;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
   /**
    * The inputs to present a low-code integration builder. Values of these inputs
    * are passed to the `perform` function when the action is invoked.

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -7,11 +7,11 @@ import type { OutputSchema } from "./OutputSchema";
 
 /**
  * Whether a perform is safe to invoke inline (to populate reference data in the Prismatic UI):
- * `SAFE` to run as-is, `NOT_ALLOWED` to opt out.
+ * `safe` to run as-is, `notAllowed` to opt out.
  */
 export const PerformSafety = {
-  SAFE: "SAFE",
-  NOT_ALLOWED: "NOT_ALLOWED",
+  SAFE: "safe",
+  NOT_ALLOWED: "notAllowed",
 } as const;
 
 export type PerformSafety = (typeof PerformSafety)[keyof typeof PerformSafety];

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -1,3 +1,4 @@
+import type { PerformSafety } from "./ActionDefinition";
 import type { CollectionType } from "./ConfigVars";
 import type { DataSourceType } from "./DataSourceResult";
 import type { InputFieldType } from "./Inputs";
@@ -23,6 +24,11 @@ interface BaseInput {
 export interface ComponentManifestAction {
   key?: string;
   perform: (values: any) => Promise<unknown>;
+  // Typed for completeness; the manifest generator emits no stub for it (it's invoked via
+  // the published server action, not the manifest).
+  examplePerform?: (values: any) => Promise<unknown>;
+  examplePerformSafety?: PerformSafety;
+  performSafety?: PerformSafety;
   inputs: Record<string, BaseInput>;
   examplePayload?: unknown;
   /** Declares the shape of this action's output `data` as a JSON Schema (discriminated union: actionOutput | branchingOutput). */

--- a/packages/spectral/src/types/ComponentManifest.ts
+++ b/packages/spectral/src/types/ComponentManifest.ts
@@ -24,8 +24,6 @@ interface BaseInput {
 export interface ComponentManifestAction {
   key?: string;
   perform: (values: any) => Promise<unknown>;
-  // Typed for completeness; the manifest generator emits no stub for it (it's invoked via
-  // the published server action, not the manifest).
   examplePerform?: (values: any) => Promise<unknown>;
   examplePerformSafety?: PerformSafety;
   performSafety?: PerformSafety;


### PR DESCRIPTION
# What
This adds support on the spectral side for inline action calling which lets the integration builder invoke an action's perform (or mock examplePerform) from the Designer/EWB to populate live reference data.

# Changes
Author Facing type changes
- `PerformSafety` exposed along with a const companion which allows for authors to use either `PerformSafety.safe` or the string `"safe"` and get typechecking with both.
- Values are `"safe" | "notAllowed"` to match the backend graphQL enum type (`ActionPerformSafety`).

Publish-wire conversion
- `convertAction` wraps `examplePerform` via `createPerform` to add input cleaning and error handling and mirroring `perform`. Its destructured out of the `...action` spread so the raw function doesn't leak onto the wire when it isn't wrapped.
The published `Action` wire type declares `examplePerform` & both `examplePerformSafety` and `performSafety` fields.

Component manifest
- `ComponentManifestAction` adds the two `*Safety` scalars into the manifest so the frontend knows they are inline invokable.
- `examplePerform` is added to `ComponentManifestAction` type only. The generator doesn't emit a value or stub for it because its invoked by the published server action rather than the manifest.

CNI Component Manifest
- Threads the two `*Safety` flags through the graphQL fetch path so components fetched from the API surface them.