### PR TITLE
Add userActivatedConnection for code-native integrations

### DIFF
--- a/packages/spectral-test/src/ConfigVars.test-d.ts
+++ b/packages/spectral-test/src/ConfigVars.test-d.ts
@@ -18,6 +18,7 @@ expectAssignable<"A Connection" | "Ref Connection">(null as unknown as keyof Con
 expectAssignable<Connection>(null as unknown as ConfigVars["A Connection"]);
 expectAssignable<Connection>(null as unknown as ConfigVars["Ref Connection"]);
 expectAssignable<Connection>(null as unknown as ConfigVars["My Customer Connection"]);
+expectAssignable<Connection>(null as unknown as ConfigVars["My User Connection"]);
 
 expectAssignable<ConfigVar>({
   stableKey: "cni-oauth-connection",

--- a/packages/spectral-test/src/testData.test-d.ts
+++ b/packages/spectral-test/src/testData.test-d.ts
@@ -10,6 +10,7 @@ import {
   OAuth2Type,
   type ObjectSelection,
   organizationActivatedConnection,
+  userActivatedConnection,
 } from "@prismatic-io/spectral";
 import { expectAssignable } from "tsd";
 
@@ -240,5 +241,8 @@ export const componentRegistry = {
 export const scopedConfigVars = {
   "My Customer Connection": organizationActivatedConnection({
     stableKey: "my-customer-connection-stable-key",
+  }),
+  "My User Connection": userActivatedConnection({
+    stableKey: "my-user-connection-stable-key",
   }),
 };

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -36,6 +36,7 @@ import type {
   TriggerDefinition,
   TriggerPayload,
   TriggerResult,
+  UserActivatedConnectionConfigVar,
 } from "./types";
 import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition";
 import type { Exact } from "./types/utils";
@@ -426,6 +427,27 @@ export const customerActivatedConnection = <T extends { stableKey: string }>(
 export const organizationActivatedConnection = <T extends { stableKey: string }>(
   definition: T,
 ): OrganizationActivatedConnectionConfigVar => {
+  return { ...definition, dataType: "connection" };
+};
+
+/**
+ * This function creates a user-activated connection for code-native
+ * integrations. User-activated connections are activated by each person who
+ * uses the integration, so every one of them supplies their own credentials
+ * rather than sharing the organization's.
+ *
+ * @param definition A User-Activated Connection Config Var type object.
+ * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
+ * @example
+ * import { userActivatedConnection } from "@prismatic-io/spectral";
+ *
+ * const userSlackConnection = userActivatedConnection({
+ *   stableKey: "user-slack-connection",
+ * });
+ */
+export const userActivatedConnection = <T extends { stableKey: string }>(
+  definition: T,
+): UserActivatedConnectionConfigVar => {
   return { ...definition, dataType: "connection" };
 };
 

--- a/packages/spectral/src/integration.ts
+++ b/packages/spectral/src/integration.ts
@@ -16,5 +16,6 @@ export {
   oauth2Connection,
   onPremConnection,
   organizationActivatedConnection,
+  userActivatedConnection,
 } from "./index";
 export * from "./types/typeExportIntegration";

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { batchFlowTrigger, configPage, configVar, flow, integration } from "..";
+import {
+  batchFlowTrigger,
+  configPage,
+  configVar,
+  customerActivatedConnection,
+  flow,
+  integration,
+  organizationActivatedConnection,
+  userActivatedConnection,
+} from "..";
 import type { ConfigVar, TriggerReference } from "../types";
 import {
   convertConfigPages,
@@ -401,11 +410,69 @@ describe("convertConfigPages", () => {
     expect(result[0].name).toBe("EmptyPage");
     expect(result[0].elements).toHaveLength(0);
   });
+
+  it("omits scoped config vars from page elements, so they reach the server only as required config vars", () => {
+    const pages = {
+      Connections: configPage({
+        elements: {
+          ApiKey: configVar({
+            stableKey: "api-key",
+            dataType: "string",
+          }),
+          Slack: organizationActivatedConnection({
+            stableKey: "org-slack-connection",
+          }),
+        },
+      }),
+    };
+
+    const result = convertConfigPages(pages, false);
+
+    expect(result[0].elements).toHaveLength(1);
+    expect(result[0].elements[0]).toEqual({ type: "configVar", value: "ApiKey" });
+  });
 });
 
 describe("convertConfigVar", () => {
   const referenceKey = "test-component";
   const componentRegistry = {};
+
+  describe("scoped config vars", () => {
+    it("emits a reference to the scoped config variable by stable key", () => {
+      const scopedConfigVar = organizationActivatedConnection({
+        stableKey: "org-slack-connection",
+      }) as ConfigVar;
+
+      const result = convertConfigVar("Slack", scopedConfigVar, referenceKey, componentRegistry);
+
+      expect(result).toEqual({
+        key: "Slack",
+        stableKey: "org-slack-connection",
+        dataType: "connection",
+        useScopedConfigVar: "org-slack-connection",
+      });
+    });
+
+    it("emits an identical definition whichever scope the author declared", () => {
+      const stableKey = "shared-connection";
+      const convert = (scopedConfigVar: ConfigVar) =>
+        convertConfigVar("Slack", scopedConfigVar, referenceKey, componentRegistry);
+
+      // Scope is resolved server-side from the Scoped Config Variable that the
+      // stable key names, so the declaration carries no scope of its own. The
+      // helpers differ only in what they tell a reader.
+      const asOrganizationActivated = convert(
+        organizationActivatedConnection({ stableKey }) as ConfigVar,
+      );
+
+      expect(convert(customerActivatedConnection({ stableKey }) as ConfigVar)).toEqual(
+        asOrganizationActivated,
+      );
+      expect(convert(userActivatedConnection({ stableKey }) as ConfigVar)).toEqual(
+        asOrganizationActivated,
+      );
+    });
+  });
 
   describe("onPremConnectionConfig validation", () => {
     it("should return onPremiseConnectionConfig when connection has onPremControlled inputs and config set", () => {

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -28,10 +28,7 @@ import type {
   Schedule,
 } from "./Inputs";
 import type { ValidationMode } from "./jsonforms/ValidationMode";
-import type {
-  OrganizationActivatedConnectionConfigVar,
-  ScopedConfigVarMap,
-} from "./ScopedConfigVars";
+import type { ScopedConfigVar, ScopedConfigVarMap } from "./ScopedConfigVars";
 import type { Prettify, UnionToIntersection } from "./utils";
 
 /** Supported data types for config variables. */
@@ -384,7 +381,7 @@ export type ConfigVar =
   | StandardConfigVar
   | DataSourceConfigVar
   | ConnectionConfigVar
-  | OrganizationActivatedConnectionConfigVar;
+  | ScopedConfigVar;
 
 type WithCollectionType<TValue, TCollectionType extends CollectionType | undefined> =
   | undefined
@@ -457,15 +454,15 @@ type ExtractConfigVars<TConfigPages extends { [key: string]: ConfigPage }> =
 
 type ExtractScopedConfigVars<
   TScopedConfigVarMap extends {
-    [key: string]: string | OrganizationActivatedConnectionConfigVar;
+    [key: string]: string | ScopedConfigVar;
   },
 > = keyof TScopedConfigVarMap extends infer TScopedConfigVarName
   ? TScopedConfigVarName extends keyof TScopedConfigVarMap
     ? TScopedConfigVarMap[TScopedConfigVarName] extends infer TScopedConfigVar
-      ? TScopedConfigVar extends OrganizationActivatedConnectionConfigVar
+      ? TScopedConfigVar extends ScopedConfigVar
         ? {
             [Key in keyof TScopedConfigVarMap as Key extends string
-              ? TScopedConfigVarMap[Key] extends OrganizationActivatedConnectionConfigVar
+              ? TScopedConfigVarMap[Key] extends ScopedConfigVar
                 ? Key
                 : never
               : never]: Connection;

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -15,10 +15,16 @@ export type OrganizationActivatedConnectionConfigVar = {
   stableKey: string;
 };
 
+export type UserActivatedConnectionConfigVar = {
+  dataType: "connection";
+  stableKey: string;
+};
+
 /* More types may eventually be added to this union. */
 export type ScopedConfigVar =
   | CustomerActivatedConnectionConfigVar
-  | OrganizationActivatedConnectionConfigVar;
+  | OrganizationActivatedConnectionConfigVar
+  | UserActivatedConnectionConfigVar;
 
 /**
  * Root ScopedConfigVars type exposed for augmentation.
@@ -27,7 +33,7 @@ export type ScopedConfigVar =
  *
  * ```ts
  * interface IntegrationDefinitionScopedConfigVars {
- *   [key: string]: OrganizationActivatedConnectionConfigVar
+ *   [key: string]: ScopedConfigVar
  * }
  * ```
  *
@@ -39,11 +45,11 @@ type CreateScopedConfigVars<TScopedConfigVarMap> = keyof TScopedConfigVarMap ext
      *   introduce this union here so the ConfigVars type will correctly
      *   bottom out to empty when there are no ScopedConfigVars defined.
      */
-    { [key: string]: OrganizationActivatedConnectionConfigVar | string }
+    { [key: string]: ScopedConfigVar | string }
   : UnionToIntersection<
       keyof TScopedConfigVarMap extends infer TScopedConfigVarName
         ? TScopedConfigVarName extends keyof TScopedConfigVarMap
-          ? TScopedConfigVarMap[TScopedConfigVarName] extends OrganizationActivatedConnectionConfigVar
+          ? TScopedConfigVarMap[TScopedConfigVarName] extends ScopedConfigVar
             ? {
                 [Key in TScopedConfigVarName]: TScopedConfigVarMap[TScopedConfigVarName];
               }
@@ -54,9 +60,7 @@ type CreateScopedConfigVars<TScopedConfigVarMap> = keyof TScopedConfigVarMap ext
 
 export type ScopedConfigVarMap = CreateScopedConfigVars<IntegrationDefinitionScopedConfigVars>;
 
-export const isConnectionScopedConfigVar = (
-  cv: unknown,
-): cv is OrganizationActivatedConnectionConfigVar => {
+export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar => {
   if (!cv || typeof cv !== "object" || Array.isArray(cv)) {
     return false;
   }


### PR DESCRIPTION
Story: [SC-38384](https://app.shortcut.com/prismatic/story/38384/fe-declare-user-scoped-connections-from-code)

Lets a code-native author declare that a reusable connection is activated by **each person** who uses the integration, rather than once by the organization.

## `userActivatedConnection`

```ts
const userSlackConnection = userActivatedConnection({
  stableKey: "user-slack-connection",
});
```

It emits **the same definition as its siblings**. That is the design, not an oversight: scope is resolved server-side from the Scoped Config Variable that the stable key names, so the declaration carries no scope of its own and the wire shape needs no new field. The three helpers differ only in what they tell a reader - exactly as `customerActivatedConnection` and `organizationActivatedConnection` already do today.

Exported from both entry points (`integration.ts` uses an explicit named list, so code-native authors importing from `dist/integration` would not otherwise see it).

## Widened the scoped config var filters

Six sites used `OrganizationActivatedConnectionConfigVar` where they meant the whole `ScopedConfigVar` union. Worth knowing the history, because it wasn't a bad decision — it wasn't a decision at all:

- **2024-10-04** (`7451e1e`) - the union was born as `type ScopedConfigVar = OrganizationActivatedConnectionConfigVar`, a **one-member alias**. The two names were the same type, so writing either was identical.
- **2025-03-05** (`7cdf5ac`) - `customerActivatedConnection` landed and widened the union to two members. The filters weren't revisited. That same commit renamed the guard from `isOrganizationActivatedConnectionConfigVar` to `isConnectionScopedConfigVar`, acknowledging the new generality, but left its return type on the org member.

Nothing caught it because the members are structurally identical, so every filter kept working and `tsc` had nothing to complain about. **No behavior change here** - this just makes the filters say what they mean before the types ever diverge.