### PR TITLE
Compute `examplePerformSafety` from the presence of `examplePerform`

### DIFF
--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -71,7 +71,6 @@ describe("convertAction", () => {
         },
         perform: async () => ({ data: null }),
         examplePerform: examplePerform,
-        examplePerformSafety: PerformSafety.SAFE,
       }),
     );
 
@@ -85,21 +84,33 @@ describe("convertAction", () => {
     expect(result).toStrictEqual({ data: { count: 42 } });
   });
 
-  it("converts the safety values to their wire form (enum names)", () => {
+  it("converts performSafety to its wire form (enum name)", () => {
     const converted = convertAction(
       "doThing",
       action({
         display: baseDisplay,
         inputs: {},
         perform: async () => ({ data: null }),
-        performSafety: PerformSafety.SAFE,
         // Plain-string authoring must typecheck alongside the const companion.
-        examplePerformSafety: "notAllowed",
+        performSafety: "notAllowed",
       }),
     );
 
-    expect(converted.performSafety).toBe("SAFE");
-    expect(converted.examplePerformSafety).toBe("NOT_ALLOWED");
+    expect(converted.performSafety).toBe("NOT_ALLOWED");
+  });
+
+  it("derives examplePerformSafety from the presence of examplePerform", () => {
+    const converted = convertAction(
+      "doThing",
+      action({
+        display: baseDisplay,
+        inputs: {},
+        perform: async () => ({ data: null }),
+        examplePerform: async () => ({ data: null }),
+      }),
+    );
+
+    expect(converted.examplePerformSafety).toBe("SAFE");
   });
 
   it("omits examplePerform when the author does not define it", () => {

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -13,6 +13,7 @@ import {
   type Inputs,
   type OnPremConnectionInput,
   type OutputSchema,
+  PerformSafety,
   type TriggerDefinition,
   type TriggerOptionChoice,
   type TriggerPayload,
@@ -393,7 +394,6 @@ export const convertAction = (
     outputSchema,
     examplePerform,
     performSafety,
-    examplePerformSafety,
     ...action
   }: ActionDefinition<Inputs, any, boolean, any>,
   hooks?: ComponentHooks,
@@ -419,12 +419,10 @@ export const convertAction = (
             inputCleaners,
             errorHandler: hooks?.error,
           }),
+          examplePerformSafety: toServerPerformSafety(PerformSafety.SAFE),
         }
       : {}),
     ...(performSafety ? { performSafety: toServerPerformSafety(performSafety) } : {}),
-    ...(examplePerformSafety
-      ? { examplePerformSafety: toServerPerformSafety(examplePerformSafety) }
-      : {}),
   };
 };
 

--- a/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
+++ b/packages/spectral/src/serverTypes/inlineActionCalling.publishWire.spec.ts
@@ -48,13 +48,12 @@ const testComponent = component({
       inputs: sharedInputs,
       perform: noop,
     }),
-    // B — example perform + its safety flag.
+    // B — example perform.
     examplePerformAction: action({
       display: display("Example Perform Action"),
       inputs: sharedInputs,
       perform: noop,
       examplePerform: echo,
-      examplePerformSafety: PerformSafety.SAFE,
     }),
     // C — real perform marked runnable.
     runnablePerformAction: action({
@@ -84,11 +83,11 @@ describe("inline action calling: publish-wire conversion output", () => {
     expect(a.performSafety).toBeUndefined();
   });
 
-  it("B — example perform is wrapped (invokable) and its safety flag is carried", async () => {
+  it("B — example perform is wrapped (invokable) and implies a SAFE safety flag", async () => {
     const a = actionsByKey.examplePerformAction;
     expect(typeof a.examplePerform).toBe("function");
     expect(a.examplePerformSafety).toBe("SAFE");
-    // Only the field the author set is carried; no performSafety leaks in.
+    // The example flag must not imply anything about the real perform.
     expect(a.performSafety).toBeUndefined();
     // Wrapped fn is invokable and passes params through.
     const result: any = await a.examplePerform?.({} as any, { tags: ["x"] });

--- a/packages/spectral/src/types/ActionDefinition.ts
+++ b/packages/spectral/src/types/ActionDefinition.ts
@@ -47,7 +47,6 @@ export interface ActionDefinition<
     TAllowsBranching,
     TReturn
   >;
-  examplePerformSafety?: PerformSafety;
   performSafety?: PerformSafety;
   /**
    * The inputs to present a low-code integration builder. Values of these inputs


### PR DESCRIPTION
There's not a legitimate use case for providing an `examplePerform` function and then marking it as unsafe. This removes this from the public API and computing it in the convert layer.