### PR TITLE
Add schema to JSON code inputs

### DIFF
--- a/packages/spectral-test/src/Inputs.test-d.ts
+++ b/packages/spectral-test/src/Inputs.test-d.ts
@@ -3,8 +3,10 @@ import {
   type Connection,
   type InputCleanFunction,
   input,
+  type JsonSchema,
+  type ZodSchema,
 } from "@prismatic-io/spectral";
-import { expectType } from "tsd";
+import { expectAssignable, expectError, expectType } from "tsd";
 
 const omittedCollectionInput = input({
   label: "Omitted Collection",
@@ -51,3 +53,29 @@ const mapCollectionInput = input({
   clean: (value) => value,
 });
 expectType<InputCleanFunction<unknown, unknown>>(mapCollectionInput.clean);
+
+const jsonCodeInput = input({
+  label: "JSON Code",
+  type: "code",
+  language: "json",
+  schema: { type: "object", properties: { name: { type: "string" } } },
+});
+expectAssignable<JsonSchema | ZodSchema | undefined>(jsonCodeInput.schema);
+
+const zodLikeSchema = { toJSONSchema: () => ({ type: "object" }) };
+const zodJsonCodeInput = input({
+  label: "JSON Code",
+  type: "code",
+  language: "json",
+  schema: zodLikeSchema,
+});
+expectAssignable<JsonSchema | ZodSchema | undefined>(zodJsonCodeInput.schema);
+
+expectError(
+  input({
+    label: "YAML Code",
+    type: "code",
+    language: "yaml",
+    schema: { type: "object" },
+  }),
+);

--- a/packages/spectral/src/index.ts
+++ b/packages/spectral/src/index.ts
@@ -814,6 +814,19 @@ export const dataSource = <
  *
  * @example
  * import { input } from "@prismatic-io/spectral";
+ * import { z } from "zod";
+ *
+ * // A JSON code input with a schema describing the expected JSON.
+ * // `schema` accepts a JSON Schema object or a Zod 4 schema.
+ * const contact = input({
+ *   label: "Contact",
+ *   type: "code",
+ *   language: "json",
+ *   schema: z.object({ name: z.string(), email: z.string().email() }),
+ * });
+ *
+ * @example
+ * import { input } from "@prismatic-io/spectral";
  *
  * // A key-value list collection input
  * const headers = input({

--- a/packages/spectral/src/serverTypes/convertComponent.test.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.test.ts
@@ -175,6 +175,32 @@ describe("convertInput", () => {
     });
   });
 
+  it("serializes a JSON Schema declared on a JSON code input", () => {
+    const schema = { type: "object", properties: { name: { type: "string" } } } as const;
+    const body = input({ label: "Body", type: "code", language: "json", schema });
+
+    const converted = convertInput("body", body);
+
+    expect(converted.schema).toBe(JSON.stringify(schema));
+  });
+
+  it("converts a Zod schema declared on a JSON code input to serialized JSON Schema", () => {
+    const jsonSchema = { type: "object", properties: { name: { type: "string" } } };
+    const zodSchema = { toJSONSchema: vi.fn(() => jsonSchema) };
+    const body = input({ label: "Body", type: "code", language: "json", schema: zodSchema });
+
+    const converted = convertInput("body", body);
+
+    expect(zodSchema.toJSONSchema).toHaveBeenCalledOnce();
+    expect(converted.schema).toBe(JSON.stringify(jsonSchema));
+  });
+
+  it("does not emit `schema` on a code input that declares none", () => {
+    const body = input({ label: "Body", type: "code", language: "json" });
+    const converted = convertInput("body", body);
+    expect("schema" in converted).toBe(false);
+  });
+
   it("does not emit `inputs` on a non-structuredObject input", () => {
     const basicInput = input({ type: "string", label: "Basic" });
     const converted = convertInput("basic", basicInput);

--- a/packages/spectral/src/serverTypes/convertComponent.ts
+++ b/packages/spectral/src/serverTypes/convertComponent.ts
@@ -18,7 +18,9 @@ import {
   type TriggerOptionChoice,
   type TriggerPayload,
   type TriggerResult,
+  type ZodSchema,
 } from "../types";
+import type { JsonSchema } from "../types/jsonforms/JsonSchema";
 import {
   isPollingTriggerDefinition,
   type PollingTriggerDefinition,
@@ -257,9 +259,11 @@ export const convertInput = (
     collection,
     inputs: childInputs,
     configurations,
+    schema,
     ...rest
   } = definition as {
     default?: unknown;
+    schema?: JsonSchema | ZodSchema;
     type: InputFieldDefinition["type"] | "template";
     label: string | { key: string; value: string };
     collection?: "valuelist" | "keyvaluelist";
@@ -309,9 +313,16 @@ export const convertInput = (
     keyLabel,
     onPremiseControlled: rest.onPremControlled === true ? true : undefined,
     inputs: nestedInputs,
+    ...(schema ? { schema: convertInputSchema(schema) } : {}),
     ...(scope ? { scope } : {}),
   };
 };
+
+const isZodSchema = (schema: JsonSchema | ZodSchema): schema is ZodSchema =>
+  typeof (schema as ZodSchema).toJSONSchema === "function";
+
+const convertInputSchema = (schema: JsonSchema | ZodSchema): string =>
+  JSON.stringify(isZodSchema(schema) ? schema.toJSONSchema() : schema);
 
 const TEMPLATE_VALUE_REGEX = /{{#(\w+)}}/g;
 const TEMPLATE_VALUE_ERRORS = {

--- a/packages/spectral/src/serverTypes/index.ts
+++ b/packages/spectral/src/serverTypes/index.ts
@@ -448,6 +448,7 @@ export interface Input {
   required?: boolean;
   model?: InputFieldChoice[];
   language?: string;
+  schema?: string;
   onPremiseControlled?: boolean;
   dataSource?: string;
   shown?: boolean;

--- a/packages/spectral/src/types/Inputs.ts
+++ b/packages/spectral/src/types/Inputs.ts
@@ -245,33 +245,63 @@ export type ConnectionTemplateInputField = BaseInputField & {
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
 
-/** Defines attributes of a CodeInputField. */
-export type CodeInputField = BaseInputField & {
+/** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
+export type CodeLanguage =
+  | "css"
+  | "graphql"
+  | "handlebars"
+  | "hcl"
+  | "html"
+  | "javascript"
+  | "json"
+  | "liquid"
+  | "markdown"
+  | "mysql"
+  | "pgsql"
+  | "plaintext"
+  | "sql"
+  | "typescript"
+  | "xml"
+  | "yaml";
+
+/**
+ * Structural stand-in for a Zod 4 schema (`z.ZodType`). Spectral does not depend
+ * on `zod`; any object that exposes Zod 4.1's `toJSONSchema()` instance method
+ * qualifies. The schema is converted to JSON Schema when the component is published.
+ */
+export interface ZodSchema {
+  toJSONSchema(params?: unknown): object;
+}
+
+type CodeInputFieldBase = BaseInputField & {
   /** Data type the input will collect. */
   type: "code";
-  /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
-  language:
-    | "css"
-    | "graphql"
-    | "handlebars"
-    | "hcl"
-    | "html"
-    | "javascript"
-    | "json"
-    | "liquid"
-    | "markdown"
-    | "mysql"
-    | "pgsql"
-    | "plaintext"
-    | "sql"
-    | "typescript"
-    | "xml"
-    | "yaml";
   /** Dictates possible choices for the input. */
   model?: InputFieldChoice[];
   /** Clean function. */
   clean?: InputCleanFunction<unknown>;
 } & CollectionOptions<string>;
+
+/** A code input that collects JSON. May declare the shape of that JSON with a schema. */
+export type JsonCodeInputField = CodeInputFieldBase & {
+  /** Code language for syntax highlighting. */
+  language: "json";
+  /**
+   * Schema describing the JSON this input collects, as a JSON Schema or a Zod
+   * schema. Used by the Prismatic UI to validate and assist input authoring.
+   */
+  schema?: JsonSchema | ZodSchema;
+};
+
+/** A code input for any language other than JSON. */
+export type NonJsonCodeInputField = CodeInputFieldBase & {
+  /** Code language for syntax highlighting. For no syntax highlighting, choose "plaintext" */
+  language: Exclude<CodeLanguage, "json">;
+  schema?: never;
+};
+
+/** Defines attributes of a CodeInputField. */
+export type CodeInputField = JsonCodeInputField | NonJsonCodeInputField;
 
 /** Defines attributes of a ConditionalInputField. */
 export interface ConditionalInputField extends BaseInputField {

--- a/packages/spectral/src/types/index.ts
+++ b/packages/spectral/src/types/index.ts
@@ -29,6 +29,7 @@ export * from "./Inputs";
 export * from "./InstanceAttributes";
 export * from "./IntegrationAttributes";
 export * from "./IntegrationDefinition";
+export type { JsonSchema } from "./jsonforms/JsonSchema";
 export * from "./OutputSchema";
 export * from "./PollingTriggerDefinition";
 export * from "./ScopedConfigVars";


### PR DESCRIPTION
Allow a code input with language "json" to declare the shape of the JSON it collects as a JSON Schema or a Zod 4 schema. The schema is serialized to a JSON Schema string when the component is converted for the platform.