### PR TITLE
Generate a helper for user-activated connections too

### DIFF
--- a/packages/spectral/src/generators/cniComponentManifest/cli.test.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/cli.test.ts
@@ -112,6 +112,8 @@ const apiMocks = vi.hoisted(() => ({
   fetchComponentDataForManifest:
     vi.fn<CniComponentManifestModule["fetchComponentDataForManifest"]>(),
   fetchConnectionStableKeys: vi.fn<CniComponentManifestModule["fetchConnectionStableKeys"]>(),
+  fetchUserActivatedConnectionStableKeys:
+    vi.fn<CniComponentManifestModule["fetchUserActivatedConnectionStableKeys"]>(),
 }));
 
 vi.mock(import("."), async (importOriginal) => ({
@@ -158,6 +160,7 @@ describe("cni-component-manifest filesystem behavior", () => {
     workingDir = await mkdtemp(path.join(tmpdir(), "spectral-cni-manifest-"));
     apiMocks.fetchComponentDataForManifest.mockResolvedValue(component);
     apiMocks.fetchConnectionStableKeys.mockResolvedValue(["existing-connection"]);
+    apiMocks.fetchUserActivatedConnectionStableKeys.mockResolvedValue(["existing-user-connection"]);
     consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
   });
 
@@ -234,6 +237,19 @@ describe("cni-component-manifest filesystem behavior", () => {
         );
       }),
     );
+
+    const connectionsIndex = await readFile(
+      path.join(destinationDir, "connections", "index.ts"),
+      "utf8",
+    );
+
+    // The two helpers differ by the config var they build, so each is asserted on the
+    // dataType it produces rather than on its name alone.
+    expect(connectionsIndex).toContain("acmeReusableConnection");
+    expect(connectionsIndex).toContain('dataType: "connection"');
+    expect(connectionsIndex).toContain("acmeUserActivatedConnection");
+    expect(connectionsIndex).toContain('"existing-user-connection"');
+    expect(connectionsIndex).toContain('dataType: "userScopedConnection"');
 
     const action = await readFile(path.join(destinationDir, "actions", "doThing.ts"), "utf8");
     expect(action).toMatchSnapshot();

--- a/packages/spectral/src/generators/cniComponentManifest/cli.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/cli.ts
@@ -3,7 +3,11 @@ import { generateManifest } from "../componentManifest/generateManifest";
 import { createFlagHelpText } from "../utils/createFlagHelpText";
 import { createTemplate } from "../utils/createTemplate";
 import { getFlagsBooleanValue } from "../utils/getFlagBooleanValue";
-import { fetchComponentDataForManifest, fetchConnectionStableKeys } from ".";
+import {
+  fetchComponentDataForManifest,
+  fetchConnectionStableKeys,
+  fetchUserActivatedConnectionStableKeys,
+} from ".";
 
 export const runMain = async (process: NodeJS.Process) => {
   const args = process.argv.slice(2);
@@ -70,10 +74,12 @@ export const runMain = async (process: NodeJS.Process) => {
     isPrivate: flags.isPrivate.value || false,
   });
 
-  const reusableConnectionStableKeys = await fetchConnectionStableKeys({
-    componentKey: component.key,
-    isPrivate: flags.isPrivate.value || false,
-  });
+  const isPrivate = flags.isPrivate.value || false;
+
+  const [reusableConnectionStableKeys, userActivatedConnectionStableKeys] = await Promise.all([
+    fetchConnectionStableKeys({ componentKey: component.key, isPrivate }),
+    fetchUserActivatedConnectionStableKeys({ componentKey: component.key, isPrivate }),
+  ]);
 
   // Generate the manifest
   const destinationDir = path.join(process.cwd(), "src", "manifests", component.key);
@@ -93,6 +99,7 @@ export const runMain = async (process: NodeJS.Process) => {
     manifestDir: destinationDir,
     generatedSourceDir: destinationDir,
     reusableConnectionStableKeys,
+    userActivatedConnectionStableKeys,
     createEntryPointFiles: () =>
       createTemplate({
         source: path.join(templatesDir, "index.ts.ejs"),

--- a/packages/spectral/src/generators/cniComponentManifest/index.ts
+++ b/packages/spectral/src/generators/cniComponentManifest/index.ts
@@ -300,6 +300,76 @@ export const fetchConnectionStableKeys = async ({
   }
 };
 
+/**
+ * The user-activated connections of one component that this organization has set up.
+ *
+ * A sibling of the fetch above rather than part of it: an integration declares this
+ * kind with `userActivatedConnection`, which builds a `userScopedConnection` config
+ * var, so its keys cannot appear in the same union as the reusable ones.
+ *
+ * Containers only. An integration references the container so the platform can
+ * resolve whose credential to run with, and the leaves beneath it are one person's
+ * own credential and the organization's for testing - neither is a choice. The API
+ * has no `treeLocation` filter, so that last narrowing happens here.
+ *
+ * `variableScope` filters lower case but comes back upper case, so the two spellings
+ * below are both deliberate.
+ */
+export const fetchUserActivatedConnectionStableKeys = async ({
+  componentKey,
+  isPrivate,
+}: {
+  componentKey: string;
+  isPrivate: boolean;
+}): Promise<string[]> => {
+  const accessToken = await getPrismAccessToken();
+  const prismaticUrl = process.env.PRISMATIC_URL ?? "https://app.prismatic.io";
+
+  const query = `
+    query userActivatedConnectionStableKeysQuery($componentSelector: [ComponentSelector]!) {
+      scopedConfigVariables(
+        connection_Component_In: $componentSelector
+        managedBy_In: ["org"]
+        variableScope_In: ["user"]
+      ) {
+        nodes {
+          stableKey
+          treeLocation
+        }
+      }
+    }
+  `;
+
+  try {
+    const response = await axios.post(
+      new URL("/api", prismaticUrl).toString(),
+      {
+        query,
+        variables: {
+          componentSelector: [{ key: componentKey, isPublic: !isPrivate }],
+        },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+          "Prismatic-Client": "spectral",
+        },
+      },
+    );
+
+    const nodes: Array<{ stableKey: string; treeLocation: "ROOT" | "LEAF" }> =
+      response.data?.data?.scopedConfigVariables?.nodes ?? [];
+
+    return nodes.filter((node) => node.treeLocation === "ROOT").map((node) => node.stableKey);
+  } catch (error) {
+    if (error instanceof AxiosError && error.response?.data?.errors) {
+      throw new Error(JSON.stringify(error.response.data.errors, null, 2));
+    }
+    throw error;
+  }
+};
+
 async function getComponentActions(componentId: string, prismaticUrl: string, accessToken: string) {
   let hasNextPage = true;
   let cursor: string | null = null;

--- a/packages/spectral/src/generators/componentManifest/createConnections.ts
+++ b/packages/spectral/src/generators/componentManifest/createConnections.ts
@@ -32,6 +32,7 @@ interface CreateConnectionsProps<
   sourceDir: string;
   destinationDir: string;
   reusableConnectionStableKeys?: string[];
+  userActivatedConnectionStableKeys?: string[];
 }
 
 export const createConnections = async <
@@ -51,6 +52,7 @@ export const createConnections = async <
   sourceDir,
   destinationDir,
   reusableConnectionStableKeys = [],
+  userActivatedConnectionStableKeys = [],
 }: CreateConnectionsProps<
   TInputs,
   TActionInputs,
@@ -74,6 +76,7 @@ export const createConnections = async <
     sourceDir,
     destinationDir,
     reusableConnectionStableKeys,
+    userActivatedConnectionStableKeys,
     componentKey: component.key,
   });
 
