### PR TITLE
Rename "Code-Native" to "Code-First"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>@prismatic-io/spectral</h1>
 </div>
 
-This monorepo contains packages to build custom Prismatic connectors and code-native integrations using TypeScript.
+This monorepo contains packages to build custom Prismatic connectors and code-first integrations using TypeScript.
 
 ## Building Locally
 
@@ -13,13 +13,13 @@ Run `bun install` to install node dependencies, `mise run build` to build all wo
 
 ## What is Prismatic?
 
-Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.
+Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-first building options, deployment and management tooling, and self-serve customer tools.
 
 Prismatic's unparalleled versatility lets teams deliver any integration from simple to complex in one powerful platform. SaaS companies worldwide, from startups to Fortune 500s, trust Prismatic to help connect their products to the other products their customers use.
 
 With Prismatic, you can:
 
-- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-native](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
+- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-first](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
 - Leverage pre-built [connectors](https://prismatic.io/docs/components/) for common integration tasks, or develop custom connectors using our TypeScript SDK
 - Embed a native [integration marketplace](https://prismatic.io/docs/embed/) in your product for customer self-service
 - Configure and deploy customer-specific integration instances with powerful configuration tools

--- a/packages/eslint-config-spectral/README.md
+++ b/packages/eslint-config-spectral/README.md
@@ -26,13 +26,13 @@ Note that you do not need to install the plugin packages as peer dependencies as
 
 ## What is Prismatic?
 
-Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.
+Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-first building options, deployment and management tooling, and self-serve customer tools.
 
 Prismatic's unparalleled versatility lets teams deliver any integration from simple to complex in one powerful platform. SaaS companies worldwide, from startups to Fortune 500s, trust Prismatic to help connect their products to the other products their customers use.
 
 With Prismatic, you can:
 
-- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-native](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
+- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-first](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
 - Leverage pre-built [connectors](https://prismatic.io/docs/components/) for common integration tasks, or develop custom connectors using our TypeScript SDK
 - Embed a native [integration marketplace](https://prismatic.io/docs/embed/) in your product for customer self-service
 - Configure and deploy customer-specific integration instances with powerful configuration tools

--- a/packages/eslint-config-spectral/package.json
+++ b/packages/eslint-config-spectral/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@prismatic-io/eslint-config-spectral",
   "version": "2.2.0",
-  "description": "ESLint config for building Prismatic connectors and code-native integrations",
-  "keywords": ["prismatic", "eslint"],
+  "description": "ESLint config for building Prismatic connectors and code-first integrations",
+  "keywords": [
+    "prismatic",
+    "eslint"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "homepage": "https://prismatic.io",
@@ -23,7 +26,9 @@
     "build": "bun run clean && tsc",
     "prepack": "bun run build"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",

--- a/packages/spectral/README.md
+++ b/packages/spectral/README.md
@@ -3,7 +3,7 @@
   <h1>@prismatic-io/spectral</h1>
 </div>
 
-This repository contains code for Prismatic's TypeScript library, `spectral`, which is used to build custom Prismatic connectors and code-native integrations.
+This repository contains code for Prismatic's TypeScript library, `spectral`, which is used to build custom Prismatic connectors and code-first integrations.
 
 ## Using Spectral
 
@@ -17,13 +17,13 @@ Please see our [documentation](https://prismatic.io/docs/custom-connectors/) on 
 
 ## What is Prismatic?
 
-Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.
+Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-first building options, deployment and management tooling, and self-serve customer tools.
 
 Prismatic's unparalleled versatility lets teams deliver any integration from simple to complex in one powerful platform. SaaS companies worldwide, from startups to Fortune 500s, trust Prismatic to help connect their products to the other products their customers use.
 
 With Prismatic, you can:
 
-- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-native](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
+- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-first](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
 - Leverage pre-built [connectors](https://prismatic.io/docs/components/) for common integration tasks, or develop custom connectors using our TypeScript SDK
 - Embed a native [integration marketplace](https://prismatic.io/docs/embed/) in your product for customer self-service
 - Configure and deploy customer-specific integration instances with powerful configuration tools

--- a/packages/spectral/package.json
+++ b/packages/spectral/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prismatic-io/spectral",
   "version": "10.26.0",
-  "description": "Utility library for building Prismatic connectors and code-native integrations",
+  "description": "Utility library for building Prismatic connectors and code-first integrations",
   "keywords": [
     "prismatic"
   ],

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * This module contains functions to help custom component and code-native
+ * This module contains functions to help custom component and code-first
  * integration authors create inputs, actions, components, and integrations
  * that can run on the Prismatic platform.
  */
@@ -41,12 +41,12 @@ import type { PollingTriggerDefinition } from "./types/PollingTriggerDefinition"
 import type { Exact } from "./types/utils";
 
 /**
- * This function creates a code-native integration object that can be
+ * This function creates a code-first integration object that can be
  * imported into Prismatic.
  *
  * @param definition An IntegrationDefinition type object.
  * @returns This function returns an integration object that has the shape the Prismatic API expects.
- * @see {@link https://prismatic.io/docs/integrations/code-native/ | Code-Native Integrations}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/ | Code-First Integrations}
  * @example
  * import { integration } from "@prismatic-io/spectral";
  * import flows from "./flows";
@@ -108,11 +108,11 @@ export const integration = <
 };
 
 /**
- * This function creates a flow object for use in code-native integrations.
+ * This function creates a flow object for use in code-first integrations.
  *
  * @param definition A Flow type object.
  * @returns This function returns a flow object that has the shape the Prismatic API expects.
- * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-First Flows}
  * @example
  * // A webhook-triggered flow
  * import { flow } from "@prismatic-io/spectral";
@@ -203,7 +203,7 @@ export const flow = <
  *
  * @typeParam TItem - the item type each batched execution receives.
  * @typeParam TPaginationState - the pagination state round-tripped via `payload.paginationState`.
- * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-Native Flows}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/flows/ | Code-First Flows}
  * @example
  * import { flow, batchFlowTrigger } from "@prismatic-io/spectral";
  *
@@ -234,12 +234,12 @@ export const batchFlowTrigger = <
 ): BatchTrigger<TItem, TPaginationState> => trigger;
 
 /**
- * This function creates a config wizard page object for use in code-native
+ * This function creates a config wizard page object for use in code-first
  * integrations.
  *
  * @param definition A Config Page type object.
  * @returns This function returns a config page object that has the shape the Prismatic API expects.
- * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/ | Code-Native Config Wizard}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/ | Code-First Config Wizard}
  * @example
  * import { configPage, connectionConfigVar, configVar } from "@prismatic-io/spectral";
  *
@@ -273,7 +273,7 @@ export const batchFlowTrigger = <
 export const configPage = <T extends ConfigPage = ConfigPage>(definition: T): T => definition;
 
 /**
- * This function creates a config variable object for code-native integrations.
+ * This function creates a config variable object for code-first integrations.
  *
  * @param definition A Config Var type object.
  * @returns This function returns a standard config var object that has the shape the Prismatic API expects.
@@ -326,12 +326,12 @@ export const configPage = <T extends ConfigPage = ConfigPage>(definition: T): T 
 export const configVar = <T extends StandardConfigVar>(definition: T): T => definition;
 
 /**
- * This function creates a data source-backed config variable for code-native
+ * This function creates a data source-backed config variable for code-first
  * integrations.
  *
  * @param definition A Data Source Config Var type object.
  * @returns This function returns a data source config var object that has the shape the Prismatic API expects.
- * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#data-sources-is-code-native-integrations | Data Sources in Code-Native}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#data-sources-is-code-native-integrations | Data Sources in Code-First}
  * @example
  * import { dataSourceConfigVar } from "@prismatic-io/spectral";
  *
@@ -350,12 +350,12 @@ export const dataSourceConfigVar = <TDataSourceConfigVar extends DataSourceConfi
 ): TDataSourceConfigVar => definition;
 
 /**
- * This function creates a connection config variable for code-native
+ * This function creates a connection config variable for code-first
  * integrations.
  *
  * @param definition A Connection Config Var type object.
  * @returns This function returns a connection config var object that has the shape the Prismatic API expects.
- * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#connections-in-code-native-integrations | Connections in Code-Native}
+ * @see {@link https://prismatic.io/docs/integrations/code-native/config-wizard/#connections-in-code-native-integrations | Connections in Code-First}
  * @example
  * import { connectionConfigVar } from "@prismatic-io/spectral";
  * import { acmeConnection } from "./connections";
@@ -388,7 +388,7 @@ export const connectionConfigVar = <T extends ConnectionConfigVar = ConnectionCo
 ): T => definition;
 
 /**
- * This function creates a customer-activated connection for code-native
+ * This function creates a customer-activated connection for code-first
  * integrations. Customer-activated connections are configured by end-users
  * and can be shared across multiple integrations.
  *
@@ -409,7 +409,7 @@ export const customerActivatedConnection = <T extends { stableKey: string }>(
 };
 
 /**
- * This function creates an org-activated connection for code-native
+ * This function creates an org-activated connection for code-first
  * integrations. Org-activated connections are configured once by the
  * organization and shared across all customer instances.
  *
@@ -430,8 +430,8 @@ export const organizationActivatedConnection = <T extends { stableKey: string }>
 };
 
 /**
- * Generate a manifest of components that this code-native integration relies on.
- * Component manifests allow your code-native integration to reference actions,
+ * Generate a manifest of components that this code-first integration relies on.
+ * Component manifests allow your code-first integration to reference actions,
  * triggers, connections, and data sources from published Prismatic components.
  *
  * @param definition A Component Manifest type object.
@@ -848,7 +848,7 @@ export const dynamicObjectInput = <
 });
 
 /**
- * This function creates a connection that can be used by a code-native integration
+ * This function creates a connection that can be used by a code-first integration
  * or custom component. Connections define the fields (API keys, tokens, etc.) needed
  * to authenticate with a third-party service.
  *
@@ -885,7 +885,7 @@ export const connection = <T extends DefaultConnectionDefinition>(
 ): T => definition;
 
 /**
- * This function creates an on-prem connection for a code-native integration or custom component.
+ * This function creates an on-prem connection for a code-first integration or custom component.
  * On-prem connections include `host` and `port` fields that are automatically overridden by the
  * on-prem agent with local tunnel endpoints.
  *
@@ -934,7 +934,7 @@ export const onPremConnection = <T extends OnPremConnectionDefinition>(
 ): T => definition;
 
 /**
- * This function creates an OAuth 2.0 connection for a code-native integration or custom component.
+ * This function creates an OAuth 2.0 connection for a code-first integration or custom component.
  * Supports both Authorization Code and Client Credentials grant types.
  *
  * @param definition An OAuth2ConnectionDefinition object that describes the type of a connection for a custom component action or trigger, and information on how it should be displayed in the Prismatic WebApp.
@@ -996,7 +996,7 @@ export const oauth2Connection = <T extends OAuth2ConnectionDefinition>(
 ): T => definition;
 
 /**
- * Register multiple component manifests for a code-native integration.
+ * Register multiple component manifests for a code-first integration.
  * Each manifest declares a published Prismatic component and the specific
  * actions, triggers, connections, and data sources your integration uses.
  *

--- a/packages/spectral/src/serverTypes/perform.ts
+++ b/packages/spectral/src/serverTypes/perform.ts
@@ -267,7 +267,7 @@ export const createCNIPollingPerform = <
         context: cniContext,
         invokeAction: async () => {
           throw new Error(
-            "invokeAction is not available for code-native polling triggers. " +
+            "invokeAction is not available for code-first polling triggers. " +
               "Use getState/setState to manage polling state directly in your onTrigger function.",
           );
         },

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -139,7 +139,7 @@ async function invokeFlowTest(
 }
 
 /**
- * Creates basic component action mocks based on a code-native integration's
+ * Creates basic component action mocks based on a code-first integration's
  * component registry. Each action mock returns the action's `examplePayload`
  * by default. Pass overrides in the second argument to customize specific mocks.
  *
@@ -531,7 +531,7 @@ const createConfigVars = <TConfigVarValues extends TestConfigVarValues>(
 };
 
 /**
- * Invokes a code-native integration flow within a test harness. Runs the
+ * Invokes a code-first integration flow within a test harness. Runs the
  * flow's `onTrigger` (if defined) followed by `onExecution`, and returns
  * the execution result. Accepts optional config variables, context overrides,
  * and a custom trigger payload.

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -20,7 +20,7 @@ import type { TriggerPerformFunction } from "./TriggerPerformFunction";
 import type { TriggerResult } from "./TriggerResult";
 
 /**
- * Defines attributes of a code-native integration. See
+ * Defines attributes of a code-first integration. See
  * https://prismatic.io/docs/integrations/code-native/
  */
 export type IntegrationDefinition<
@@ -87,7 +87,7 @@ export type IntegrationDefinition<
    */
   instanceProfile?: string;
   /**
-   * A list of components this code-native integration uses. See
+   * A list of components this code-first integration uses. See
    * https://prismatic.io/docs/integrations/code-native/existing-components/
    */
   componentRegistry?: ComponentRegistry;
@@ -399,7 +399,7 @@ interface PollingFlow<
   >;
 }
 
-/** Defines attributes of a flow of a code-native integration. */
+/** Defines attributes of a flow of a code-first integration. */
 export type Flow<
   TInputs extends Inputs,
   TActionInputs extends Inputs,


### PR DESCRIPTION
We've historically called integrations written using this SDK "Code-Native Integrations". It turns out, "Code-First" is a more commonly recognized industry-standard term. This updates some READMEs and comments to say "Code-First Integration" rather than "Code-Native Integration".