### PR TITLE
Add additional batch configuration validation and on deploy inputs

### DIFF
--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -608,9 +608,11 @@ export const trigger = <
   TConfigVars extends ConfigVarResultCollection,
   TAllowsBranching extends boolean,
   TResult extends TriggerResult<TAllowsBranching, TriggerPayload>,
+  TOnDeployInputs extends Inputs = Inputs,
 >(
-  definition: TriggerDefinition<TInputs, TConfigVars, TAllowsBranching, TResult>,
-): TriggerDefinition<TInputs, TConfigVars, TAllowsBranching, TResult> => definition;
+  definition: TriggerDefinition<TInputs, TConfigVars, TAllowsBranching, TResult, TOnDeployInputs>,
+): TriggerDefinition<TInputs, TConfigVars, TAllowsBranching, TResult, TOnDeployInputs> =>
+  definition;
 
 /**
  * This function creates a polling trigger object that can be referenced

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -672,6 +672,35 @@ describe("convertTrigger triggerResolver", () => {
     expect(result.hasResolveTriggerItems).toBeUndefined();
   });
 
+  it("requires batchConfig at author time when a triggerResolver is declared", () => {
+    trigger({
+      ...baseTrigger,
+      // @ts-expect-error - declaring a triggerResolver requires a batchConfig (default batch size)
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+    });
+    // With batchConfig present it compiles.
+    trigger({
+      ...baseTrigger,
+      triggerResolver: { resolveItems: () => [1, 2, 3] },
+      batchConfig: { batchSize: 10 },
+    });
+  });
+
+  it("requires batchConfig at author time when an onDeployResolver is declared", () => {
+    trigger({
+      ...baseTrigger,
+      onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+      // @ts-expect-error - declaring an onDeployResolver requires a batchConfig (default batch size)
+      onDeployResolver: { resolveItems: () => [1, 2, 3] },
+    });
+    trigger({
+      ...baseTrigger,
+      onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+      onDeployResolver: { resolveItems: () => [1, 2, 3] },
+      batchConfig: { batchSize: 10 },
+    });
+  });
+
   it("emits default batchSize 1 when triggerResolverSupport is 'valid' without a batch config", () => {
     const result = convertTrigger(
       "myTrigger",
@@ -855,6 +884,107 @@ describe("convertTrigger on-deploy", () => {
     expect(result.hasResolveOnDeployItems).toBe(true);
     expect(result.triggerResolverDefaultBatchSize).toBe(25);
     expect(typeof result.resolveOnDeployItems).toBe("function");
+  });
+
+  it("hoists onDeployResolver.inputs into the flat inputs[] tagged scope 'ON_DEPLOY'", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        inputs: { triggerInput: input({ label: "Trigger Input", type: "string" }) },
+        batchConfig: { batchSize: 10 },
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+        onDeployResolver: {
+          resolveItems: () => [1, 2, 3],
+          inputs: {
+            backfillStartDate: input({ label: "Backfill Start Date", type: "string" }),
+          },
+        },
+      }),
+    );
+
+    const backfill = result.inputs.find((i) => i.key === "backfillStartDate");
+    expect(backfill?.scope).toBe("ON_DEPLOY");
+
+    const triggerInput = result.inputs.find((i) => i.key === "triggerInput");
+    expect(triggerInput).toBeDefined();
+    expect(triggerInput?.scope).toBeUndefined();
+  });
+
+  it("emits no scoped input when onDeployResolver has no inputs", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 10 },
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+        onDeployResolver: { resolveItems: () => [1, 2, 3] },
+      }),
+    );
+    expect(result.inputs.some((i) => i.scope === "ON_DEPLOY")).toBe(false);
+  });
+
+  it("rejects an onDeployResolver input whose key collides with a trigger input", () => {
+    expect(() =>
+      convertTrigger(
+        "myTrigger",
+        trigger({
+          ...baseTrigger,
+          inputs: { shared: input({ label: "Shared", type: "string" }) },
+          batchConfig: { batchSize: 10 },
+          onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+          onDeployResolver: {
+            resolveItems: () => [1, 2, 3],
+            inputs: { shared: input({ label: "Shared On-Deploy", type: "string" }) },
+          },
+        }),
+      ),
+    ).toThrow(/duplicates a trigger input/);
+  });
+
+  it("exposes onDeployResolver.inputs to onDeployPerform params but not to perform params", () => {
+    trigger({
+      display: { label: "Typed", description: "" },
+      inputs: { triggerInput: input({ label: "Trigger Input", type: "string" }) },
+      scheduleSupport: "invalid",
+      synchronousResponseSupport: "invalid",
+      batchConfig: { batchSize: 10 },
+      perform: async (_context, _payload, params) => {
+        // The normal perform sees the trigger input...
+        params.triggerInput;
+        // @ts-expect-error - on-deploy inputs are NOT in the normal perform's params
+        params.backfillStartDate;
+        return { payload: { body: { data: "" }, headers: {} } };
+      },
+      onDeployPerform: async (_context, _payload, params) => {
+        // ...and onDeployPerform additionally sees the on-deploy-scoped input.
+        params.triggerInput;
+        params.backfillStartDate;
+        return { payload: { body: { data: "" }, headers: {} } };
+      },
+      onDeployResolver: {
+        resolveItems: () => [1, 2, 3],
+        inputs: { backfillStartDate: input({ label: "Backfill Start Date", type: "string" }) },
+      },
+    });
+  });
+
+  it("does not leak the author onDeployResolver object onto the wire trigger", () => {
+    const result = convertTrigger(
+      "myTrigger",
+      trigger({
+        ...baseTrigger,
+        batchConfig: { batchSize: 10 },
+        onDeployPerform: async () => ({ payload: { body: { data: "" }, headers: {} } }),
+        onDeployResolver: {
+          resolveItems: () => [1, 2, 3],
+          inputs: { backfillStartDate: input({ label: "Backfill Start Date", type: "string" }) },
+        },
+      }),
+    );
+    expect("onDeployResolver" in result).toBe(false);
+    expect("triggerResolver" in result).toBe(false);
+    expect("batchConfig" in result).toBe(false);
   });
 });
 

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -25,6 +25,7 @@ import {
 } from "../types/PollingTriggerDefinition";
 import type { BatchConfig, TriggerResolverBehavior } from "../types/TriggerDefinition";
 import type {
+  InputScope,
   Action as ServerAction,
   Component as ServerComponent,
   Connection as ServerConnection,
@@ -246,6 +247,7 @@ const buildOnDeployResolverFields = <
 export const convertInput = (
   key: string,
   definition: InputFieldDefinition | OnPremConnectionInput | ConnectionInput,
+  scope?: InputScope,
 ): ServerInput => {
   // Cast: the field union is wider than any single member; runtime guards below handle it.
   const {
@@ -307,6 +309,7 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
+    ...(scope ? { scope } : {}),
   };
 };
 
@@ -496,6 +499,26 @@ export const convertTrigger = <
     );
   }
 
+  // On-deploy-scoped inputs live on `onDeployResolver.inputs` in the author model; the wire
+  // expects one flat `inputs[]`, so hoist them alongside the trigger inputs, each tagged
+  // `scope: "ON_DEPLOY"`. Both sets share one key namespace on the wire — reject collisions.
+  const onDeployInputs: Inputs = onDeployResolver?.inputs ?? {};
+  const onDeployInputEntries = Object.entries(onDeployInputs);
+  for (const [key] of onDeployInputEntries) {
+    if (triggerInputKeys.includes(key)) {
+      throw new Error(
+        `Trigger "${trigger.display.label}" declares an onDeployResolver input with key "${key}", which duplicates a trigger input. On-deploy and trigger inputs share one key namespace; give the on-deploy input a different key.`,
+      );
+    }
+  }
+  const convertedOnDeployInputs = onDeployInputEntries.map(([key, value]) =>
+    convertInput(key, value, "ON_DEPLOY"),
+  );
+  const onDeployInputCleaners = onDeployInputEntries.reduce<InputCleaners>(
+    (result, [key, value]) => ({ ...result, [key]: cleanerFor(value) }),
+    {},
+  );
+
   let convertedActionInputs: Array<ServerInput> = [];
   let performToUse: PerformFn;
 
@@ -556,7 +579,7 @@ export const convertTrigger = <
     // wire carries the serialized resolver behavior plus the single batch size instead.
     ...omit(trigger, ["batchConfig", "triggerResolver", "onDeployResolver"]),
     key: triggerKey,
-    inputs: convertedTriggerInputs.concat(convertedActionInputs),
+    inputs: convertedTriggerInputs.concat(convertedActionInputs, convertedOnDeployInputs),
     perform: performToUse,
     scheduleSupport,
     synchronousResponseSupport:
@@ -588,7 +611,7 @@ export const convertTrigger = <
 
   if (onDeployPerform) {
     result.onDeployPerform = createPerform(onDeployPerform, {
-      inputCleaners: triggerInputCleaners,
+      inputCleaners: { ...triggerInputCleaners, ...onDeployInputCleaners },
       errorHandler: hooks?.error,
     });
     result.hasOnDeployPerform = true;

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -117,6 +117,44 @@ describe("convertFlow with polling triggers", () => {
     });
   });
 
+  it("emits runInitialSyncOnDeploy on the flow wire when the CNI author opts in", () => {
+    const optedInFlow = flow({
+      ...baseFlowInput,
+      runInitialSyncOnDeploy: true,
+      batchConfig: { batchSize: 25 },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+        onDeploy: async () => ({ items: [4, 5, 6] }),
+      }),
+    });
+
+    const result = convertFlow(optedInFlow, {}, "test-ref");
+
+    expect(result.triggerResolver).toEqual({
+      batchSize: 25,
+      enabled: true,
+      runInitialSyncOnDeploy: true,
+    });
+  });
+
+  it("omits runInitialSyncOnDeploy when the CNI author does not opt in (default off)", () => {
+    const defaultOffFlow = flow({
+      ...baseFlowInput,
+      batchConfig: { batchSize: 25 },
+      trigger: batchFlowTrigger({
+        onTrigger: async () => ({ items: [1, 2, 3] }),
+        onDeploy: async () => ({ items: [4, 5, 6] }),
+      }),
+    });
+
+    const result = convertFlow(defaultOffFlow, {}, "test-ref");
+
+    expect(result.triggerResolver).toEqual({ batchSize: 25, enabled: true });
+    expect(
+      (result.triggerResolver as { runInitialSyncOnDeploy?: boolean }).runInitialSyncOnDeploy,
+    ).toBeUndefined();
+  });
+
   it("throws when the flow-level batch concurrentBatchLimit is invalid", () => {
     const invalidFlow = flow({
       ...baseFlowInput,

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -885,6 +885,12 @@ export const convertFlow = <
   const triggerResolver = "triggerResolver" in flow ? flow.triggerResolver : undefined;
   const onDeployResolver = "onDeployResolver" in flow ? flow.onDeployResolver : undefined;
   const batchConfig = "batchConfig" in flow ? flow.batchConfig : undefined;
+  // CNI authors referencing an existing component's batching trigger opt the initial
+  // on-deploy sync in/out with this flow-level flag (default off). A `batchFlowTrigger`
+  // flow instead drives the on-deploy fire structurally (presence of `onDeploy`), so the
+  // flag is not read there.
+  const runInitialSyncOnDeploy =
+    "runInitialSyncOnDeploy" in flow ? Boolean(flow.runInitialSyncOnDeploy) : false;
 
   // Resolver behaviors (resolveItems/getNextPaginationState) are serialized onto the
   // synthesized trigger below. On the flow wire we emit only `triggerResolver`, the single
@@ -922,6 +928,7 @@ export const convertFlow = <
       batchSize: validateBatchSize(flow.name, "batchConfig", batchConfig.batchSize),
       enabled: true,
       ...(concurrentBatchLimit !== undefined ? { concurrentBatchLimit } : {}),
+      ...(runInitialSyncOnDeploy ? { runInitialSyncOnDeploy: true } : {}),
     };
   }
 

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -425,6 +425,13 @@ interface InputFieldChoice {
   value: string;
 }
 
+/**
+ * The scope in which an input is accessible, mirroring the platform's
+ * `InputFieldScope`. `"ON_DEPLOY"` marks an input that only participates when the
+ * flow runs its initial sync on deploy; absent means a normal, always-included input.
+ */
+export type InputScope = "ON_DEPLOY";
+
 export interface Input {
   key: string;
   label: string;
@@ -441,6 +448,9 @@ export interface Input {
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;
+  /** Set for inputs hoisted from a trigger's `onDeployResolver.inputs`; absent for
+   * normal inputs. The platform reads this as `InputField.scope`. */
+  scope?: InputScope;
   /** Nested children. For `structuredObject`, the declared inputs; for
    * `dynamicObject`, one `structuredObject` per configuration. */
   inputs?: Input[];

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -253,6 +253,14 @@ interface FlowBase<TTriggerPayload extends TriggerPayload = TriggerPayload, TIte
   preprocessFlowConfig?: PreprocessFlowConfig;
   /** Value that specifies whether this flow is synchronous. @default `false` */
   isSynchronous?: boolean;
+  /**
+   * For a CNI flow whose trigger references an existing component's batching trigger:
+   * whether the trigger's initial on-deploy sync (backfill) runs when an instance is first
+   * deployed. Ignored for a `batchFlowTrigger` flow, which drives the on-deploy fire by the
+   * presence of its `onDeploy` handler instead.
+   * @default `false`
+   */
+  runInitialSyncOnDeploy?: boolean;
   /** Value that specifies whether this flow is an AI agent flow on the integrations MCP server. @default `false` */
   isAgentFlow?: boolean;
   /** Retry Configuration for this flow. */

--- a/packages/spectral/src/types/TriggerDefinition.ts
+++ b/packages/spectral/src/types/TriggerDefinition.ts
@@ -8,12 +8,13 @@ import type { TriggerBaseResult, TriggerResult } from "./TriggerResult";
 
 /**
  * Encodes the relationship between `triggerResolverSupport` and `triggerResolver`:
- * - absent or `"invalid"`: no resolver allowed
- * - `"valid"`: resolver optional
- * - `"required"`: resolver required
+ * - absent or `"invalid"`: no resolver allowed, no `batchConfig`
+ * - `"valid"`: resolver optional; when a resolver IS declared, `batchConfig` is required
+ * - `"required"`: resolver required, so `batchConfig` is required
  *
- * `triggerResolver` is the resolver *behavior* only; batch sizing comes from the
- * trigger's shared `batchConfig` (see `TriggerDefinition`).
+ * `triggerResolver` is the resolver *behavior* only; batch sizing comes from the shared,
+ * now-mandatory-when-batching `batchConfig`. A trigger that batches must declare a default
+ * batch size — the type enforces this at author time rather than defaulting silently.
  */
 export type TriggerResolverDecl<
   TConfigVars extends ConfigVarResultCollection,
@@ -21,15 +22,42 @@ export type TriggerResolverDecl<
   TItem = unknown,
   TPaginationState extends Record<string, unknown> = Record<string, unknown>,
 > =
-  | { triggerResolverSupport?: "invalid" | undefined; triggerResolver?: undefined }
+  | {
+      triggerResolverSupport?: "invalid" | undefined;
+      triggerResolver?: undefined;
+      batchConfig?: BatchConfig;
+    }
+  | { triggerResolverSupport: "valid"; triggerResolver?: undefined; batchConfig?: BatchConfig }
   | {
       triggerResolverSupport: "valid";
-      triggerResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
+      triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
+      batchConfig: BatchConfig;
     }
   | {
       triggerResolverSupport: "required";
       triggerResolver: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
+      batchConfig: BatchConfig;
     };
+
+/**
+ * The on-deploy resolver: the shared resolver behavior plus optional on-deploy-scoped
+ * `inputs`. These inputs only make sense while the initial sync runs on deploy (e.g. a
+ * backfill start date / page size). They are declared here — separate from the trigger's
+ * `inputs` — and the convert layer hoists them into the flat wire `inputs[]` tagged with
+ * `scope: "ON_DEPLOY"`. Because `TOnDeployInputs` parameterizes the on-deploy resolver, an
+ * author's `onDeployPerform` receives them on its params while the normal `perform` does not.
+ */
+export interface OnDeployResolverBehavior<
+  TOnDeployInputs extends Inputs = Inputs,
+  TConfigVars extends ConfigVarResultCollection = ConfigVarResultCollection,
+  TPayload extends TriggerPayload = TriggerPayload,
+  TItem = unknown,
+  TPaginationState extends Record<string, unknown> = Record<string, unknown>,
+> extends TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState> {
+  /** Inputs presented only when the flow runs its initial sync on deploy. Values are passed
+   * to `onDeployPerform` (not to the normal `perform`). Kept separate from `TriggerDefinition.inputs`. */
+  inputs?: TOnDeployInputs;
+}
 
 /**
  * Encodes the relationship between `onDeployPerform` and `onDeployResolver`. On-deploy is
@@ -39,7 +67,8 @@ export type TriggerResolverDecl<
  *
  * `onDeployPerform` is the component-trigger sibling to `perform`. A CNI flow names the
  * same on-deploy fire `onDeployTrigger` (sibling to its `onTrigger`); both flatten to
- * `onDeployPerform` on the wire.
+ * `onDeployPerform` on the wire. `onDeployPerform`'s params merge the trigger's `TInputs`
+ * with the on-deploy resolver's own `TOnDeployInputs`.
  */
 export type OnDeployDecl<
   TInputs extends Inputs,
@@ -49,11 +78,34 @@ export type OnDeployDecl<
   TResult extends TriggerResult<TAllowsBranching, TPayload>,
   TItem = unknown,
   TPaginationState extends Record<string, unknown> = Record<string, unknown>,
+  TOnDeployInputs extends Inputs = Inputs,
 > =
-  | { onDeployPerform?: undefined; onDeployResolver?: undefined }
+  | { onDeployPerform?: undefined; onDeployResolver?: undefined; batchConfig?: BatchConfig }
   | {
-      onDeployPerform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
-      onDeployResolver?: TriggerResolverBehavior<TConfigVars, TPayload, TItem, TPaginationState>;
+      onDeployPerform: TriggerPerformFunction<
+        TInputs & TOnDeployInputs,
+        TConfigVars,
+        TAllowsBranching,
+        TResult
+      >;
+      onDeployResolver?: undefined;
+      batchConfig?: BatchConfig;
+    }
+  | {
+      onDeployPerform: TriggerPerformFunction<
+        TInputs & TOnDeployInputs,
+        TConfigVars,
+        TAllowsBranching,
+        TResult
+      >;
+      onDeployResolver: OnDeployResolverBehavior<
+        TOnDeployInputs,
+        TConfigVars,
+        TPayload,
+        TItem,
+        TPaginationState
+      >;
+      batchConfig: BatchConfig;
     };
 
 const optionChoices = ["invalid", "valid", "required"] as const;
@@ -143,9 +195,19 @@ export type TriggerDefinition<
     TAllowsBranching,
     TriggerPayload
   >,
+  TOnDeployInputs extends Inputs = Inputs,
 > = TriggerDefinitionBase<TInputs, TConfigVars, TAllowsBranching, TResult> &
   TriggerResolverDecl<TConfigVars, TriggerPayload> &
-  OnDeployDecl<TInputs, TConfigVars, TriggerPayload, TAllowsBranching, TResult>;
+  OnDeployDecl<
+    TInputs,
+    TConfigVars,
+    TriggerPayload,
+    TAllowsBranching,
+    TResult,
+    unknown,
+    Record<string, unknown>,
+    TOnDeployInputs
+  >;
 
 interface TriggerDefinitionBase<
   TInputs extends Inputs = Inputs,
@@ -160,12 +222,6 @@ interface TriggerDefinitionBase<
   display: ActionDisplayDefinition;
   /** Function to perform when this trigger is invoked. */
   perform: TriggerPerformFunction<TInputs, TConfigVars, TAllowsBranching, TResult>;
-  /**
-   * Default batch-dispatch config shared by `triggerResolver` and `onDeployResolver`.
-   * Required when this trigger declares either (a `triggerResolver` with
-   * `triggerResolverSupport` `"valid"`/`"required"`, or an `onDeployResolver`).
-   */
-  batchConfig?: BatchConfig;
   /**
    * Function to execute when an instance of an integration with a flow that uses this trigger is deployed. See
    * https://prismatic.io/docs/custom-connectors/triggers/#instance-deploy-and-delete-events-for-triggers


### PR DESCRIPTION
**`batchConfig` is now required when a trigger batches.** A trigger that declares a `triggerResolver` (or has `triggerResolverSupport: "required"`) must also declare a default batch size. Previously a batching trigger could omit it and get a silent default, which meant the platform picked a batch size of 1 which is unexpected.

**On-deploy-scoped trigger inputs.** `onDeployResolver` accepts its own `inputs`, for values that only make sense during an initial sync on deploy (e.g. a backfill start date or page size). These are declared separately from the trigger's regular `inputs` and reach `onDeployPerform` only, not the normal `perform`, since they don't exist outside the on-deploy execution.

Also adds flow-level `runInitialSyncOnDeploy` for code-native authors whose flow references an existing component's batching trigger — the case where the opt-in can't be inferred structurally.
