### PR TITLE
Fix stable key and redirect urls leaking into component types

### DIFF
--- a/packages/spectral-test/src/ConfigVars.test-d.ts
+++ b/packages/spectral-test/src/ConfigVars.test-d.ts
@@ -5,7 +5,8 @@ import type {
   Connection,
   DataSourceConfigVar,
 } from "@prismatic-io/spectral";
-import type { ValueOf } from "@prismatic-io/spectral/dist/types";
+import { OAuth2Type } from "@prismatic-io/spectral";
+import type { ValueOf } from "@prismatic-io/spectral/dist/types/utils";
 import { expectAssignable, expectNotType } from "tsd";
 
 type RawConnectionElems = ValueOf<ConfigPages>["elements"];
@@ -17,6 +18,41 @@ expectAssignable<"A Connection" | "Ref Connection">(null as unknown as keyof Con
 expectAssignable<Connection>(null as unknown as ConfigVars["A Connection"]);
 expectAssignable<Connection>(null as unknown as ConfigVars["Ref Connection"]);
 expectAssignable<Connection>(null as unknown as ConfigVars["My Customer Connection"]);
+
+expectAssignable<ConfigVar>({
+  stableKey: "cni-oauth-connection",
+  dataType: "connection",
+  oauth2Type: OAuth2Type.AuthorizationCode,
+  oauth2Config: {
+    allowedTokenParams: ["state"],
+    overrideGrantType: "authorization_code",
+    oAuthSuccessRedirectUri: "https://example.com/success",
+    oAuthFailureRedirectUri: "https://example.com/failure",
+  },
+  inputs: {
+    authorizeUrl: { label: "Authorize URL", type: "string", required: true },
+    tokenUrl: { label: "Token URL", type: "string", required: true },
+    scopes: { label: "Scopes", type: "string", required: true },
+    clientId: { label: "Client ID", type: "string", required: true },
+    clientSecret: { label: "Client Secret", type: "password", required: true },
+  },
+});
+
+expectAssignable<ConfigVar>({
+  stableKey: "cni-client-credentials-connection",
+  dataType: "connection",
+  oauth2Type: OAuth2Type.ClientCredentials,
+  oauth2Config: {
+    oAuthSuccessRedirectUri: "https://example.com/success",
+    oAuthFailureRedirectUri: "https://example.com/failure",
+  },
+  inputs: {
+    tokenUrl: { label: "Token URL", type: "string", required: true },
+    scopes: { label: "Scopes", type: "string", required: true },
+    clientId: { label: "Client ID", type: "string", required: true },
+    clientSecret: { label: "Client Secret", type: "password", required: true },
+  },
+});
 
 // Having both a dataSource & dataSourceType in a DataSourceConfigVar is invalid
 expectNotType<DataSourceConfigVar>({

--- a/packages/spectral-test/src/ConnectionDefinition.test-d.ts
+++ b/packages/spectral-test/src/ConnectionDefinition.test-d.ts
@@ -1,5 +1,11 @@
-import { type OnPremConnectionDefinition, onPremConnection } from "@prismatic-io/spectral";
-import { expectAssignable, expectNotAssignable } from "tsd";
+import {
+  connection,
+  OAuth2Type,
+  type OnPremConnectionDefinition,
+  oauth2Connection,
+  onPremConnection,
+} from "@prismatic-io/spectral";
+import { expectAssignable, expectError, expectNotAssignable } from "tsd";
 
 const valid = onPremConnection({
   key: "basic",
@@ -68,3 +74,45 @@ const invalid = {
   },
 };
 expectNotAssignable<OnPremConnectionDefinition>(invalid);
+
+expectError(
+  connection({
+    key: "basic",
+    stableKey: "basic-stable-key",
+    display: { label: "Basic", description: "" },
+    inputs: {},
+  }),
+);
+
+expectError(onPremConnection({ ...valid, stableKey: "on-prem-stable-key" }));
+
+const oauthInputs = {
+  authorizeUrl: { label: "Authorize URL", type: "string" as const, required: true },
+  tokenUrl: { label: "Token URL", type: "string" as const, required: true },
+  scopes: { label: "Scopes", type: "string" as const, required: true },
+  clientId: { label: "Client ID", type: "string" as const, required: true },
+  clientSecret: { label: "Client Secret", type: "password" as const, required: true },
+};
+
+expectError(
+  oauth2Connection({
+    key: "oauth",
+    stableKey: "oauth-stable-key",
+    display: { label: "OAuth", description: "" },
+    oauth2Type: OAuth2Type.AuthorizationCode,
+    inputs: oauthInputs,
+  }),
+);
+
+expectError(
+  oauth2Connection({
+    key: "oauth",
+    display: { label: "OAuth", description: "" },
+    oauth2Type: OAuth2Type.AuthorizationCode,
+    oauth2Config: {
+      oAuthSuccessRedirectUri: "https://example.com/success",
+      oAuthFailureRedirectUri: "https://example.com/failure",
+    },
+    inputs: oauthInputs,
+  }),
+);

--- a/packages/spectral-test/src/Utils.test-d.ts
+++ b/packages/spectral-test/src/Utils.test-d.ts
@@ -1,0 +1,33 @@
+import type { Exact } from "@prismatic-io/spectral/dist/types/utils";
+import { expectAssignable, expectNotAssignable } from "tsd";
+
+type Shape = {
+  required: string;
+  optional?: number;
+};
+
+expectAssignable<Exact<Shape, { required: string }>>({ required: "value" });
+expectAssignable<Exact<Shape, { required: string; optional: number }>>({
+  required: "value",
+  optional: 1,
+});
+expectNotAssignable<Exact<Shape, { required: string; extra: boolean }>>({
+  required: "value",
+  extra: true,
+});
+
+type Variant = { type: "first"; first: string } | { type: "second"; second: number };
+
+expectAssignable<Exact<Variant, { type: "first"; first: string }>>({
+  type: "first",
+  first: "value",
+});
+expectAssignable<Exact<Variant, { type: "second"; second: number }>>({
+  type: "second",
+  second: 1,
+});
+expectNotAssignable<Exact<Variant, { type: "first"; first: string; second: number }>>({
+  type: "first",
+  first: "value",
+  second: 1,
+});

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -26,6 +26,7 @@ import type {
   InputFieldDefinition,
   Inputs,
   IntegrationDefinition,
+  OAuth2Config,
   OAuth2ConnectionDefinition,
   OnPremConnectionDefinition,
   OrganizationActivatedConnectionConfigVar,
@@ -37,6 +38,7 @@ import type {
   TriggerResult,
 } from "./types";
 import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
+import type { Exact } from "./types/utils";
 
 /**
  * This function creates a code-native integration object that can be
@@ -876,7 +878,9 @@ export const dynamicObjectInput = <
  *   },
  * });
  */
-export const connection = <T extends DefaultConnectionDefinition>(definition: T): T => definition;
+export const connection = <T extends DefaultConnectionDefinition>(
+  definition: Exact<DefaultConnectionDefinition, T>,
+): T => definition;
 
 /**
  * This function creates an on-prem connection for a code-native integration or custom component.
@@ -923,8 +927,9 @@ export const connection = <T extends DefaultConnectionDefinition>(definition: T)
  *   },
  * });
  */
-export const onPremConnection = <T extends OnPremConnectionDefinition>(definition: T): T =>
-  definition;
+export const onPremConnection = <T extends OnPremConnectionDefinition>(
+  definition: Exact<OnPremConnectionDefinition, T>,
+): T => definition;
 
 /**
  * This function creates an OAuth 2.0 connection for a code-native integration or custom component.
@@ -979,8 +984,14 @@ export const onPremConnection = <T extends OnPremConnectionDefinition>(definitio
  *   },
  * });
  */
-export const oauth2Connection = <T extends OAuth2ConnectionDefinition>(definition: T): T =>
-  definition;
+export const oauth2Connection = <T extends OAuth2ConnectionDefinition>(
+  definition: Exact<OAuth2ConnectionDefinition, T> &
+    (T extends { oauth2Config?: infer TConfig }
+      ? {
+          oauth2Config?: TConfig extends OAuth2Config ? Exact<OAuth2Config, TConfig> : never;
+        }
+      : object),
+): T => definition;
 
 /**
  * Register multiple component manifests for a code-native integration.

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -10,7 +10,12 @@ import type {
   ConfigPages,
   UserLevelConfigPages,
 } from "./ConfigPages";
-import type { ConnectionDefinition } from "./ConnectionDefinition";
+import type {
+  ConnectionDefinition,
+  OAuth2Config,
+  OAuth2ConnectionDefinition,
+  OAuth2Type,
+} from "./ConnectionDefinition";
 import type { DataSourceDefinition } from "./DataSourceDefinition";
 import type { CollectionDataSourceType, DataSourceType } from "./DataSourceResult";
 import type {
@@ -309,13 +314,37 @@ type BaseConnectionConfigVar = BaseConfigVar & {
   dataType: "connection";
 };
 
+export interface OAuth2UrlOverrides {
+  /**
+   * Custom URI where users should be sent on OAuth success. See
+   * https://prismatic.io/docs/integrations/connections/oauth2/custom-redirects/
+   */
+  oAuthSuccessRedirectUri?: string;
+  /**
+   * Custom URI where users should be sent on OAuth failure. See
+   * https://prismatic.io/docs/integrations/connections/oauth2/custom-redirects/
+   */
+  oAuthFailureRedirectUri?: string;
+}
+
+type ConnectionConfigVarOAuth2Config<TConnectionDefinition extends ConnectionDefinition> =
+  TConnectionDefinition extends OAuth2ConnectionDefinition
+    ? {
+        oauth2Config?: (TConnectionDefinition extends { oauth2Type: OAuth2Type.AuthorizationCode }
+          ? Omit<OAuth2Config, keyof OAuth2UrlOverrides>
+          : object) &
+          OAuth2UrlOverrides;
+      }
+    : object;
+
 export type OnPremiseConnectionConfigTypeEnum = "allowed" | "disallowed" | "required";
 
 type ConnectionDefinitionConfigVar =
   ConnectionDefinition extends infer TConnectionDefinitionType extends ConnectionDefinition
     ? TConnectionDefinitionType extends infer TConnectionDefinition extends ConnectionDefinition
       ? BaseConnectionConfigVar &
-          Omit<TConnectionDefinition, "inputs" | "display" | "key"> & {
+          Omit<TConnectionDefinition, "inputs" | "display" | "key" | "oauth2Config"> &
+          ConnectionConfigVarOAuth2Config<TConnectionDefinition> & {
             icons?: TConnectionDefinition["display"]["icons"];
             onPremConnectionConfig?: OnPremiseConnectionConfigTypeEnum;
             inputs: {

--- a/packages/spectral/src/types/ConnectionDefinition.ts
+++ b/packages/spectral/src/types/ConnectionDefinition.ts
@@ -119,27 +119,14 @@ export function templateConnectionInputs<
 ) {
   return merge(inputs, templateInputs);
 }
-interface OAuth2Config {
+export interface OAuth2Config {
   overrideGrantType?: string;
   allowedTokenParams?: string[];
 }
 
-export interface OAuth2UrlOverrides {
-  /**
-   * Custom URI where users should be sent on OAuth success. See
-   * https://prismatic.io/docs/integrations/connections/oauth2/custom-redirects/
-   */
-  oAuthSuccessRedirectUri?: string;
-  /**
-   * Custom URI where users should be sent on OAuth failure. See
-   * https://prismatic.io/docs/integrations/connections/oauth2/custom-redirects/
-   */
-  oAuthFailureRedirectUri?: string;
-}
-
 interface OAuth2AuthorizationCodeConnectionDefinition extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.AuthorizationCode;
-  oauth2Config?: OAuth2Config & OAuth2UrlOverrides;
+  oauth2Config?: OAuth2Config;
   /**
    * The PKCE method (S256 or plain) that this OAuth 2.0 connection uses (if any). See
    * https://prismatic.io/docs/custom-connectors/connections/#supporting-pkce-with-oauth-20
@@ -152,7 +139,6 @@ interface OAuth2AuthorizationCodeConnectionDefinition extends BaseConnectionDefi
 
 interface OAuth2ClientCredentialConnectionDefinition extends BaseConnectionDefinition {
   oauth2Type: OAuth2Type.ClientCredentials;
-  oauth2Config?: OAuth2UrlOverrides;
   inputs: OAuth2ClientCredentialInputs & {
     [key: string]: ConnectionInput;
   };

--- a/packages/spectral/src/types/index.ts
+++ b/packages/spectral/src/types/index.ts
@@ -37,4 +37,3 @@ export * from "./TriggerPayload";
 export * from "./TriggerPerformFunction";
 export * from "./TriggerResult";
 export * from "./UserAttributes";
-export * from "./utils";

--- a/packages/spectral/src/types/utils.ts
+++ b/packages/spectral/src/types/utils.ts
@@ -9,3 +9,9 @@ export type Prettify<T> = {
 };
 
 export type ValueOf<T> = T[keyof T];
+
+export type Exact<TExpected, TActual extends TExpected> = TExpected extends unknown
+  ? TActual extends TExpected
+    ? TActual & Record<Exclude<keyof TActual, keyof TExpected>, never>
+    : never
+  : never;


### PR DESCRIPTION
Adds type tests throughout including a new Exact helper which helps catch the `stableKey` class of error.

This also noticed that we re-exported the type utils so I've removed that as I couldn't find a downstream usage needing it.