### PR TITLE
Add @prismatic-io/eslint-plugin-spectral for section linting rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         options:
           - spectral
           - eslint-config-spectral
+          - eslint-plugin-spectral
       bump:
         description: "Version bump type"
         required: true

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       "name": "@prismatic-io/eslint-config-spectral",
       "version": "2.2.0",
       "dependencies": {
+        "@prismatic-io/eslint-plugin-spectral": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.67.0",
         "eslint-config-prettier": "10.1.8",
@@ -29,9 +30,28 @@
         "typescript": ">=5",
       },
     },
+    "packages/eslint-plugin-spectral": {
+      "name": "@prismatic-io/eslint-plugin-spectral",
+      "version": "1.0.0",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.67.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.15",
+        "@types/eslint": "9.6.1",
+        "@types/node": "26.1.2",
+        "@typescript-eslint/rule-tester": "^8.67.0",
+        "eslint": "^8.57.1",
+        "typescript": "^6",
+        "vitest": "^4.1.10",
+      },
+      "peerDependencies": {
+        "eslint": ">=8",
+      },
+    },
     "packages/spectral": {
       "name": "@prismatic-io/spectral",
-      "version": "10.26.1",
+      "version": "10.28.0",
       "bin": {
         "component-manifest": "bin/component-manifest.js",
         "cni-component-manifest": "bin/cni-component-manifest.js",
@@ -168,6 +188,10 @@
 
     "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
 
+    "@eslint/eslintrc": ["@eslint/eslintrc@2.1.4", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^9.6.0", "globals": "^13.19.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ=="],
+
+    "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
+
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
@@ -178,7 +202,11 @@
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
 
+    "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
+
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/object-schema": ["@humanwhocodes/object-schema@2.0.3", "", {}, "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
@@ -203,6 +231,8 @@
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
     "@prismatic-io/eslint-config-spectral": ["@prismatic-io/eslint-config-spectral@workspace:packages/eslint-config-spectral"],
+
+    "@prismatic-io/eslint-plugin-spectral": ["@prismatic-io/eslint-plugin-spectral@workspace:packages/eslint-plugin-spectral"],
 
     "@prismatic-io/spectral": ["@prismatic-io/spectral@workspace:packages/spectral"],
 
@@ -312,6 +342,8 @@
 
     "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.67.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.67.0", "@typescript-eslint/types": "^8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw=="],
 
+    "@typescript-eslint/rule-tester": ["@typescript-eslint/rule-tester@8.69.0", "", { "dependencies": { "@typescript-eslint/parser": "8.69.0", "@typescript-eslint/typescript-estree": "8.69.0", "@typescript-eslint/utils": "8.69.0", "ajv": "^6.12.6", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "4.6.2", "semver": "^7.7.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-VHKAWEzEeB+XgLzgvkP3eFAkNaKhF1TEBZvjuZ9G8ySp4u6iZjnfBVBwEtXocO/a+g/B32II+WaSf5OcikmAyg=="],
+
     "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
 
     "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.67.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg=="],
@@ -325,6 +357,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.4.0", "", {}, "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ=="],
 
     "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
 
@@ -394,6 +428,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
 
     "array-includes": ["array-includes@3.1.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.0", "es-object-atoms": "^1.1.1", "get-intrinsic": "^1.3.0", "is-string": "^1.1.1", "math-intrinsics": "^1.1.0" } }, "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ=="],
@@ -437,6 +473,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
@@ -622,6 +660,8 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "globals": ["globals@13.24.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ=="],
+
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
@@ -629,6 +669,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 
@@ -653,6 +695,8 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -704,6 +748,8 @@
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
 
+    "is-path-inside": ["is-path-inside@3.0.3", "", {}, "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="],
+
     "is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
@@ -744,6 +790,8 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
+
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
@@ -765,6 +813,8 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
 
@@ -838,6 +888,8 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -900,9 +952,13 @@
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
@@ -980,6 +1036,8 @@
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-hyperlinks": ["supports-hyperlinks@2.3.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA=="],
@@ -987,6 +1045,8 @@
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "synckit": ["synckit@0.11.13", "", { "dependencies": { "@pkgr/core": "^0.3.6" } }, "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg=="],
+
+    "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 
     "through2": ["through2@2.0.5", "", { "dependencies": { "readable-stream": "~2.3.6", "xtend": "~4.0.1" } }, "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ=="],
 
@@ -1014,7 +1074,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
@@ -1080,17 +1140,35 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/eslintrc/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "@fast-check/vitest/fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "@humanwhocodes/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@jest/pattern/@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@jest/types/@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
+
+    "@prismatic-io/eslint-plugin-spectral/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint": ["eslint@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.6.1", "@eslint/eslintrc": "^2.1.4", "@eslint/js": "8.57.1", "@humanwhocodes/config-array": "^0.13.0", "@humanwhocodes/module-importer": "^1.0.1", "@nodelib/fs.walk": "^1.2.8", "@ungap/structured-clone": "^1.2.0", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.2", "debug": "^4.3.2", "doctrine": "^3.0.0", "escape-string-regexp": "^4.0.0", "eslint-scope": "^7.2.2", "eslint-visitor-keys": "^3.4.3", "espree": "^9.6.1", "esquery": "^1.4.2", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^6.0.1", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "globals": "^13.19.0", "graphemer": "^1.4.0", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "is-path-inside": "^3.0.3", "js-yaml": "^4.1.0", "json-stable-stringify-without-jsonify": "^1.0.1", "levn": "^0.4.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3", "strip-ansi": "^6.0.1", "text-table": "^0.2.0" }, "bin": { "eslint": "bin/eslint.js" } }, "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA=="],
 
     "@types/prettier/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
 
     "@types/sax/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/parser": ["@typescript-eslint/parser@8.69.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.69.0", "@typescript-eslint/types": "8.69.0", "@typescript-eslint/typescript-estree": "8.69.0", "@typescript-eslint/visitor-keys": "8.69.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.69.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.69.0", "@typescript-eslint/tsconfig-utils": "8.69.0", "@typescript-eslint/types": "8.69.0", "@typescript-eslint/visitor-keys": "8.69.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/utils": ["@typescript-eslint/utils@8.69.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.69.0", "@typescript-eslint/types": "8.69.0", "@typescript-eslint/typescript-estree": "8.69.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw=="],
+
+    "@typescript-eslint/rule-tester/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1124,6 +1202,8 @@
 
     "jest-util/@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
+    "meow/type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "normalize-package-data/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -1148,11 +1228,47 @@
 
     "which-builtin-type/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
+    "@eslint/eslintrc/espree/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "@humanwhocodes/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
     "@jest/pattern/@types/node/undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
     "@jest/types/@types/node/undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
 
+    "@prismatic-io/eslint-plugin-spectral/eslint/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/eslint-scope": ["eslint-scope@7.2.2", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/file-entry-cache": ["file-entry-cache@6.0.1", "", { "dependencies": { "flat-cache": "^3.0.4" } }, "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "@types/sax/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.69.0", "", { "dependencies": { "@typescript-eslint/types": "8.69.0", "@typescript-eslint/visitor-keys": "8.69.0" } }, "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.69.0", "", {}, "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.69.0", "", { "dependencies": { "@typescript-eslint/types": "8.69.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.69.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.69.0", "@typescript-eslint/types": "^8.69.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/typescript-estree/@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.69.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.69.0", "", {}, "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.69.0", "", { "dependencies": { "@typescript-eslint/types": "8.69.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.69.0", "", { "dependencies": { "@typescript-eslint/types": "8.69.0", "@typescript-eslint/visitor-keys": "8.69.0" } }, "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.69.0", "", {}, "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA=="],
 
     "copyfiles/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -1176,6 +1292,16 @@
 
     "through2/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
+    "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@humanwhocodes/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/file-entry-cache/flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "@typescript-eslint/rule-tester/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.69.0", "", { "dependencies": { "@typescript-eslint/types": "8.69.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w=="],
+
     "copyfiles/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -1183,6 +1309,8 @@
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "@prismatic-io/eslint-plugin-spectral/eslint/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }

--- a/mise.toml
+++ b/mise.toml
@@ -30,10 +30,10 @@ description = "Run all CI validation checks"
 depends = ["check", "test", "tsd"]
 
 [tasks.version-bump]
-description = "Bump a package's version (set PACKAGE=spectral|eslint-config-spectral and BUMP_TYPE=patch|minor|major|preview)"
+description = "Bump a package's version (set PACKAGE=spectral|eslint-config-spectral|eslint-plugin-spectral and BUMP_TYPE=patch|minor|major|preview)"
 run = """
 if [ -z "$PACKAGE" ]; then
-  echo "ERROR: PACKAGE env var is required (spectral|eslint-config-spectral)."
+  echo "ERROR: PACKAGE env var is required (spectral|eslint-config-spectral|eslint-plugin-spectral)."
   exit 1
 fi
 if [ ! -d "packages/$PACKAGE" ]; then
@@ -52,7 +52,7 @@ fi
 description = "Trigger a release workflow on GitHub"
 usage = '''
 arg "<package>" help="Package to release" {
-  choices "spectral" "eslint-config-spectral"
+  choices "spectral" "eslint-config-spectral" "eslint-plugin-spectral"
 }
 arg "<bump>" help="Version bump type" {
   choices "patch" "minor" "major" "preview"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "spectral-monorepo",
   "private": true,
   "packageManager": "bun@1.3.12",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
-    "build": "bun run --filter @prismatic-io/eslint-config-spectral build && bun run --filter @prismatic-io/spectral build && bun run --filter spectral-test build",
-    "test": "bun run --filter @prismatic-io/spectral test",
+    "build": "bun run --filter @prismatic-io/eslint-plugin-spectral build && bun run --filter @prismatic-io/eslint-config-spectral build && bun run --filter @prismatic-io/spectral build && bun run --filter spectral-test build",
+    "test": "bun run --filter @prismatic-io/spectral test && bun run --filter @prismatic-io/eslint-plugin-spectral test",
     "tsd": "bun run --filter spectral-test tsd",
-    "check": "bun run --filter @prismatic-io/spectral check",
-    "lint": "bun run --filter @prismatic-io/spectral lint",
+    "check": "bun run --filter @prismatic-io/spectral check && bun run --filter @prismatic-io/eslint-plugin-spectral check",
+    "lint": "bun run --filter @prismatic-io/spectral lint && bun run --filter @prismatic-io/eslint-plugin-spectral lint",
     "all": "bun run check && bun run lint && bun run build && bun run test && bun run tsd"
   }
 }

--- a/packages/eslint-config-spectral/README.md
+++ b/packages/eslint-config-spectral/README.md
@@ -24,6 +24,20 @@ You will need to update your [ESLint configuration](https://eslint.org/docs/user
 
 Note that you do not need to install the plugin packages as peer dependencies as resolution of those packages is handled with [Microsoft's ESLint patch](https://www.npmjs.com/package/@rushstack/eslint-patch). There are still a handful of peer dependencies you will need to install - use `npm info "@prismatic-io/eslint-config-spectral@latest" peerDependencies` to list them or use `npx install-peerdeps --dev @prismatic-io/eslint-config-spectral` to install them automatically.
 
+## Rules for Code-Native Integrations
+
+This config enables [`@prismatic-io/eslint-plugin-spectral`](../eslint-plugin-spectral), which
+checks the `logger.section()` / `logger.sectionEnd()` calls used to group a code-native flow's
+logs. Misusing them is not a crash — the runtime logs a warning and drops the section — so these
+rules surface the mistake at lint time instead:
+
+| Rule | Catches |
+| --- | --- |
+| `@prismatic-io/spectral/no-nested-section` | A section opened while another is still open |
+| `@prismatic-io/spectral/no-unclosed-section` | A section never closed, or a `sectionEnd` with nothing open |
+| `@prismatic-io/spectral/section-label-match` | A `sectionEnd` label that does not match the open section |
+| `@prismatic-io/spectral/no-section-outside-flow` | A section opened in a helper rather than in a flow handler |
+
 ## What is Prismatic?
 
 Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.

--- a/packages/eslint-config-spectral/README.md
+++ b/packages/eslint-config-spectral/README.md
@@ -37,6 +37,12 @@ rules surface the mistake at lint time instead:
 | `@prismatic-io/spectral/no-unclosed-section` | A section never closed, or a `sectionEnd` with nothing open |
 | `@prismatic-io/spectral/section-label-match` | A `sectionEnd` label that does not match the open section |
 | `@prismatic-io/spectral/no-section-outside-flow` | A section opened in a helper rather than in a flow handler |
+| `@prismatic-io/spectral/section-in-loop` | A section opened in a loop, which can exhaust an execution's section limit |
+
+Every rule above is an error except `section-in-loop`, which is a warning. A section opened in a
+loop is not a mistake, but it opens one section per iteration and an execution records at most
+1000, after which logs are still written but are no longer grouped. Since the rule cannot know how
+many times a loop runs, it reports every one.
 
 ## What is Prismatic?
 

--- a/packages/eslint-config-spectral/package.json
+++ b/packages/eslint-config-spectral/package.json
@@ -25,6 +25,7 @@
   },
   "files": ["dist"],
   "dependencies": {
+    "@prismatic-io/eslint-plugin-spectral": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.67.0",
     "eslint-plugin-import": "2.32.0",

--- a/packages/eslint-config-spectral/src/index.ts
+++ b/packages/eslint-config-spectral/src/index.ts
@@ -7,7 +7,7 @@ module.exports = {
     project: true,
     sourceType: "module",
   },
-  plugins: ["@typescript-eslint", "import", "prettier"],
+  plugins: ["@typescript-eslint", "import", "prettier", "@prismatic-io/spectral"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended-type-checked",
@@ -34,6 +34,10 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/prefer-nullish-coalescing": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
+    "@prismatic-io/spectral/no-nested-section": "error",
+    "@prismatic-io/spectral/no-section-outside-flow": "error",
+    "@prismatic-io/spectral/no-unclosed-section": "error",
+    "@prismatic-io/spectral/section-label-match": "error",
   },
   settings: {
     "import/parsers": {

--- a/packages/eslint-config-spectral/src/index.ts
+++ b/packages/eslint-config-spectral/src/index.ts
@@ -37,6 +37,7 @@ module.exports = {
     "@prismatic-io/spectral/no-nested-section": "error",
     "@prismatic-io/spectral/no-section-outside-flow": "error",
     "@prismatic-io/spectral/no-unclosed-section": "error",
+    "@prismatic-io/spectral/section-in-loop": "warn",
     "@prismatic-io/spectral/section-label-match": "error",
   },
   settings: {

--- a/packages/eslint-plugin-spectral/LICENSE
+++ b/packages/eslint-plugin-spectral/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Prismatic Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-plugin-spectral/README.md
+++ b/packages/eslint-plugin-spectral/README.md
@@ -75,11 +75,14 @@ Inline callbacks within a handler are fine, since they are still visible in the 
 ```ts
 onExecution: async (context) => {
   for (const record of records) {
-    logger.section(record.id); // allowed
+    logger.section(record.id); // allowed by this rule
     logger.sectionEnd({ label: record.id });
   }
 },
 ```
+
+A section opened in a loop is still subject to the section limit, which `section-in-loop`
+reports separately.
 
 The handler names can be overridden:
 
@@ -91,6 +94,39 @@ Note that this rule only ever applies to code-native integrations. Connector `pe
 functions receive a plain `ActionLogger` with no `section` methods at all, so there is nothing
 for it to report there.
 
+### `section-in-loop`
+
+Advisory. A flow execution records at most 1000 sections. A `section()` opened in a loop creates
+one section per iteration, so a loop over a collection that grows with a customer's data can
+exhaust the limit. Past it the logs are still written, but are no longer grouped into sections.
+The runtime warns in the execution log when an execution reaches the limit; this rule reports the
+loop that gets you there before you deploy.
+
+```ts
+for (const record of records) {
+  logger.section(record.id); // reported
+  logger.sectionEnd({ label: record.id });
+}
+```
+
+Prefer one section per batch over one per record:
+
+```ts
+logger.section(`page ${page}`);
+for (const record of records) {
+  logger.info(record.id);
+}
+logger.sectionEnd({ label: `page ${page}` });
+```
+
+Array iteration methods count as loops too — `forEach`, `map`, `flatMap`, `filter`, `reduce`,
+`reduceRight`, `some`, and `every`.
+
+This is the one rule the recommended config sets to `warn` rather than `error`. It cannot know how
+many times a loop will run, so it reports every section opened in a loop, including loops that stay
+well under the limit. A loop over a handful of records is fine, and silencing the warning with
+`// eslint-disable-next-line` is a reasonable response.
+
 ## Limitations
 
 Each function body is analyzed on its own, in source order. That keeps the rules free of false
@@ -98,6 +134,8 @@ positives on ordinary code, at the cost of two blind spots:
 
 - A section opened in one function and closed in another is not tracked. Keep a section's start and
   end in the same function.
+- Loop iteration counts are unknown, so `section-in-loop` cannot tell a loop over ten records
+  from a loop over a million. It reports both.
 - Concurrency is not modeled. Two helpers that each open a section, run under `Promise.all`, will
   interleave at runtime; no lint rule can see that. Sections are designed for a linear, top-level
   flow body.

--- a/packages/eslint-plugin-spectral/README.md
+++ b/packages/eslint-plugin-spectral/README.md
@@ -60,9 +60,9 @@ logger.sectionEnd({ label: "order" }); // reported
 
 ### `no-section-outside-flow`
 
-Sections belong in a flow handler — `onExecution`, `onTrigger`, `onDeployTrigger`,
-`onInstanceDeploy`, or `onInstanceDelete`. A section opened inside a helper function nests
-inside its caller's section without either author being able to see it.
+Sections belong in a flow's `onExecution` handler, the only handler whose logger exposes the
+section methods. A section opened inside a helper function nests inside its caller's section
+without either author being able to see it.
 
 ```ts
 const syncCustomers = async (logger) => {
@@ -83,12 +83,6 @@ onExecution: async (context) => {
 
 A section opened in a loop is still subject to the section limit, which `section-in-loop`
 reports separately.
-
-The handler names can be overridden:
-
-```jsonc
-"@prismatic-io/spectral/no-section-outside-flow": ["error", { "handlers": ["onExecution"] }]
-```
 
 Note that this rule only ever applies to code-native integrations. Connector `perform`
 functions receive a plain `ActionLogger` with no `section` methods at all, so there is nothing

--- a/packages/eslint-plugin-spectral/README.md
+++ b/packages/eslint-plugin-spectral/README.md
@@ -1,0 +1,140 @@
+<div align="center">
+  <img src="https://prismatic.io/favicon-48x48.png" />
+  <h1>@prismatic-io/eslint-plugin-spectral</h1>
+</div>
+
+This package contains [ESLint](https://eslint.org/) rules for building Prismatic connectors and
+code-native integrations.
+
+Most developers should not install this package directly — it is enabled for you by
+[`@prismatic-io/eslint-config-spectral`](../eslint-config-spectral), which is what
+`prism integrations:init` scaffolds into new projects.
+
+## Rules
+
+A code-native flow can group its logs into sections:
+
+```ts
+const label = "Sync customers";
+logger.section(label);
+const customers = await fetchCustomers();
+logger.sectionEnd({ label, data: { count: customers.length } });
+```
+
+The runtime is forgiving about misuse — a nested section, an unmatched label, or a section left
+open produces a warning in the execution log and the section data is dropped rather than shown in
+the execution details. That is easy to miss, so these rules report the same mistakes at lint time.
+
+### `no-nested-section`
+
+Sections cannot be nested. A `section()` opened while another section is still open is ignored at
+runtime, and its logs are collated under the already-open section instead.
+
+```ts
+logger.section("orders");
+logger.section("line items"); // reported
+```
+
+### `no-unclosed-section`
+
+Every `section()` should be closed by a `sectionEnd()` in the same function. Also reports a
+`sectionEnd()` with no open section to close.
+
+```ts
+logger.section("orders");
+await syncOrders(); // reported: "orders" is never closed
+```
+
+An early `return` between the pair is fine — the runtime closes an abandoned section when the
+function returns or throws — so only a missing `sectionEnd()` is reported.
+
+### `section-label-match`
+
+A `sectionEnd()` whose label does not match the open section is ignored at runtime, leaving the
+section open.
+
+```ts
+logger.section("orders");
+logger.sectionEnd({ label: "order" }); // reported
+```
+
+### `no-section-outside-flow`
+
+Sections belong in a flow handler — `onExecution`, `onTrigger`, `onDeployTrigger`,
+`onInstanceDeploy`, or `onInstanceDelete`. A section opened inside a helper function nests
+inside its caller's section without either author being able to see it.
+
+```ts
+const syncCustomers = async (logger) => {
+  logger.section("customers"); // reported
+};
+```
+
+Inline callbacks within a handler are fine, since they are still visible in the flow body:
+
+```ts
+onExecution: async (context) => {
+  for (const record of records) {
+    logger.section(record.id); // allowed
+    logger.sectionEnd({ label: record.id });
+  }
+},
+```
+
+The handler names can be overridden:
+
+```jsonc
+"@prismatic-io/spectral/no-section-outside-flow": ["error", { "handlers": ["onExecution"] }]
+```
+
+Note that this rule only ever applies to code-native integrations. Connector `perform`
+functions receive a plain `ActionLogger` with no `section` methods at all, so there is nothing
+for it to report there.
+
+## Limitations
+
+Each function body is analyzed on its own, in source order. That keeps the rules free of false
+positives on ordinary code, at the cost of two blind spots:
+
+- A section opened in one function and closed in another is not tracked. Keep a section's start and
+  end in the same function.
+- Concurrency is not modeled. Two helpers that each open a section, run under `Promise.all`, will
+  interleave at runtime; no lint rule can see that. Sections are designed for a linear, top-level
+  flow body.
+
+## What is Prismatic?
+
+Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.
+
+Prismatic's unparalleled versatility lets teams deliver any integration from simple to complex in one powerful platform. SaaS companies worldwide, from startups to Fortune 500s, trust Prismatic to help connect their products to the other products their customers use.
+
+With Prismatic, you can:
+
+- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-native](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
+- Leverage pre-built [connectors](https://prismatic.io/docs/components/) for common integration tasks, or develop custom connectors using our TypeScript SDK
+- Embed a native [integration marketplace](https://prismatic.io/docs/embed/) in your product for customer self-service
+- Configure and deploy customer-specific integration instances with powerful configuration tools
+- Support customers efficiently with comprehensive [logging, monitoring, and alerting](https://prismatic.io/docs/monitor-instances/)
+- Run integrations in a secure, scalable infrastructure designed for B2B SaaS
+- Customize the platform to fit your product, industry, and development workflows
+
+## Who uses Prismatic?
+
+Prismatic is built for B2B software companies that need to provide integrations to their customers. Whether you're a growing SaaS startup or an established enterprise, Prismatic's platform scales with your integration needs.
+
+Our platform is particularly powerful for teams serving specialized vertical markets. We provide the flexibility and tools to build exactly the integrations your customers need, regardless of the systems you're connecting to or how unique your integration requirements may be.
+
+## What kind of integrations can you build using Prismatic?
+
+Prismatic supports integrations of any complexity - from simple data syncs to sophisticated, industry-specific solutions. Teams use it to build integrations between any type of system, whether modern SaaS or legacy with standard or custom protocols. Here are some example use cases:
+
+- Connect your product with customers' ERPs, CRMs, and other business systems
+- Process data from multiple sources with customer-specific transformation requirements
+- Automate workflows with customizable triggers, actions, and schedules
+- Handle complex authentication flows and data mapping scenarios
+
+For information on the Prismatic platform, check out our [website](https://prismatic.io/) and [docs](https://prismatic.io/docs/).
+
+## License
+
+This repository is MIT licensed.

--- a/packages/eslint-plugin-spectral/package.json
+++ b/packages/eslint-plugin-spectral/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@prismatic-io/eslint-plugin-spectral",
+  "version": "1.0.0",
+  "description": "ESLint rules for building Prismatic connectors and code-native integrations",
+  "keywords": [
+    "prismatic",
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "homepage": "https://prismatic.io",
+  "bugs": {
+    "url": "https://github.com/prismatic-io/spectral"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prismatic-io/spectral.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "bun run format && bun run clean && tsc",
+    "prepack": "bun run build",
+    "lint": "biome lint .",
+    "format": "biome check --write --unsafe .",
+    "check": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@typescript-eslint/utils": "^8.67.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.15",
+    "@types/eslint": "9.6.1",
+    "@types/node": "26.1.2",
+    "@typescript-eslint/rule-tester": "^8.67.0",
+    "eslint": "^8.57.1",
+    "typescript": "^6",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "eslint": ">=8"
+  }
+}

--- a/packages/eslint-plugin-spectral/src/index.ts
+++ b/packages/eslint-plugin-spectral/src/index.ts
@@ -1,6 +1,7 @@
 import noNestedSection from "./rules/noNestedSection";
 import noSectionOutsideFlow from "./rules/noSectionOutsideFlow";
 import noUnclosedSection from "./rules/noUnclosedSection";
+import sectionInLoop from "./rules/sectionInLoop";
 import sectionLabelMatch from "./rules/sectionLabelMatch";
 
 const plugin = {
@@ -8,6 +9,7 @@ const plugin = {
     "no-nested-section": noNestedSection,
     "no-section-outside-flow": noSectionOutsideFlow,
     "no-unclosed-section": noUnclosedSection,
+    "section-in-loop": sectionInLoop,
     "section-label-match": sectionLabelMatch,
   },
   configs: {
@@ -17,6 +19,7 @@ const plugin = {
         "@prismatic-io/spectral/no-nested-section": "error",
         "@prismatic-io/spectral/no-section-outside-flow": "error",
         "@prismatic-io/spectral/no-unclosed-section": "error",
+        "@prismatic-io/spectral/section-in-loop": "warn",
         "@prismatic-io/spectral/section-label-match": "error",
       },
     },

--- a/packages/eslint-plugin-spectral/src/index.ts
+++ b/packages/eslint-plugin-spectral/src/index.ts
@@ -1,0 +1,26 @@
+import noNestedSection from "./rules/noNestedSection";
+import noSectionOutsideFlow from "./rules/noSectionOutsideFlow";
+import noUnclosedSection from "./rules/noUnclosedSection";
+import sectionLabelMatch from "./rules/sectionLabelMatch";
+
+const plugin = {
+  rules: {
+    "no-nested-section": noNestedSection,
+    "no-section-outside-flow": noSectionOutsideFlow,
+    "no-unclosed-section": noUnclosedSection,
+    "section-label-match": sectionLabelMatch,
+  },
+  configs: {
+    recommended: {
+      plugins: ["@prismatic-io/spectral"],
+      rules: {
+        "@prismatic-io/spectral/no-nested-section": "error",
+        "@prismatic-io/spectral/no-section-outside-flow": "error",
+        "@prismatic-io/spectral/no-unclosed-section": "error",
+        "@prismatic-io/spectral/section-label-match": "error",
+      },
+    },
+  },
+};
+
+export = plugin;

--- a/packages/eslint-plugin-spectral/src/rules/noNestedSection.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noNestedSection.test.ts
@@ -1,0 +1,56 @@
+import rule from "./noNestedSection";
+import { ruleTester } from "./ruleTester";
+
+ruleTester.run("no-nested-section", rule, {
+  valid: [
+    // Sequential sections in one function are fine; only overlap is nesting.
+    `const { logger } = context;
+     logger.section("one");
+     logger.sectionEnd({ label: "one" });
+     logger.section("two");
+     logger.sectionEnd({ label: "two" });`,
+    // A section per loop iteration opens and closes within the iteration.
+    `for (const record of records) {
+       logger.section(record.id);
+       logger.sectionEnd({ label: record.id });
+     }`,
+    // Each callback is its own scope, so these are not statically nested.
+    `items.forEach(() => {
+       logger.section("a");
+       logger.sectionEnd({ label: "a" });
+     });
+     other.forEach(() => {
+       logger.section("b");
+       logger.sectionEnd({ label: "b" });
+     });`,
+    // The receiver has to look like a logger.
+    `queryBuilder.section("a"); queryBuilder.section("b");`,
+    `context.logger.section("a"); context.logger.sectionEnd({ label: "a" });`,
+  ],
+  invalid: [
+    {
+      code: `logger.section("outer"); logger.section("inner");`,
+      errors: [{ messageId: "nested", data: { openLabel: "outer" } }],
+    },
+    {
+      // The rejected inner section must not consume the end that closes "outer",
+      // so no-unclosed-section has nothing to add here.
+      code: `logger.section("outer");
+             logger.section("inner");
+             logger.sectionEnd({ label: "outer" });`,
+      errors: [{ messageId: "nested" }],
+    },
+    {
+      code: `logger.section(buildLabel()); logger.section("inner");`,
+      errors: [{ messageId: "nestedUnknownLabel" }],
+    },
+    {
+      code: `const { logger } = context;
+             logger.section("a");
+             await doWork();
+             logger.section("b");
+             logger.sectionEnd({ label: "b" });`,
+      errors: [{ messageId: "nested", data: { openLabel: "a" } }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-spectral/src/rules/noNestedSection.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noNestedSection.ts
@@ -1,0 +1,37 @@
+import { createRule, withSectionAnalysis } from "../sections";
+
+type MessageIds = "nested" | "nestedUnknownLabel";
+
+export default createRule<[], MessageIds>({
+  name: "no-nested-section",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow opening a log section while another section is still open",
+    },
+    schema: [],
+    messages: {
+      nested:
+        'This section cannot be opened while the section "{{openLabel}}" is still open. Sections cannot be nested, so this call is ignored at runtime. Close the open section with logger.sectionEnd() first.',
+      nestedUnknownLabel:
+        "This section cannot be opened while another section is still open. Sections cannot be nested, so this call is ignored at runtime. Close the open section with logger.sectionEnd() first.",
+    },
+  },
+  defaultOptions: [],
+  create: withSectionAnalysis<MessageIds>((context, event) => {
+    if (event.type !== "nested") {
+      return;
+    }
+
+    if (event.openLabel === undefined) {
+      context.report({ node: event.node, messageId: "nestedUnknownLabel" });
+      return;
+    }
+
+    context.report({
+      node: event.node,
+      messageId: "nested",
+      data: { openLabel: event.openLabel },
+    });
+  }),
+});

--- a/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.test.ts
@@ -1,0 +1,89 @@
+import rule from "./noSectionOutsideFlow";
+import { ruleTester } from "./ruleTester";
+
+const handlerList = "onExecution, onTrigger, onDeployTrigger, onInstanceDeploy, onInstanceDelete";
+
+ruleTester.run("no-section-outside-flow", rule, {
+  valid: [
+    `export const syncFlow = flow({
+       onExecution: async (context) => {
+         const { logger } = context;
+         logger.section("one");
+         logger.sectionEnd({ label: "one" });
+       },
+     });`,
+    // A loop body is not a function boundary.
+    `flow({
+       onExecution: async (context) => {
+         for (const record of records) {
+           logger.section(record.id);
+           logger.sectionEnd({ label: record.id });
+         }
+       },
+     });`,
+    // An inline callback hides nothing: it is still visible in the flow body.
+    `flow({
+       onExecution: async (context) => {
+         items.forEach((item) => {
+           logger.section(item.id);
+           logger.sectionEnd({ label: item.id });
+         });
+       },
+     });`,
+    // Every handler that receives a code-native logger is allowed.
+    `flow({ onTrigger: async () => { logger.section("t"); logger.sectionEnd({ label: "t" }); } });`,
+    `flow({ onInstanceDeploy: async () => { logger.section("d"); logger.sectionEnd({ label: "d" }); } });`,
+    // A handler declared separately and passed in by name.
+    `const onExecution = async (context) => {
+       logger.section("one");
+       logger.sectionEnd({ label: "one" });
+     };
+     flow({ onExecution });`,
+    `async function onExecution(context) {
+       logger.section("one");
+       logger.sectionEnd({ label: "one" });
+     }`,
+    `flow({ "onExecution": async () => { logger.section("one"); } });`,
+    // Shorthand method form.
+    `flow({
+       onExecution(context) {
+         logger.section("one");
+         logger.sectionEnd({ label: "one" });
+       },
+     });`,
+    {
+      code: `const runFlow = async () => { logger.section("one"); };`,
+      options: [{ handlers: ["runFlow"] }],
+    },
+    // Not a section call at all.
+    `const helper = () => { logger.info("hi"); };`,
+  ],
+  invalid: [
+    {
+      code: `const syncCustomers = async (logger) => {
+               logger.section("customers");
+               logger.sectionEnd({ label: "customers" });
+             };`,
+      errors: [
+        { messageId: "outsideFlow", data: { name: "section", handlerList } },
+        { messageId: "outsideFlow", data: { name: "sectionEnd", handlerList } },
+      ],
+    },
+    {
+      code: `function syncOrders() {
+               logger.section("orders");
+             }`,
+      errors: [{ messageId: "outsideFlow", data: { name: "section", handlerList } }],
+    },
+    {
+      // Module scope is not a handler either.
+      code: `logger.section("one");`,
+      errors: [{ messageId: "outsideFlow" }],
+    },
+    {
+      code: `const onExecution = async () => { logger.section("one"); };`,
+      options: [{ handlers: ["onTrigger"] }],
+      errors: [{ messageId: "outsideFlow" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.test.ts
@@ -1,8 +1,6 @@
 import rule from "./noSectionOutsideFlow";
 import { ruleTester } from "./ruleTester";
 
-const handlerList = "onExecution, onTrigger, onDeployTrigger, onInstanceDeploy, onInstanceDelete";
-
 ruleTester.run("no-section-outside-flow", rule, {
   valid: [
     `export const syncFlow = flow({
@@ -30,9 +28,6 @@ ruleTester.run("no-section-outside-flow", rule, {
          });
        },
      });`,
-    // Every handler that receives a code-native logger is allowed.
-    `flow({ onTrigger: async () => { logger.section("t"); logger.sectionEnd({ label: "t" }); } });`,
-    `flow({ onInstanceDeploy: async () => { logger.section("d"); logger.sectionEnd({ label: "d" }); } });`,
     // A handler declared separately and passed in by name.
     `const onExecution = async (context) => {
        logger.section("one");
@@ -51,10 +46,6 @@ ruleTester.run("no-section-outside-flow", rule, {
          logger.sectionEnd({ label: "one" });
        },
      });`,
-    {
-      code: `const runFlow = async () => { logger.section("one"); };`,
-      options: [{ handlers: ["runFlow"] }],
-    },
     // Not a section call at all.
     `const helper = () => { logger.info("hi"); };`,
   ],
@@ -65,15 +56,15 @@ ruleTester.run("no-section-outside-flow", rule, {
                logger.sectionEnd({ label: "customers" });
              };`,
       errors: [
-        { messageId: "outsideFlow", data: { name: "section", handlerList } },
-        { messageId: "outsideFlow", data: { name: "sectionEnd", handlerList } },
+        { messageId: "outsideFlow", data: { name: "section" } },
+        { messageId: "outsideFlow", data: { name: "sectionEnd" } },
       ],
     },
     {
       code: `function syncOrders() {
                logger.section("orders");
              }`,
-      errors: [{ messageId: "outsideFlow", data: { name: "section", handlerList } }],
+      errors: [{ messageId: "outsideFlow", data: { name: "section" } }],
     },
     {
       // Module scope is not a handler either.
@@ -81,9 +72,18 @@ ruleTester.run("no-section-outside-flow", rule, {
       errors: [{ messageId: "outsideFlow" }],
     },
     {
-      code: `const onExecution = async () => { logger.section("one"); };`,
-      options: [{ handlers: ["onTrigger"] }],
-      errors: [{ messageId: "outsideFlow" }],
+      // A helper is a helper no matter what it is named.
+      code: `const runFlow = async () => { logger.section("one"); };`,
+      errors: [{ messageId: "outsideFlow", data: { name: "section" } }],
+    },
+    {
+      // Other flow handlers do not receive a logger with section methods.
+      code: `flow({ onTrigger: async () => { logger.section("t"); } });`,
+      errors: [{ messageId: "outsideFlow", data: { name: "section" } }],
+    },
+    {
+      code: `flow({ onInstanceDeploy: async () => { logger.section("d"); } });`,
+      errors: [{ messageId: "outsideFlow", data: { name: "section" } }],
     },
   ],
 });

--- a/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.ts
@@ -2,77 +2,54 @@ import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { createRule, withSectionCalls } from "../sections";
 
 type MessageIds = "outsideFlow";
-type Options = [{ handlers?: string[] }?];
 
-const DEFAULT_HANDLERS = [
-  "onExecution",
-  "onTrigger",
-  "onDeployTrigger",
-  "onInstanceDeploy",
-  "onInstanceDelete",
-];
+const HANDLER = "onExecution";
 
 /**
  * A handler is normally an object property (`onExecution: async () => {}`), but a flow can
  * also be assembled from a separately declared function of the same name.
  */
-const isHandler = (ancestor: TSESTree.Node, handlers: Set<string>): boolean => {
+const isHandler = (ancestor: TSESTree.Node): boolean => {
   if (ancestor.type === "Property" && !ancestor.computed) {
     if (ancestor.key.type === "Identifier") {
-      return handlers.has(ancestor.key.name);
+      return ancestor.key.name === HANDLER;
     }
 
-    return (
-      ancestor.key.type === "Literal" &&
-      typeof ancestor.key.value === "string" &&
-      handlers.has(ancestor.key.value)
-    );
+    return ancestor.key.type === "Literal" && ancestor.key.value === HANDLER;
   }
 
   if (ancestor.type === "VariableDeclarator" && ancestor.id.type === "Identifier") {
-    return handlers.has(ancestor.id.name);
+    return ancestor.id.name === HANDLER;
   }
 
-  return ancestor.type === "FunctionDeclaration" && !!ancestor.id && handlers.has(ancestor.id.name);
+  return ancestor.type === "FunctionDeclaration" && ancestor.id?.name === HANDLER;
 };
 
-export default createRule<Options, MessageIds>({
+export default createRule<[], MessageIds>({
   name: "no-section-outside-flow",
   meta: {
     type: "problem",
     docs: {
-      description: "Disallow log sections outside of a code-native flow handler",
+      description: "Disallow log sections outside of a code-native flow's onExecution handler",
     },
-    schema: [
-      {
-        type: "object",
-        properties: {
-          handlers: { type: "array", items: { type: "string" }, minItems: 1 },
-        },
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
     messages: {
       outsideFlow:
-        "Call logger.{{name}}() inside a flow handler ({{handlerList}}) rather than in a helper function. A section opened in a helper can nest inside its caller's section, which the runtime silently drops.",
+        "Call logger.{{name}}() inside a flow's onExecution handler rather than in a helper function. A section opened in a helper can nest inside its caller's section, which the runtime silently drops.",
     },
   },
-  defaultOptions: [{}],
-  create: withSectionCalls<MessageIds, Options>((context, node, kind) => {
-    const handlers = new Set(context.options[0]?.handlers ?? DEFAULT_HANDLERS);
+  defaultOptions: [],
+  create: withSectionCalls<MessageIds>((context, node, kind) => {
     const sourceCode: TSESLint.SourceCode = context.sourceCode ?? context.getSourceCode();
 
-    if (sourceCode.getAncestors(node).some((ancestor) => isHandler(ancestor, handlers))) {
+    if (sourceCode.getAncestors(node).some(isHandler)) {
       return;
     }
 
     context.report({
       node,
       messageId: "outsideFlow",
-      data: {
-        name: kind === "start" ? "section" : "sectionEnd",
-        handlerList: [...handlers].join(", "),
-      },
+      data: { name: kind === "start" ? "section" : "sectionEnd" },
     });
   }),
 });

--- a/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noSectionOutsideFlow.ts
@@ -1,0 +1,78 @@
+import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { createRule, withSectionCalls } from "../sections";
+
+type MessageIds = "outsideFlow";
+type Options = [{ handlers?: string[] }?];
+
+const DEFAULT_HANDLERS = [
+  "onExecution",
+  "onTrigger",
+  "onDeployTrigger",
+  "onInstanceDeploy",
+  "onInstanceDelete",
+];
+
+/**
+ * A handler is normally an object property (`onExecution: async () => {}`), but a flow can
+ * also be assembled from a separately declared function of the same name.
+ */
+const isHandler = (ancestor: TSESTree.Node, handlers: Set<string>): boolean => {
+  if (ancestor.type === "Property" && !ancestor.computed) {
+    if (ancestor.key.type === "Identifier") {
+      return handlers.has(ancestor.key.name);
+    }
+
+    return (
+      ancestor.key.type === "Literal" &&
+      typeof ancestor.key.value === "string" &&
+      handlers.has(ancestor.key.value)
+    );
+  }
+
+  if (ancestor.type === "VariableDeclarator" && ancestor.id.type === "Identifier") {
+    return handlers.has(ancestor.id.name);
+  }
+
+  return ancestor.type === "FunctionDeclaration" && !!ancestor.id && handlers.has(ancestor.id.name);
+};
+
+export default createRule<Options, MessageIds>({
+  name: "no-section-outside-flow",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow log sections outside of a code-native flow handler",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          handlers: { type: "array", items: { type: "string" }, minItems: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      outsideFlow:
+        "Call logger.{{name}}() inside a flow handler ({{handlerList}}) rather than in a helper function. A section opened in a helper can nest inside its caller's section, which the runtime silently drops.",
+    },
+  },
+  defaultOptions: [{}],
+  create: withSectionCalls<MessageIds, Options>((context, node, kind) => {
+    const handlers = new Set(context.options[0]?.handlers ?? DEFAULT_HANDLERS);
+    const sourceCode: TSESLint.SourceCode = context.sourceCode ?? context.getSourceCode();
+
+    if (sourceCode.getAncestors(node).some((ancestor) => isHandler(ancestor, handlers))) {
+      return;
+    }
+
+    context.report({
+      node,
+      messageId: "outsideFlow",
+      data: {
+        name: kind === "start" ? "section" : "sectionEnd",
+        handlerList: [...handlers].join(", "),
+      },
+    });
+  }),
+});

--- a/packages/eslint-plugin-spectral/src/rules/noUnclosedSection.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noUnclosedSection.test.ts
@@ -1,0 +1,61 @@
+import rule from "./noUnclosedSection";
+import { ruleTester } from "./ruleTester";
+
+ruleTester.run("no-unclosed-section", rule, {
+  valid: [
+    `logger.section("one"); logger.sectionEnd({ label: "one" });`,
+    // A const label resolves to the same string on both sides.
+    `const label = "one";
+     logger.section(label);
+     logger.sectionEnd({ label });`,
+    // An early return between the pair is auto-closed by the runtime.
+    `const onExecution = async (context) => {
+       const { logger } = context;
+       logger.section("one");
+       if (!context.params) return;
+       logger.sectionEnd({ label: "one" });
+     };`,
+    `for (const record of records) {
+       logger.section(record.id);
+       logger.sectionEnd({ label: record.id });
+     }`,
+    `logger.info("no sections here");`,
+  ],
+  invalid: [
+    {
+      code: `logger.section("one"); doWork();`,
+      errors: [{ messageId: "unclosed", data: { label: "one" } }],
+    },
+    {
+      code: `logger.section(buildLabel()); doWork();`,
+      errors: [{ messageId: "unclosedUnknownLabel" }],
+    },
+    {
+      code: `logger.sectionEnd({ label: "one" });`,
+      errors: [{ messageId: "strayEnd" }],
+    },
+    {
+      // Each function body is analyzed on its own, so closing from inside a callback
+      // is out of reach and reported as unclosed.
+      code: `const run = async () => {
+               logger.section("one");
+               await items.map(async () => {
+                 logger.sectionEnd({ label: "one" });
+               });
+             };`,
+      errors: [{ messageId: "unclosed", data: { label: "one" } }, { messageId: "strayEnd" }],
+    },
+    {
+      code: `const run = async () => {
+               logger.section("one");
+             };
+             const other = async () => {
+               logger.section("two");
+             };`,
+      errors: [
+        { messageId: "unclosed", data: { label: "one" } },
+        { messageId: "unclosed", data: { label: "two" } },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-spectral/src/rules/noUnclosedSection.ts
+++ b/packages/eslint-plugin-spectral/src/rules/noUnclosedSection.ts
@@ -1,0 +1,44 @@
+import { createRule, withSectionAnalysis } from "../sections";
+
+type MessageIds = "unclosed" | "unclosedUnknownLabel" | "strayEnd";
+
+export default createRule<[], MessageIds>({
+  name: "no-unclosed-section",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require every log section to be closed in the function that opened it",
+    },
+    schema: [],
+    messages: {
+      unclosed:
+        'The section "{{label}}" is never closed in this function. Call logger.sectionEnd({ label: "{{label}}" }) before the function returns.',
+      unclosedUnknownLabel:
+        "This section is never closed in this function. Call logger.sectionEnd() with the same label before the function returns.",
+      strayEnd:
+        "There is no open section for this logger.sectionEnd() to close, so it is ignored at runtime.",
+    },
+  },
+  defaultOptions: [],
+  create: withSectionAnalysis<MessageIds>((context, event) => {
+    if (event.type === "strayEnd") {
+      context.report({ node: event.node, messageId: "strayEnd" });
+      return;
+    }
+
+    if (event.type !== "unclosed") {
+      return;
+    }
+
+    if (event.label === undefined) {
+      context.report({ node: event.node, messageId: "unclosedUnknownLabel" });
+      return;
+    }
+
+    context.report({
+      node: event.node,
+      messageId: "unclosed",
+      data: { label: event.label },
+    });
+  }),
+});

--- a/packages/eslint-plugin-spectral/src/rules/ruleTester.ts
+++ b/packages/eslint-plugin-spectral/src/rules/ruleTester.ts
@@ -1,0 +1,9 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+export const ruleTester = new RuleTester();

--- a/packages/eslint-plugin-spectral/src/rules/sectionInLoop.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/sectionInLoop.test.ts
@@ -1,0 +1,100 @@
+import { ruleTester } from "./ruleTester";
+import rule from "./sectionInLoop";
+
+ruleTester.run("section-in-loop", rule, {
+  valid: [
+    // One section around the whole loop is the shape this rule is steering toward.
+    `flow({
+       onExecution: async ({ logger }) => {
+         logger.section("sync customers");
+         for (const record of records) {
+           logger.info(record.id);
+         }
+         logger.sectionEnd({ label: "sync customers" });
+       },
+     });`,
+    // A section that does not repeat.
+    `flow({
+       onExecution: async ({ logger }) => {
+         logger.section("one");
+         logger.sectionEnd({ label: "one" });
+       },
+     });`,
+    // Closing a section inside a loop is how a per-batch section gets closed; only opens repeat.
+    `for (const record of records) {
+       logger.sectionEnd({ label: record.id });
+     }`,
+    // A `for` initializer runs once.
+    `for (let index = logger.section("one"); index < 10; index += 1) {
+       logger.info(index);
+     }`,
+    // Not an iteration method, just a method that takes a callback.
+    `records.then(() => {
+       logger.section("one");
+     });`,
+    // Not a section call at all.
+    `for (const record of records) {
+       logger.info(record.id);
+     }`,
+  ],
+  invalid: [
+    {
+      code: `for (const record of records) {
+               logger.section(record.id);
+               logger.sectionEnd({ label: record.id });
+             }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `for (const key in records) { logger.section(key); }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `for (let index = 0; index < records.length; index += 1) { logger.section("one"); }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `while (hasMore) { logger.section("page"); }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `do { logger.section("page"); } while (hasMore);`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `for await (const record of records) { logger.section(record.id); }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    // An iteration callback repeats just as much as a `for` body.
+    {
+      code: `records.forEach((record) => { logger.section(record.id); });`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    {
+      code: `await Promise.all(records.map(async (record) => { logger.section(record.id); }));`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    // A helper defined and called inside the loop still runs per iteration.
+    {
+      code: `for (const record of records) {
+               const start = () => { logger.section(record.id); };
+               start();
+             }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    // Reported once per section call, not once per enclosing loop.
+    {
+      code: `for (const batch of batches) {
+               for (const record of batch) {
+                 logger.section(record.id);
+               }
+             }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+    // Any receiver whose name ends in "logger".
+    {
+      code: `for (const record of records) { context.logger.section(record.id); }`,
+      errors: [{ messageId: "sectionInLoop" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-spectral/src/rules/sectionInLoop.ts
+++ b/packages/eslint-plugin-spectral/src/rules/sectionInLoop.ts
@@ -1,0 +1,81 @@
+import type { TSESTree } from "@typescript-eslint/utils";
+import { createRule, withSectionCalls } from "../sections";
+
+type MessageIds = "sectionInLoop";
+
+/** Sections a single flow execution records before the runtime stops recording them. */
+const SECTION_LIMIT = 1000;
+
+/** Array methods that call their callback once per element. */
+const ITERATION_METHODS = new Set([
+  "forEach",
+  "map",
+  "flatMap",
+  "filter",
+  "reduce",
+  "reduceRight",
+  "some",
+  "every",
+]);
+
+/**
+ * True when `child` is the part of `parent` that runs repeatedly: a loop body, or the
+ * callback handed to an array iteration method. Matching the body specifically — rather
+ * than just the ancestor's type — keeps a section opened in a `for` initializer, which
+ * runs once, from being reported.
+ */
+const isRepeated = (parent: TSESTree.Node, child: TSESTree.Node): boolean => {
+  switch (parent.type) {
+    case "ForStatement":
+    case "ForInStatement":
+    case "ForOfStatement":
+    case "WhileStatement":
+    case "DoWhileStatement":
+      return parent.body === child;
+    case "CallExpression":
+      return (
+        parent.callee.type === "MemberExpression" &&
+        !parent.callee.computed &&
+        parent.callee.property.type === "Identifier" &&
+        ITERATION_METHODS.has(parent.callee.property.name) &&
+        (parent.arguments as TSESTree.Node[]).includes(child)
+      );
+    default:
+      return false;
+  }
+};
+
+export default createRule<[], MessageIds>({
+  name: "section-in-loop",
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Warn that log sections opened in a loop scale with the size of the data",
+    },
+    schema: [],
+    messages: {
+      sectionInLoop:
+        "This opens one section per iteration, and a flow execution records at most {{limit}} sections. Past that limit the logs are still written, but are no longer grouped into sections. If this loop scales with the size of your data, open one section per batch instead of one per record.",
+    },
+  },
+  defaultOptions: [],
+  create: withSectionCalls<MessageIds>((context, node, kind) => {
+    if (kind !== "start") {
+      return;
+    }
+
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const path: TSESTree.Node[] = [...sourceCode.getAncestors(node), node];
+
+    for (let index = 0; index < path.length - 1; index += 1) {
+      if (isRepeated(path[index], path[index + 1])) {
+        context.report({
+          node,
+          messageId: "sectionInLoop",
+          data: { limit: SECTION_LIMIT },
+        });
+        return;
+      }
+    }
+  }),
+});

--- a/packages/eslint-plugin-spectral/src/rules/sectionLabelMatch.test.ts
+++ b/packages/eslint-plugin-spectral/src/rules/sectionLabelMatch.test.ts
@@ -1,0 +1,58 @@
+import { ruleTester } from "./ruleTester";
+import rule from "./sectionLabelMatch";
+
+ruleTester.run("section-label-match", rule, {
+  valid: [
+    `logger.section("one"); logger.sectionEnd({ label: "one" });`,
+    `const label = "one"; logger.section(label); logger.sectionEnd({ label });`,
+    // Two consts holding the same string still match.
+    `const start = "one";
+     const end = "one";
+     logger.section(start);
+     logger.sectionEnd({ label: end });`,
+    // The same binding matches even when its value is unknowable at lint time.
+    `const label = buildLabel();
+     logger.section(label);
+     logger.sectionEnd({ label });`,
+    `logger.section(\`one\`); logger.sectionEnd({ label: "one" });`,
+    // Distinct unresolvable labels could hold the same value at runtime.
+    `logger.section(record.id); logger.sectionEnd({ label: other.id });`,
+    // A reassignable binding is never read as a value.
+    `let label = "one";
+     label = "two";
+     logger.section(label);
+     logger.sectionEnd({ label: "two" });`,
+    // Nothing to compare against.
+    `logger.section("one"); logger.sectionEnd();`,
+    `logger.section("one"); logger.sectionEnd({ data: {} });`,
+  ],
+  invalid: [
+    {
+      code: `logger.section("one"); logger.sectionEnd({ label: "two" });`,
+      errors: [{ messageId: "mismatch", data: { startLabel: "one", endLabel: "two" } }],
+    },
+    {
+      // A type annotation must not stop the label from resolving.
+      code: `const start: string = "one";
+             logger.section(start);
+             logger.sectionEnd({ label: "two" });`,
+      errors: [{ messageId: "mismatch", data: { startLabel: "one", endLabel: "two" } }],
+    },
+    {
+      code: `const start = "one";
+             const end = "two";
+             logger.section(start);
+             logger.sectionEnd({ label: end });`,
+      errors: [{ messageId: "mismatch", data: { startLabel: "one", endLabel: "two" } }],
+    },
+    {
+      // A mismatch is reported once and treated as closing the section, so the next
+      // section is not also reported as nested.
+      code: `logger.section("one");
+             logger.sectionEnd({ label: "two" });
+             logger.section("three");
+             logger.sectionEnd({ label: "three" });`,
+      errors: [{ messageId: "mismatch" }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-spectral/src/rules/sectionLabelMatch.ts
+++ b/packages/eslint-plugin-spectral/src/rules/sectionLabelMatch.ts
@@ -1,0 +1,30 @@
+import { createRule, withSectionAnalysis } from "../sections";
+
+type MessageIds = "mismatch";
+
+export default createRule<[], MessageIds>({
+  name: "section-label-match",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require a sectionEnd label to match the label of the section it closes",
+    },
+    schema: [],
+    messages: {
+      mismatch:
+        'This label "{{endLabel}}" does not match the open section "{{startLabel}}", so this call is ignored at runtime and the section is left open.',
+    },
+  },
+  defaultOptions: [],
+  create: withSectionAnalysis<MessageIds>((context, event) => {
+    if (event.type !== "labelMismatch") {
+      return;
+    }
+
+    context.report({
+      node: event.node,
+      messageId: "mismatch",
+      data: { startLabel: event.startLabel, endLabel: event.endLabel },
+    });
+  }),
+});

--- a/packages/eslint-plugin-spectral/src/sections.ts
+++ b/packages/eslint-plugin-spectral/src/sections.ts
@@ -1,0 +1,260 @@
+import { ASTUtils, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+
+const SECTION = "section";
+const SECTION_END = "sectionEnd";
+
+export const createRule = ESLintUtils.RuleCreator(
+  () => "https://prismatic.io/docs/integrations/code-native/",
+);
+
+export type SectionCallKind = "start" | "end";
+
+/**
+ * What a rule was able to learn about a section label. `text` is only set when the
+ * label resolves to a string at lint time; `variable` lets two labels be compared as
+ * equal when they are the same binding even though its value is unknowable.
+ */
+interface LabelInfo {
+  text?: string;
+  variable?: TSESLint.Scope.Variable;
+}
+
+interface SectionCall {
+  kind: SectionCallKind;
+  node: TSESTree.CallExpression;
+  label: LabelInfo | null;
+}
+
+export type SectionEvent =
+  | { type: "nested"; node: TSESTree.CallExpression; openLabel?: string }
+  | { type: "strayEnd"; node: TSESTree.CallExpression }
+  | { type: "unclosed"; node: TSESTree.CallExpression; label?: string }
+  | {
+      type: "labelMismatch";
+      node: TSESTree.CallExpression;
+      startLabel: string;
+      endLabel: string;
+    };
+
+type SectionRuleCreate<
+  TMessageIds extends string,
+  TOptions extends readonly unknown[] = [],
+> = TSESLint.RuleModule<TMessageIds, TOptions>["create"];
+
+const isLoggerName = (name: string): boolean => name.toLowerCase().endsWith("logger");
+
+const isLoggerReceiver = (node: TSESTree.Node): boolean => {
+  if (node.type === "Identifier") {
+    return isLoggerName(node.name);
+  }
+
+  return (
+    node.type === "MemberExpression" &&
+    !node.computed &&
+    node.property.type === "Identifier" &&
+    isLoggerName(node.property.name)
+  );
+};
+
+const getSectionCallKind = (node: TSESTree.CallExpression): SectionCallKind | null => {
+  const { callee } = node;
+
+  if (
+    callee.type !== "MemberExpression" ||
+    callee.computed ||
+    callee.property.type !== "Identifier"
+  ) {
+    return null;
+  }
+
+  if (!isLoggerReceiver(callee.object)) {
+    return null;
+  }
+
+  if (callee.property.name === SECTION) {
+    return "start";
+  }
+
+  return callee.property.name === SECTION_END ? "end" : null;
+};
+
+/** `sectionEnd({ label })` — the label lives on the options object, not the argument list. */
+const getEndLabelArgument = (node: TSESTree.CallExpression): TSESTree.Expression | null => {
+  const [argument] = node.arguments;
+
+  if (argument?.type !== "ObjectExpression") {
+    return null;
+  }
+
+  for (const property of argument.properties) {
+    if (property.type !== "Property" || property.value.type === "AssignmentPattern") {
+      continue;
+    }
+
+    if (ASTUtils.getPropertyName(property) === "label") {
+      return property.value as TSESTree.Expression;
+    }
+  }
+
+  return null;
+};
+
+const resolveLabel = (
+  node: TSESTree.Node | null | undefined,
+  scope: TSESLint.Scope.Scope,
+): LabelInfo | null => {
+  if (!node || node.type === "SpreadElement") {
+    return null;
+  }
+
+  const variable = node.type === "Identifier" ? ASTUtils.findVariable(scope, node) : null;
+  const text = ASTUtils.getStringIfConstant(node, scope);
+
+  if (text !== null) {
+    return { text, variable: variable ?? undefined };
+  }
+
+  if (!variable) {
+    return null;
+  }
+
+  return { variable };
+};
+
+const compareLabels = (
+  a: LabelInfo | null,
+  b: LabelInfo | null,
+): "match" | "mismatch" | "unknown" => {
+  if (!a || !b) {
+    return "unknown";
+  }
+
+  if (a.text !== undefined && b.text !== undefined) {
+    return a.text === b.text ? "match" : "mismatch";
+  }
+
+  if (a.variable && a.variable === b.variable) {
+    return "match";
+  }
+
+  return "unknown";
+};
+
+/**
+ * Replays a scope's section calls the way the runtime logger does: a section opened
+ * while another is still open is dropped, and an end whose label doesn't match the open
+ * section is dropped. A mismatch closes the section here anyway so that one typo doesn't
+ * also cascade into an "unclosed section" report.
+ */
+const simulate = (calls: SectionCall[]): SectionEvent[] => {
+  const events: SectionEvent[] = [];
+  let open: SectionCall | null = null;
+
+  for (const call of calls) {
+    if (call.kind === "start") {
+      if (open) {
+        events.push({ type: "nested", node: call.node, openLabel: open.label?.text });
+      } else {
+        open = call;
+      }
+      continue;
+    }
+
+    if (!open) {
+      events.push({ type: "strayEnd", node: call.node });
+      continue;
+    }
+
+    if (compareLabels(open.label, call.label) === "mismatch") {
+      events.push({
+        type: "labelMismatch",
+        node: call.node,
+        startLabel: open.label?.text as string,
+        endLabel: call.label?.text as string,
+      });
+    }
+
+    open = null;
+  }
+
+  if (open) {
+    events.push({ type: "unclosed", node: open.node, label: open.label?.text });
+  }
+
+  return events;
+};
+
+/**
+ * Walks each function body independently and hands the resulting section events to
+ * `onEvent`. Calls are analyzed in source order per scope; a section opened in one
+ * function and closed in another is out of reach of static analysis and is deliberately
+ * not reported.
+ */
+export const withSectionAnalysis =
+  <TMessageIds extends string>(
+    onEvent: (
+      context: Readonly<TSESLint.RuleContext<TMessageIds, []>>,
+      event: SectionEvent,
+    ) => void,
+  ): SectionRuleCreate<TMessageIds> =>
+  (context) => {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const stack: SectionCall[][] = [];
+
+    const enterScope = (): void => {
+      stack.push([]);
+    };
+
+    const exitScope = (): void => {
+      const calls = stack.pop();
+
+      if (!calls?.length) {
+        return;
+      }
+
+      for (const event of simulate(calls)) {
+        onEvent(context, event);
+      }
+    };
+
+    return {
+      Program: enterScope,
+      "Program:exit": exitScope,
+      ":function": enterScope,
+      ":function:exit": exitScope,
+      CallExpression(node) {
+        const kind = getSectionCallKind(node);
+
+        if (!kind) {
+          return;
+        }
+
+        const labelNode = kind === "start" ? node.arguments[0] : getEndLabelArgument(node);
+        const label = resolveLabel(labelNode, sourceCode.getScope(node));
+
+        stack[stack.length - 1]?.push({ kind, node, label });
+      },
+    };
+  };
+
+/**
+ * Sees every section call on its own, without the per-scope pairing analysis. Rules that
+ * only care about where a call appears use this.
+ */
+export const withSectionCalls =
+  <TMessageIds extends string, TOptions extends readonly unknown[] = []>(
+    onCall: (
+      context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+      node: TSESTree.CallExpression,
+      kind: SectionCallKind,
+    ) => void,
+  ): SectionRuleCreate<TMessageIds, TOptions> =>
+  (context) => ({
+    CallExpression(node) {
+      const kind = getSectionCallKind(node);
+
+      if (kind) {
+        onCall(context, node, kind);
+      }
+    },
+  });

--- a/packages/eslint-plugin-spectral/tsconfig.json
+++ b/packages/eslint-plugin-spectral/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["esnext"],
+    "module": "commonjs",
+    "strict": true,
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/rules/ruleTester.ts"]
+}

--- a/packages/eslint-plugin-spectral/vitest.config.ts
+++ b/packages/eslint-plugin-spectral/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/packages/spectral/src/testing.ts
+++ b/packages/spectral/src/testing.ts
@@ -34,6 +34,7 @@ import type {
   ActionPerformReturn as InvokeActionPerformReturn,
   DataSourceResult as InvokeDataSourceResult,
   TriggerResult as InvokeTriggerResult,
+  PollingContext,
   TriggerDefinition,
   TriggerEventFunctionReturn,
 } from "./types";
@@ -277,6 +278,28 @@ const createActionContext = <
     },
     flowSchemas: {},
     ...context,
+  };
+};
+
+/**
+ * The context a code-native flow handler receives: an `ActionContext` whose logger carries
+ * the section methods that only code-native integrations get.
+ */
+type CodeNativeTestContext<TConfigVars extends ConfigVarResultCollection> = ActionContext<
+  TConfigVars,
+  Record<string, ComponentManifest["actions"]>,
+  string[],
+  CodeNativeActionLogger
+>;
+
+const createCodeNativeActionContext = <TConfigVars extends ConfigVarResultCollection>(
+  context?: Partial<CodeNativeTestContext<TConfigVars>>,
+): CodeNativeTestContext<TConfigVars> => {
+  const actionContext = createActionContext<TConfigVars>(context);
+
+  return {
+    ...actionContext,
+    logger: context?.logger ?? loggerMock(),
   };
 };
 
@@ -586,12 +609,12 @@ export const invokeFlow = async <
     payload,
   }: {
     configVars?: TConfigVarValues;
-    context?: Partial<ActionContext<TConfigVars>>;
+    context?: Partial<CodeNativeTestContext<TConfigVars>>;
     payload?: Partial<TriggerPayload>;
   } = {},
 ): Promise<InvokeReturn<InvokeActionPerformReturn<false, unknown>>> => {
   const realizedConfigVars = createConfigVars(configVars);
-  const realizedContext = createActionContext({
+  const realizedContext = createCodeNativeActionContext({
     ...context,
     configVars: realizedConfigVars,
   });
@@ -603,7 +626,9 @@ export const invokeFlow = async <
 
   if ("onTrigger" in flow && typeof flow.onTrigger === "function") {
     const triggerResult = await flow.onTrigger(
-      realizedContext as any,
+      // A polling trigger's perform additionally expects the `polling` helpers, which this
+      // tester does not simulate; the cast is narrowed to just that gap.
+      realizedContext as typeof realizedContext & PollingContext<TActionInputs>,
       realizedPayload,
       params as ActionInputParameters<TInputs>,
     );
@@ -611,7 +636,7 @@ export const invokeFlow = async <
     params.onTrigger = { results: triggerResult?.payload };
   }
 
-  const result = await flow.onExecution(realizedContext as any, params);
+  const result = await flow.onExecution(realizedContext, params);
 
   return {
     result,


### PR DESCRIPTION
This PR adds a new package, `@prismatic-io/eslint-plugin-spectral`, which includes linting rules for using CNI sections properly. It also updates our provided eslint config to correctly point to it and references those rules. 

Note that these rules are already enforced at run-time, but linting provides an earlier guard to hopefully streamline the development cycle a bit. Rules, w/ more detail in `packages/eslint-plugin-spectral/README.md`:

| Rule | Catches |
| --- | --- |
| `@prismatic-io/spectral/no-nested-section` | A section opened while another is still open |
| `@prismatic-io/spectral/no-unclosed-section` | A section never closed, or a `sectionEnd` with nothing open |
| `@prismatic-io/spectral/section-label-match` | A `sectionEnd` label that does not match the open section |
| `@prismatic-io/spectral/no-section-outside-flow` | A section opened in a helper rather than in a flow handler |

These rules are all listed as errors, since they should ideally block further progression until addressed.

This PR also includes the release infra for the new plugin package. A new package was needed because new rules cannot be defined in config; we must define them elsewhere to fit with how eslintrc resolves them. 

I plan to release the v1 plugin manually first, then config. Once that is through, we should update prism to bump the config version so all newly created integrations include the new rules and check them at build time (we also may need to inform existing customers to do this bump as well).