@@ -134,6 +137,7 @@ interface RenderConnectionsIndexProps {
   sourceDir: string;
   destinationDir: string;
   reusableConnectionStableKeys?: string[];
+  userActivatedConnectionStableKeys?: string[];
   componentKey: string;
 }
 
@@ -144,6 +148,7 @@ const renderConnectionsIndex = async ({
   sourceDir,
   destinationDir,
   reusableConnectionStableKeys = [],
+  userActivatedConnectionStableKeys = [],
   componentKey,
 }: RenderConnectionsIndexProps) => {
   return await createTemplate({
@@ -152,6 +157,7 @@ const renderConnectionsIndex = async ({
     data: {
       imports,
       reusableConnectionStableKeys,
+      userActivatedConnectionStableKeys,
       componentKey,
       helpers,
     },

--- a/packages/spectral/src/generators/componentManifest/generateManifest.ts
+++ b/packages/spectral/src/generators/componentManifest/generateManifest.ts
@@ -31,6 +31,7 @@ interface GenerateManifestProps<
   manifestDir: string;
   generatedSourceDir: string;
   reusableConnectionStableKeys?: string[];
+  userActivatedConnectionStableKeys?: string[];
   createEntryPointFiles: () => Promise<unknown>;
   successMessage: string;
 }
@@ -53,6 +54,7 @@ export const generateManifest = async <
   manifestDir,
   generatedSourceDir,
   reusableConnectionStableKeys,
+  userActivatedConnectionStableKeys,
   createEntryPointFiles,
   successMessage,
 }: GenerateManifestProps<
@@ -93,6 +95,7 @@ export const generateManifest = async <
       sourceDir: templatesDir,
       destinationDir: generatedSourceDir,
       reusableConnectionStableKeys,
+      userActivatedConnectionStableKeys,
     }),
     createDataSources({
       component,

--- a/packages/spectral/src/generators/componentManifest/templates/connections/index.ts.ejs
+++ b/packages/spectral/src/generators/componentManifest/templates/connections/index.ts.ejs
@@ -1,6 +1,15 @@
 <%- include('../partials/generatedHeader.ejs') -%>
-<% if (reusableConnectionStableKeys.length > 0) { -%>
-import type { CustomerActivatedConnectionConfigVar, OrganizationActivatedConnectionConfigVar } from "@prismatic-io/spectral";
+<%
+  const configVarTypes = [];
+  if (reusableConnectionStableKeys.length > 0) {
+    configVarTypes.push("CustomerActivatedConnectionConfigVar", "OrganizationActivatedConnectionConfigVar");
+  }
+  if (userActivatedConnectionStableKeys.length > 0) {
+    configVarTypes.push("UserActivatedConnectionConfigVar");
+  }
+-%>
+<% if (configVarTypes.length > 0) { -%>
+import type { <%- configVarTypes.join(", ") %> } from "@prismatic-io/spectral";
 <% } -%>
 <%- include('../partials/importBarrel.ejs', { imports }) -%>
 <% if (reusableConnectionStableKeys.length > 0) { %>
@@ -9,5 +18,13 @@ export const <%- helpers.camelCase(componentKey) %>ReusableConnection = (
 ): OrganizationActivatedConnectionConfigVar | CustomerActivatedConnectionConfigVar => ({
   stableKey,
   dataType: "connection",
+});
+<% } -%>
+<% if (userActivatedConnectionStableKeys.length > 0) { %>
+export const <%- helpers.camelCase(componentKey) %>UserActivatedConnection = (
+  stableKey: <%- userActivatedConnectionStableKeys.map(k => JSON.stringify(k)).join(" | ") %> | (string & {}),
+): UserActivatedConnectionConfigVar => ({
+  stableKey,
+  dataType: "userScopedConnection",
 });
 <% } -%>


### PR DESCRIPTION
Follow-up to #529, and to the thread that produced it.

## Why

The manifest generator has offered a typed helper for reusable connections since #413, so a CNI author picks an existing org- or customer-activated connection from a union of stable keys rather than copying one out of the UI:

```ts
slackReusableConnection("4dd3fa2b-e84c-4c19-ac99-547f06f308cb")
```

User-activated connections landed later and never got the same treatment, so their stable keys are typed from memory:

```ts
userActivatedConnection({ stableKey: "dropbox-connection-user-1" })
```

Get that wrong and the import fails without naming the key it could not find, so the failure mode is worst exactly where the help is missing.

## What this adds

The sibling helper, generated the same way:

```ts
export const slackUserActivatedConnection = (
  stableKey: "dropbox-connection-user-1" | (string & {}),
): UserActivatedConnectionConfigVar => ({
  stableKey,
  dataType: "userScopedConnection",
});
```

## Why they cannot share one union

`ReusableConnection` builds a `connection` config var; a user-activated connection is `userScopedConnection`, from a different function. A stable key in the wrong list would compile to the wrong shape.

## How the two lists are separated

One fetch, then sorted in code. `managedBy_In: ["org", "customer"]` is the same filter #529 adds, and it removes the two records neither list wants — a build-only container, which is system-managed and cannot be referenced from an integration at all, and one person's own credential, which is never referenced directly.

What is left splits on `variableScope` and `treeLocation`:

| record | pairing | goes to |
|---|---|---|
| org-activated global | `ORG : ORG : ROOT` | `ReusableConnection` |
| build-only leaf | `ORG : ORG : LEAF` | `ReusableConnection` |
| org-activated customer | `ORG : CUSTOMER : ROOT` | `ReusableConnection` |
| customer-activated | `CUSTOMER : CUSTOMER : ROOT` | `ReusableConnection` |
| user-activated container | `ORG : USER : ROOT` | `UserActivatedConnection` |
| org's test credential | `ORG : USER : LEAF` | neither |

That last row is why the split cannot live entirely in the query: a container and the organization's test credential beneath it differ only by `treeLocation`, and `scopedConfigVariables` exposes no filter for it. All six pairings above were confirmed against a real organization rather than derived.

## Relationship to #529

This keeps #529's filter and does not need to widen it. Worth knowing before that one merges: **it should not also add `variableScope_In`.** Doing so would exclude the user-scoped records this PR sorts out, and the user-activated union would come back empty. The two records #529 leaves behind — the user-activated container and the organization's test credential — are handled here instead.

Happy to rebase once #529 merges, or to fold it in here if that is easier.

## Verification

`build` and the full suite pass (345 tests). The CLI test asserts both helpers appear in the generated `connections/index.ts`, each keyed on the `dataType` it produces rather than on its name.
