### PR TITLE
Keep a user-activated connection on its user level page

### DIFF
--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -348,9 +348,9 @@ describe("convertConfigPages", () => {
   });
 
   /**
-   * The inverse rule. Every other connection kind is reusable rather than activated by
-   * each person, so a user level page would ask every individual for a credential that is
-   * not theirs to give.
+   * The inverse rule. Every other connection kind is activated by the organization or
+   * the customer rather than by each person, so a user level page would ask every
+   * individual for a credential that is not theirs to give.
    */
   it("refuses an organization- or customer-activated connection on a user level config page", () => {
     const pages = {
@@ -416,7 +416,7 @@ describe("convertConfigPages", () => {
     ]);
   });
 
-  it("still removes reusable connections from an ordinary config page", () => {
+  it("still removes organization- and customer-activated connections from an ordinary config page", () => {
     expect(
       convertConfigPages(
         {

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -348,9 +348,9 @@ describe("convertConfigPages", () => {
   });
 
   /**
-   * The inverse rule. Every other connection kind is supplied once rather than by each
-   * person, so a user level page would ask every individual for a credential that is not
-   * theirs to give.
+   * The inverse rule. Every other connection kind is reusable rather than activated by
+   * each person, so a user level page would ask every individual for a credential that is
+   * not theirs to give.
    */
   it("refuses an organization- or customer-activated connection on a user level config page", () => {
     const pages = {
@@ -416,7 +416,7 @@ describe("convertConfigPages", () => {
     ]);
   });
 
-  it("still removes connections supplied once from an ordinary config page", () => {
+  it("still removes reusable connections from an ordinary config page", () => {
     expect(
       convertConfigPages(
         {

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -393,7 +393,7 @@ describe("convertConfigPages", () => {
     );
   });
 
-  it("accepts a user-activated connection on a user level config page", () => {
+  it("keeps a user-activated connection on its user level config page", () => {
     expect(
       convertConfigPages(
         {
@@ -411,7 +411,29 @@ describe("convertConfigPages", () => {
         name: "Connections",
         tagline: "Connect your account",
         userLevelConfigured: true,
-        elements: [],
+        elements: [{ type: "configVar", value: "User Slack" }],
+      },
+    ]);
+  });
+
+  it("still removes connections supplied once from an ordinary config page", () => {
+    expect(
+      convertConfigPages(
+        {
+          Connections: configPage({
+            elements: {
+              "Shared Slack": organizationActivatedConnection({ stableKey: "org-slack" }),
+              Region: configVar({ stableKey: "region", dataType: "string" }),
+            },
+          }),
+        },
+        false,
+      ),
+    ).toEqual([
+      {
+        name: "Connections",
+        tagline: undefined,
+        elements: [{ type: "configVar", value: "Region" }],
       },
     ]);
   });

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -29,6 +29,7 @@ import {
   isConnectionDefinitionConfigVar,
   isConnectionReferenceConfigVar,
   isConnectionScopedConfigVar,
+  isConnectionSuppliedBeforeWizard,
   isDataSourceDefinitionConfigVar,
   isDataSourceReferenceConfigVar,
   isHtmlElementConfigVar,
@@ -304,10 +305,9 @@ export const convertConfigPages = (
       Object.entries(elements)
         .filter(
           ([_key, value]) =>
-            !isUserScopedConnectionConfigVar(value) &&
-            (isConnectionScopedConfigVar(value) ||
-              isConnectionDefinitionConfigVar(value as ConfigVar) ||
-              isConnectionReferenceConfigVar(value as ConfigVar)),
+            isConnectionSuppliedBeforeWizard(value) ||
+            isConnectionDefinitionConfigVar(value as ConfigVar) ||
+            isConnectionReferenceConfigVar(value as ConfigVar),
         )
         .map(([key]) => `"${key}" on user level config page "${name}"`),
     );
@@ -324,23 +324,17 @@ export const convertConfigPages = (
     tagline,
     ...(userLevelConfigured ? { userLevelConfigured } : {}),
     /**
-     * Scoped connections are supplied once, ahead of the wizard, so they are not
-     * elements anyone fills in and are removed here.
-     *
-     * A user-activated connection is the exception, and stays. Each person activates
-     * it themselves, so which page it was declared on is the whole of what marks it
-     * user level — the platform reads that from page membership and has nothing else
-     * to go on. Removing it left the connection looking like ordinary instance
-     * configuration, which the platform refuses.
+     * A user-activated connection is the one connection that stays. Which page it
+     * was declared on is the whole of what marks it user level — the platform reads
+     * that from page membership and has nothing else to go on. Removing it left the
+     * connection looking like ordinary instance configuration, which the platform
+     * refuses.
      *
      * Only reachable on a user level page: the guard above rejects a user-activated
      * connection declared anywhere else.
      */
     elements: Object.entries(elements)
-      .filter(
-        ([_key, value]) =>
-          !isConnectionScopedConfigVar(value) || isUserScopedConnectionConfigVar(value),
-      )
+      .filter(([_key, value]) => !isConnectionSuppliedBeforeWizard(value))
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -28,13 +28,13 @@ import {
   isComponentReference,
   isConnectionDefinitionConfigVar,
   isConnectionReferenceConfigVar,
-  isConnectionReusable,
   isConnectionScopedConfigVar,
   isDataSourceDefinitionConfigVar,
   isDataSourceReferenceConfigVar,
   isHtmlElementConfigVar,
   isJsonFormConfigVar,
   isJsonFormDataSourceConfigVar,
+  isNonUserActivatedConnection,
   isScheduleConfigVar,
   isUserScopedConnectionConfigVar,
   type KeyValuePair,
@@ -297,8 +297,8 @@ export const convertConfigPages = (
 
   /**
    * The inverse, and refused for the opposite reason: every other connection kind is
-   * reusable, activated once by the organization or the customer, so a user level page
-   * would ask each individual for a credential that is not theirs. See
+   * activated once by the organization or the customer, so a user level page would ask
+   * each individual for a credential that is not theirs. See
    * `UserLevelConfigPageElement`.
    */
   if (userLevelConfigured) {
@@ -306,7 +306,7 @@ export const convertConfigPages = (
       Object.entries(elements)
         .filter(
           ([_key, value]) =>
-            isConnectionReusable(value) ||
+            isNonUserActivatedConnection(value) ||
             isConnectionDefinitionConfigVar(value as ConfigVar) ||
             isConnectionReferenceConfigVar(value as ConfigVar),
         )
@@ -315,7 +315,7 @@ export const convertConfigPages = (
 
     if (misplaced.length) {
       throw new Error(
-        `Only a user-activated connection belongs on a user level config page: every other kind is reusable rather than activated by each person. Move ${misplaced.join(", ")}.`,
+        `Only a user-activated connection belongs on a user level config page: every other kind is activated by the organization or the customer rather than by each person. Move ${misplaced.join(", ")}.`,
       );
     }
   }
@@ -335,7 +335,7 @@ export const convertConfigPages = (
      * connection declared anywhere else.
      */
     elements: Object.entries(elements)
-      .filter(([_key, value]) => !isConnectionReusable(value))
+      .filter(([_key, value]) => !isNonUserActivatedConnection(value))
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -34,7 +34,7 @@ import {
   isHtmlElementConfigVar,
   isJsonFormConfigVar,
   isJsonFormDataSourceConfigVar,
-  isNonUserActivatedConnection,
+  isOrgOrCustomerActivatedConnection,
   isScheduleConfigVar,
   isUserScopedConnectionConfigVar,
   type KeyValuePair,
@@ -267,6 +267,18 @@ export const convertIntegration = <
   };
 };
 
+/**
+ * Whether this element is a connection of a kind a user level page does not collect.
+ *
+ * Three shapes rather than one: `isOrgOrCustomerActivatedConnection` covers a bare
+ * pointer at a Scoped Config Variable, and a connection declared inline or referenced
+ * from a component is deliberately excluded from that predicate, so each needs naming.
+ */
+const isRefusedOnUserLevelPage = (value: unknown): boolean =>
+  isOrgOrCustomerActivatedConnection(value) ||
+  isConnectionDefinitionConfigVar(value as ConfigVar) ||
+  isConnectionReferenceConfigVar(value as ConfigVar);
+
 export const convertConfigPages = (
   pages: ConfigPages | UserLevelConfigPages | undefined,
   userLevelConfigured: boolean,
@@ -302,12 +314,7 @@ export const convertConfigPages = (
   if (userLevelConfigured) {
     const misplaced = Object.entries(pages).flatMap(([name, { elements }]) =>
       Object.entries(elements)
-        .filter(
-          ([_key, value]) =>
-            isNonUserActivatedConnection(value) ||
-            isConnectionDefinitionConfigVar(value as ConfigVar) ||
-            isConnectionReferenceConfigVar(value as ConfigVar),
-        )
+        .filter(([_key, value]) => isRefusedOnUserLevelPage(value))
         .map(([key]) => `"${key}" on user level config page "${name}"`),
     );
 
@@ -328,7 +335,7 @@ export const convertConfigPages = (
      * ordinary instance configuration, which the platform refuses.
      */
     elements: Object.entries(elements)
-      .filter(([_key, value]) => !isNonUserActivatedConnection(value))
+      .filter(([_key, value]) => !isOrgOrCustomerActivatedConnection(value))
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -276,10 +276,9 @@ export const convertConfigPages = (
   }
 
   /**
-   * Checked before the filter below, which removes scoped connections from the page
-   * and with them the only record of which page they were declared on. See
-   * `ConfigPageElement` for why placement matters. Every page is inspected before
-   * throwing, so fixing one does not simply uncover the next.
+   * Checked before the filter below, which strips scoped connections and with them the
+   * only record of which page they were declared on. Every page is inspected before
+   * throwing, so fixing one does not uncover the next.
    */
   if (!userLevelConfigured) {
     const misplaced = Object.entries(pages).flatMap(([name, { elements }]) =>
@@ -296,10 +295,9 @@ export const convertConfigPages = (
   }
 
   /**
-   * The inverse, and refused for the opposite reason: every other connection kind is
-   * activated once by the organization or the customer, so a user level page would ask
-   * each individual for a credential that is not theirs. See
-   * `UserLevelConfigPageElement`.
+   * The inverse: every other connection kind is activated once by the organization or
+   * the customer, so a user level page would ask each person for a credential that is
+   * not theirs. See `UserLevelConfigPageElement`.
    */
   if (userLevelConfigured) {
     const misplaced = Object.entries(pages).flatMap(([name, { elements }]) =>
@@ -325,14 +323,9 @@ export const convertConfigPages = (
     tagline,
     ...(userLevelConfigured ? { userLevelConfigured } : {}),
     /**
-     * A user-activated connection is the one connection that stays. Which page it
-     * was declared on is the whole of what marks it user level — the platform reads
-     * that from page membership and has nothing else to go on. Removing it left the
-     * connection looking like ordinary instance configuration, which the platform
-     * refuses.
-     *
-     * Only reachable on a user level page: the guard above rejects a user-activated
-     * connection declared anywhere else.
+     * A user-activated connection is the one connection that stays. Page membership is
+     * all that marks it user level, so stripping it leaves the connection looking like
+     * ordinary instance configuration, which the platform refuses.
      */
     elements: Object.entries(elements)
       .filter(([_key, value]) => !isNonUserActivatedConnection(value))
@@ -1067,9 +1060,9 @@ export const convertConfigVar = (
     const { stableKey } = pick(configVar, ["stableKey"]);
 
     /**
-     * `userScopedConnection` is a declaration-time distinction only. The server
-     * resolves scope from the Scoped Config Variable the stable key names, so every
-     * scoped kind emits the same shape and the discriminator stops here.
+     * `userScopedConnection` is a declaration-time distinction only. The server resolves
+     * scope from the Scoped Config Variable the stable key names, so every scoped kind
+     * emits the same shape and the discriminator stops here.
      */
     return {
       key,

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -28,8 +28,8 @@ import {
   isComponentReference,
   isConnectionDefinitionConfigVar,
   isConnectionReferenceConfigVar,
+  isConnectionReusable,
   isConnectionScopedConfigVar,
-  isConnectionSuppliedBeforeWizard,
   isDataSourceDefinitionConfigVar,
   isDataSourceReferenceConfigVar,
   isHtmlElementConfigVar,
@@ -297,15 +297,16 @@ export const convertConfigPages = (
 
   /**
    * The inverse, and refused for the opposite reason: every other connection kind is
-   * supplied once, by the organization or by the customer, so a user level page would ask
-   * each individual for a credential that is not theirs. See `UserLevelConfigPageElement`.
+   * reusable, activated once by the organization or the customer, so a user level page
+   * would ask each individual for a credential that is not theirs. See
+   * `UserLevelConfigPageElement`.
    */
   if (userLevelConfigured) {
     const misplaced = Object.entries(pages).flatMap(([name, { elements }]) =>
       Object.entries(elements)
         .filter(
           ([_key, value]) =>
-            isConnectionSuppliedBeforeWizard(value) ||
+            isConnectionReusable(value) ||
             isConnectionDefinitionConfigVar(value as ConfigVar) ||
             isConnectionReferenceConfigVar(value as ConfigVar),
         )
@@ -314,7 +315,7 @@ export const convertConfigPages = (
 
     if (misplaced.length) {
       throw new Error(
-        `Only a user-activated connection belongs on a user level config page: every other kind is supplied once rather than by each person. Move ${misplaced.join(", ")}.`,
+        `Only a user-activated connection belongs on a user level config page: every other kind is reusable rather than activated by each person. Move ${misplaced.join(", ")}.`,
       );
     }
   }
@@ -334,7 +335,7 @@ export const convertConfigPages = (
      * connection declared anywhere else.
      */
     elements: Object.entries(elements)
-      .filter(([_key, value]) => !isConnectionSuppliedBeforeWizard(value))
+      .filter(([_key, value]) => !isConnectionReusable(value))
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -323,8 +323,24 @@ export const convertConfigPages = (
     name,
     tagline,
     ...(userLevelConfigured ? { userLevelConfigured } : {}),
+    /**
+     * Scoped connections are supplied once, ahead of the wizard, so they are not
+     * elements anyone fills in and are removed here.
+     *
+     * A user-activated connection is the exception, and stays. Each person activates
+     * it themselves, so which page it was declared on is the whole of what marks it
+     * user level — the platform reads that from page membership and has nothing else
+     * to go on. Removing it left the connection looking like ordinary instance
+     * configuration, which the platform refuses.
+     *
+     * Only reachable on a user level page: the guard above rejects a user-activated
+     * connection declared anywhere else.
+     */
     elements: Object.entries(elements)
-      .filter(([_key, value]) => !isConnectionScopedConfigVar(value))
+      .filter(
+        ([_key, value]) =>
+          !isConnectionScopedConfigVar(value) || isUserScopedConnectionConfigVar(value),
+      )
       .map(([key, value]) => {
         if (typeof value === "string") {
           return {

--- a/packages/spectral/src/types/ConfigPages.ts
+++ b/packages/spectral/src/types/ConfigPages.ts
@@ -49,9 +49,9 @@ export type ConfigPageElement = string | Exclude<ConfigVar, UserActivatedConnect
  * What a user level config page may contain.
  *
  * Every connection kind except the per-person one is excluded. A page on this wizard is
- * shown to each individual, and any other kind is reusable – activated once by the
- * organization or by the customer – so putting one here asks every person for something
- * that is not theirs to give, and asks it repeatedly. Config vars that are not
+ * shown to each individual, and any other kind is activated once – by the organization
+ * or by the customer – so putting one here asks every person for something that is not
+ * theirs to give, and asks it repeatedly. Config vars that are not
  * connections are unaffected: a per-person string or picklist is a real thing to collect.
  *
  * The mirror of `ConfigPageElement`, and stated the same way: the type is the canonical

--- a/packages/spectral/src/types/ConfigPages.ts
+++ b/packages/spectral/src/types/ConfigPages.ts
@@ -49,9 +49,9 @@ export type ConfigPageElement = string | Exclude<ConfigVar, UserActivatedConnect
  * What a user level config page may contain.
  *
  * Every connection kind except the per-person one is excluded. A page on this wizard is
- * shown to each individual, and the credential behind any other kind is supplied once –
- * by the organization or by the customer – so putting one here asks every person for
- * something that is not theirs to give, and asks it repeatedly. Config vars that are not
+ * shown to each individual, and any other kind is reusable – activated once by the
+ * organization or by the customer – so putting one here asks every person for something
+ * that is not theirs to give, and asks it repeatedly. Config vars that are not
  * connections are unaffected: a per-person string or picklist is a real thing to collect.
  *
  * The mirror of `ConfigPageElement`, and stated the same way: the type is the canonical

--- a/packages/spectral/src/types/ConfigPages.ts
+++ b/packages/spectral/src/types/ConfigPages.ts
@@ -37,26 +37,19 @@ export interface IntegrationDefinitionUserLevelConfigPages {}
 /**
  * What an ordinary config page may contain.
  *
- * A user-activated connection is excluded because it is activated by each person
- * individually, which only a user level config page supports. Anywhere else it is
- * emitted as an ordinary shared connection – byte for byte what a non-user-scoped
- * declaration produces – so the author would lose the feature with no error. This is
- * the canonical statement of that rule; the convert layer enforces it at build time.
+ * A user-activated connection is excluded. It is only supported on a user level config
+ * page; anywhere else it emits as an ordinary shared connection, so the author would
+ * lose the feature with no error. The convert layer enforces this at build time.
  */
 export type ConfigPageElement = string | Exclude<ConfigVar, UserActivatedConnectionConfigVar>;
 
 /**
  * What a user level config page may contain.
  *
- * Every connection kind except the per-person one is excluded. A page on this wizard is
- * shown to each individual, and any other kind is activated once – by the organization
- * or by the customer – so putting one here asks every person for something that is not
- * theirs to give, and asks it repeatedly. Config vars that are not
- * connections are unaffected: a per-person string or picklist is a real thing to collect.
- *
- * The mirror of `ConfigPageElement`, and stated the same way: the type is the canonical
- * rule and the convert layer enforces it at build time, so a JavaScript author hits it
- * too.
+ * Only the per-person connection kind. Every other kind is activated once by the
+ * organization or the customer, so putting one here asks each person for a credential
+ * that is not theirs to give. Config vars that are not connections are unaffected.
+ * The convert layer enforces this at build time.
  */
 export type UserLevelConfigPageElement =
   | string
@@ -67,12 +60,7 @@ export type UserLevelConfigPageElement =
       | OrganizationActivatedConnectionConfigVar
     >;
 
-/**
- * An element on a page of either kind.
- *
- * For the code that walks both wizards at once. The two element types are deliberately
- * different sets now, so a shared consumer has no single narrower type to reach for.
- */
+/** An element on a page of either kind, for code that walks both wizards at once. */
 export type AnyConfigPageElement = ConfigPageElement | UserLevelConfigPageElement;
 
 type CreateConfigPages<TIntegrationDefinitionConfigPages, TPage> =
@@ -107,8 +95,8 @@ export interface ConfigPage {
 /**
  * Defines attributes of a Config Wizard Page each person configures for themselves.
  *
- * Separate from `ConfigPage` so a user-activated connection can be accepted here and
- * refused everywhere else.
+ * Separate from `ConfigPage` so a user-activated connection is accepted here and refused
+ * everywhere else.
  */
 export interface UserLevelConfigPage {
   /** Elements included on this Config Page. */

--- a/packages/spectral/src/types/ConfigVars.ts
+++ b/packages/spectral/src/types/ConfigVars.ts
@@ -408,11 +408,8 @@ type GetDataSourceReference<
 /**
  * Any element either kind of config page may hold.
  *
- * Local to this module and deliberately not exported: mapping an element to its
- * runtime type is the same work whichever page it was declared on, so the two
- * helpers below should not appear to require a particular page kind. `ConfigPage`
- * accepts a narrower set than this, and that narrowing is a placement rule rather
- * than anything these helpers care about.
+ * Not exported. Mapping an element to its runtime type is the same work whichever page
+ * it was declared on, so the helpers below should not appear to require a page kind.
  */
 type AnyPageElement = string | ConfigVar;
 
@@ -437,10 +434,9 @@ type DataSourceToRuntimeType<TElement extends AnyPageElement> =
 type ElementToRuntimeType<TElement extends AnyPageElement> = TElement extends ConfigVar
   ? TElement extends ConnectionConfigVar
     ? Connection
-    : /* A page element naming a Scoped Config Variable resolves to a Connection like
-       * any other, matching what ExtractScopedConfigVars gives the same declaration
-       * made under `scopedConfigVars`. Without this the value is `never`, so the
-       * connection an author declared on a page cannot be used at runtime. */
+    : /* A page element naming a Scoped Config Variable resolves to a Connection, matching
+       * what ExtractScopedConfigVars gives the same declaration under `scopedConfigVars`.
+       * Without this it resolves to `never` and the connection is unusable at runtime. */
       TElement extends ScopedConfigVar
       ? Connection
       : TElement extends StandardConfigVar

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -19,9 +19,8 @@ export type OrganizationActivatedConnectionConfigVar = {
  * A connection each person activates for themselves.
  *
  * Carries its own `dataType` so it can be told apart from the organization- and
- * customer-activated kinds, which are otherwise structurally identical. See
- * `ConfigPageElement` for what that distinction buys. The convert layer rewrites it
- * to the shape the API expects, so this name never reaches the server.
+ * customer-activated kinds, which are otherwise identical. The convert layer rewrites
+ * it to the shape the API expects before it reaches the server.
  */
 export type UserActivatedConnectionConfigVar = {
   dataType: "userScopedConnection";
@@ -80,9 +79,8 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
     return false;
   }
 
-  // Applied to both kinds: a declaration carrying a component reference or its own
-  // inputs is a connection definition rather than a reference to a Scoped Config
-  // Variable, whichever `dataType` it claims.
+  // A declaration carrying a component reference or its own inputs is a connection
+  // definition, not a reference to a Scoped Config Variable.
   return (
     !isConnectionDefinitionConfigVar(cv as ConfigVar) &&
     !isConnectionReferenceConfigVar(cv as ConfigVar)
@@ -90,14 +88,11 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
 };
 
 /**
- * Whether this connection is activated by the organization or the customer rather
- * than by each person. Both kinds are reusable, so that is not the distinction:
- * a user-activated connection is reused across every instance its owner
- * configures. What separates them is who activates it, and how many people it
- * then answers for.
+ * Whether this connection is scoped to the organization or the customer rather than to
+ * a specific person.
  *
- * This is what decides whether a connection survives as a config page element.
- * The others are stripped, because nobody fills them in on the wizard.
+ * Only a user-activated connection survives as a config page element. The rest are
+ * stripped, because nobody fills them in on the wizard.
  */
 export const isNonUserActivatedConnection = (
   cv: unknown,

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -90,15 +90,16 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
 };
 
 /**
- * Whether this is a reusable connection: one the organization or the customer
- * activates once, which every person then shares. True of every scoped kind
- * except the user-activated one, the only connection an individual activates for
- * themselves.
+ * Whether this connection is activated by the organization or the customer rather
+ * than by each person. Both kinds are reusable, so that is not the distinction:
+ * a user-activated connection is reused across every instance its owner
+ * configures. What separates them is who activates it, and how many people it
+ * then answers for.
  *
- * This is the distinction that decides whether a connection survives as a config
- * page element: a reusable one is stripped, because nobody fills it in.
+ * This is what decides whether a connection survives as a config page element.
+ * The others are stripped, because nobody fills them in on the wizard.
  */
-export const isConnectionReusable = (
+export const isNonUserActivatedConnection = (
   cv: unknown,
 ): cv is CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar =>
   isConnectionScopedConfigVar(cv) && !isUserScopedConnectionConfigVar(cv);

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -89,6 +89,17 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
   );
 };
 
+/**
+ * Whether this connection is supplied once, ahead of the wizard, rather than by
+ * each person. True of every scoped kind except the user-activated one, which is
+ * the only connection an individual activates for themselves.
+ *
+ * This is the distinction that decides whether a connection survives as a config
+ * page element: the rest are stripped, because nobody fills them in.
+ */
+export const isConnectionSuppliedBeforeWizard = (cv: unknown): boolean =>
+  isConnectionScopedConfigVar(cv) && !isUserScopedConnectionConfigVar(cv);
+
 /** Whether this config var is a connection each person activates for themselves. */
 export const isUserScopedConnectionConfigVar = (
   cv: unknown,

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -90,14 +90,17 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
 };
 
 /**
- * Whether this connection is supplied once, ahead of the wizard, rather than by
- * each person. True of every scoped kind except the user-activated one, which is
- * the only connection an individual activates for themselves.
+ * Whether this is a reusable connection: one the organization or the customer
+ * activates once, which every person then shares. True of every scoped kind
+ * except the user-activated one, the only connection an individual activates for
+ * themselves.
  *
  * This is the distinction that decides whether a connection survives as a config
- * page element: the rest are stripped, because nobody fills them in.
+ * page element: a reusable one is stripped, because nobody fills it in.
  */
-export const isConnectionSuppliedBeforeWizard = (cv: unknown): boolean =>
+export const isConnectionReusable = (
+  cv: unknown,
+): cv is CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar =>
   isConnectionScopedConfigVar(cv) && !isUserScopedConnectionConfigVar(cv);
 
 /** Whether this config var is a connection each person activates for themselves. */

--- a/packages/spectral/src/types/ScopedConfigVars.ts
+++ b/packages/spectral/src/types/ScopedConfigVars.ts
@@ -94,7 +94,7 @@ export const isConnectionScopedConfigVar = (cv: unknown): cv is ScopedConfigVar 
  * Only a user-activated connection survives as a config page element. The rest are
  * stripped, because nobody fills them in on the wizard.
  */
-export const isNonUserActivatedConnection = (
+export const isOrgOrCustomerActivatedConnection = (
   cv: unknown,
 ): cv is CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar =>
   isConnectionScopedConfigVar(cv) && !isUserScopedConnectionConfigVar(cv);


### PR DESCRIPTION
## The problem

A code-native integration declaring a `userActivatedConnection` cannot be imported. The platform refuses it:

```
Error: definition: Required Config Var 'Your Dropbox Account' cannot use
user-level reusable connection 'dropbox-connection-baaaaaaaa'.
```

`convertConfigPages` removes scoped connections from a page's `elements`, and did so for user-activated connections too. That is right for a reusable connection – it is activated once, ahead of the wizard, and is not something a person fills in. It is wrong for this one.

A user-activated connection is activated by each person individually, and **the page it was declared on is the only record that it is user level**. The platform reads that from page membership (`build_ulc_config_var_mapping`) and has nothing else to go on. With the element removed, the connection was indistinguishable from ordinary instance configuration.

Nothing could supply the missing fact and there was no way to author around it, so this shape simply did not work from a code-native integration. Integrations built in the designer were unaffected, which is why it went unnoticed.

## The change

```diff
- .filter(([_key, value]) => !isConnectionScopedConfigVar(value))
+ .filter(([_key, value]) => !isConnectionReusable(value))
```

Whether a connection survives as an element comes down to one question: is it reusable, or does each person activate their own.

```ts
isConnectionReusable = (cv): cv is
  | CustomerActivatedConnectionConfigVar
  | OrganizationActivatedConnectionConfigVar =>
  isConnectionScopedConfigVar(cv) && !isUserScopedConnectionConfigVar(cv);
```

That is not a new idea in this codebase, which is the reason for the name. The manifest generator already emits a `ReusableConnection` returning `OrganizationActivatedConnectionConfigVar | CustomerActivatedConnectionConfigVar` – exactly the set this guard matches – so the guard narrows to that union rather than returning `boolean`, and the comments and the build error use the same word.

`isConnectionScopedConfigVar` deliberately still matches a user-activated connection, because it is one. `convertConfigVar` relies on that to emit the same `useScopedConfigVar` shape for every scoped kind. Narrowing it instead would push the special case somewhere worse.

The exception is only reachable on a user level page – the guard above already throws if a user-activated connection is declared anywhere else.

A kept element falls through to the existing default and emits `{ type: "configVar", value: key }`, which is the shape the platform reads. No new element type, no change to any other page.

## Emitted output

Before:

```yaml
configPages:
  - name: Your Dropbox
    userLevelConfigured: true
    elements: []
```

After:

```yaml
configPages:
  - name: Your Dropbox
    userLevelConfigured: true
    elements:
      - type: htmlElement
        value: Introduction
      - type: configVar
        value: Your Dropbox Account
```

## Verification

- 333 tests pass; `biome check` clean
- One test updated – it asserted the removal that caused this – and one added, covering that ordinary pages still drop reusable connections
- **Imported end to end against a live stack.** A code-native integration carrying a user-activated connection now imports, and the platform records it correctly:

```
estate-multi-simple  codeNative=True  integration.userLevelConfigured=True
   Your Dropbox Account | rcv.userLevelConfigured=True | orgOnly=False
                        | dropbox-connection-baaaaaaaa  USER
```

The same integration was refused before this change.
