### PR TITLE
Add section and sectionEnd to CNI logger

### DIFF
--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
-import { spyOn } from "jest-mock";
+import { fn, spyOn } from "jest-mock";
 import type {
   ActionLogger,
   ActionLoggerFunction,
@@ -23,6 +23,7 @@ import type {
   ActionContext,
   ActionDefinition,
   ActionInputParameters,
+  CodeNativeActionLogger,
   ComponentManifest,
   ConfigVarResultCollection,
   ConnectionDefinition,
@@ -120,7 +121,7 @@ export const connectionValue = (
  * // Pass logger in context, then assert:
  * expect(logger.info).toHaveBeenCalledWith("Processing started");
  */
-export const loggerMock = (): ActionLogger => ({
+export const loggerMock = (): CodeNativeActionLogger => ({
   metric: console.log as ActionLoggerFunction,
   trace: spyOn(console, "trace") as unknown as ActionLoggerFunction,
   debug: spyOn(console, "debug") as unknown as ActionLoggerFunction,
@@ -128,6 +129,8 @@ export const loggerMock = (): ActionLogger => ({
   log: spyOn(console, "log") as unknown as ActionLoggerFunction,
   warn: spyOn(console, "warn") as unknown as ActionLoggerFunction,
   error: spyOn(console, "error") as unknown as ActionLoggerFunction,
+  section: fn() as unknown as CodeNativeActionLogger["section"],
+  sectionEnd: fn() as unknown as CodeNativeActionLogger["sectionEnd"],
 });
 
 async function invokeFlowTest(
@@ -608,7 +611,7 @@ export const invokeFlow = async <
     params.onTrigger = { results: triggerResult?.payload };
   }
 
-  const result = await flow.onExecution(realizedContext, params);
+  const result = await flow.onExecution(realizedContext as any, params);
 
   return {
     result,

--- a/packages/spectral/src/types/ActionLogger.ts
+++ b/packages/spectral/src/types/ActionLogger.ts
@@ -11,6 +11,25 @@
 export type ActionLoggerFunction = (...args: unknown[]) => void;
 
 /**
+ * Opens a log section. Logs emitted after this call are collated under the
+ * section identified by `label` until the matching `sectionEnd(label)` is called.
+ *
+ * Sections cannot be nested: calling `section` again while a section is open keeps
+ * the open section and ignores the new one.
+ */
+export type ActionLoggerSectionFunction = (label: string) => void;
+
+/**
+ * Closes the open log section. The `label` must match the label the section was
+ * opened with; a `sectionEnd` whose label does not match the open section is
+ * ignored. An optional `data` object is attached to the section as its result.
+ */
+export type ActionLoggerSectionEndFunction = (params: {
+  label: string;
+  data?: Record<string, unknown>;
+}) => void;
+
+/**
  * An object containing logger functions. See
  * https://prismatic.io/docs/custom-connectors/actions/#logger-object
  */
@@ -22,4 +41,14 @@ export interface ActionLogger {
   log: ActionLoggerFunction;
   warn: ActionLoggerFunction;
   error: ActionLoggerFunction;
+}
+
+/**
+ * The logger passed to a code-native integration's flow execution. Adds the
+ * `section`/`sectionEnd` controls for grouping a flow's logs; these take effect
+ * only inside a code-native execution.
+ */
+export interface CodeNativeActionLogger extends ActionLogger {
+  section: ActionLoggerSectionFunction;
+  sectionEnd: ActionLoggerSectionEndFunction;
 }

--- a/packages/spectral/src/types/ActionPerformFunction.ts
+++ b/packages/spectral/src/types/ActionPerformFunction.ts
@@ -105,8 +105,9 @@ export type ActionPerformFunction<
     TAllowsBranching,
     unknown
   >,
+  TLogger extends ActionLogger = ActionLogger,
 > = (
-  context: ActionContext<TConfigVars, TComponentActions>,
+  context: ActionContext<TConfigVars, TComponentActions, string[], TLogger>,
   params: ActionInputParameters<TInputs>,
 ) => Promise<TReturn>;
 
@@ -118,9 +119,10 @@ export type ActionContext<
     ComponentManifest["actions"]
   >,
   TFlows extends string[] = string[],
+  TLogger extends ActionLogger = ActionLogger,
 > = {
   /** Logger for permanent logging; console calls are also captured. */
-  logger: ActionLogger;
+  logger: TLogger;
   /** A a flow-specific key/value store that may be used to store small amounts of data that is persisted between Instance executions. */
   instanceState: Record<string, unknown>;
   /** A key/value store that is shared between flows on an Instance that may be used to store small amounts of data that is persisted between Instance executions. */

--- a/packages/spectral/src/types/IntegrationDefinition.ts
+++ b/packages/spectral/src/types/IntegrationDefinition.ts
@@ -1,3 +1,4 @@
+import type { CodeNativeActionLogger } from "./ActionLogger";
 import type { ActionContext, ActionPerformFunction } from "./ActionPerformFunction";
 import type { ActionPerformReturn } from "./ActionPerformReturn";
 import type {
@@ -173,14 +174,17 @@ export type FlowOnExecution<
     [Key in keyof ComponentRegistry]: ComponentRegistry[Key]["actions"];
   },
   false,
-  ActionPerformReturn<false, unknown>
+  ActionPerformReturn<false, unknown>,
+  CodeNativeActionLogger
 >;
 
 export type FlowExecutionContext = ActionContext<
   ConfigVars,
   {
     [Key in keyof ComponentRegistry]: ComponentRegistry[Key]["actions"];
-  }
+  },
+  string[],
+  CodeNativeActionLogger
 >;
 
 export type FlowExecutionContextActions = FlowExecutionContext["components"];


### PR DESCRIPTION
Expose `section` and `sectionEnd` as an extension to the `ActionLogger` for CNI.

```
context.logger.section('Fetch')
context.logger.info('A log in the Fetch section')

const myRespObj = await getSomeData()
context.logger.sectionEnd('Fetch', data=myRespObj)
```