### PR TITLE
Let a user level page collect the connections it always could

### DIFF
--- a/packages/spectral-test/src/UserActivatedConnectionPlacement.test-d.ts
+++ b/packages/spectral-test/src/UserActivatedConnectionPlacement.test-d.ts
@@ -96,20 +96,23 @@ expectError(
   }),
 );
 
-expectError(
-  userLevelConfigPage({
-    tagline: "Connect your account",
-    elements: {
-      "Acme Connection": connectionConfigVar({
-        stableKey: "acme-connection",
-        dataType: "connection",
-        inputs: {
-          apiKey: { label: "API Key", type: "password", required: true },
-        },
-      }),
-    },
-  }),
-);
+/**
+ * A connection the integration defines is collected here, not refused. Nobody has
+ * supplied its credential in advance, which is the reason this wizard exists - it is
+ * the original shape of a user level page and predates the per-person kind.
+ */
+userLevelConfigPage({
+  tagline: "Connect your account",
+  elements: {
+    "Acme Connection": connectionConfigVar({
+      stableKey: "acme-connection",
+      dataType: "connection",
+      inputs: {
+        apiKey: { label: "API Key", type: "password", required: true },
+      },
+    }),
+  },
+});
 
 /** What a user level page does accept: the per-person connection, copy, and any config
  * var that is not a connection – a per-person string is a real thing to collect. */

--- a/packages/spectral/src/serverTypes/convertIntegration.test.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.test.ts
@@ -362,8 +362,39 @@ describe("convertConfigPages", () => {
     } as unknown as Parameters<typeof convertConfigPages>[0];
 
     expect(() => convertConfigPages(pages, true)).toThrow(
-      /Only a user-activated connection belongs on a user level config page/,
+      /does not belong on a user level config page/,
     );
+  });
+
+  it("accepts a connection the integration defines on a user level page", () => {
+    const pages = {
+      "Your Account": {
+        elements: {
+          "Your Account": {
+            stableKey: "your-account",
+            dataType: "connection",
+            inputs: { apiKey: { label: "API key", type: "string" } },
+          },
+        },
+      },
+    } as never;
+
+    expect(() => convertConfigPages(pages, true)).not.toThrow();
+  });
+
+  it("accepts a connection referenced from a component on a user level page", () => {
+    const pages = {
+      "Your Slack": {
+        elements: {
+          "Your Slack": {
+            stableKey: "your-slack",
+            connection: { component: "slack", key: "oauth2", values: {} },
+          },
+        },
+      },
+    } as never;
+
+    expect(() => convertConfigPages(pages, true)).not.toThrow();
   });
 
   it("leaves config vars that are not connections alone on a user level page", () => {

--- a/packages/spectral/src/serverTypes/convertIntegration.ts
+++ b/packages/spectral/src/serverTypes/convertIntegration.ts
@@ -270,14 +270,15 @@ export const convertIntegration = <
 /**
  * Whether this element is a connection of a kind a user level page does not collect.
  *
- * Three shapes rather than one: `isOrgOrCustomerActivatedConnection` covers a bare
- * pointer at a Scoped Config Variable, and a connection declared inline or referenced
- * from a component is deliberately excluded from that predicate, so each needs naming.
+ * Only the two reusable kinds. Their credential is supplied once, by the organization
+ * or by the customer, so a page shown to each individual cannot ask for it.
+ *
+ * A connection the integration defines, or references from a component, is collected
+ * per person here and is the original reason this wizard exists - refusing those broke
+ * every integration that had one.
  */
 const isRefusedOnUserLevelPage = (value: unknown): boolean =>
-  isOrgOrCustomerActivatedConnection(value) ||
-  isConnectionDefinitionConfigVar(value as ConfigVar) ||
-  isConnectionReferenceConfigVar(value as ConfigVar);
+  isOrgOrCustomerActivatedConnection(value);
 
 export const convertConfigPages = (
   pages: ConfigPages | UserLevelConfigPages | undefined,
@@ -320,7 +321,7 @@ export const convertConfigPages = (
 
     if (misplaced.length) {
       throw new Error(
-        `Only a user-activated connection belongs on a user level config page: every other kind is activated by the organization or the customer rather than by each person. Move ${misplaced.join(", ")}.`,
+        `A connection activated once by the organization or the customer does not belong on a user level config page, which asks each person for their own. Move ${misplaced.join(", ")}.`,
       );
     }
   }

--- a/packages/spectral/src/types/ConfigPages.ts
+++ b/packages/spectral/src/types/ConfigPages.ts
@@ -1,4 +1,9 @@
-import type { ConfigVar } from "./ConfigVars";
+import type {
+  ConfigVar,
+  ConnectionConfigVar,
+  DataSourceConfigVar,
+  StandardConfigVar,
+} from "./ConfigVars";
 import type {
   CustomerActivatedConnectionConfigVar,
   OrganizationActivatedConnectionConfigVar,
@@ -46,25 +51,25 @@ export type ConfigPageElement = string | Exclude<ConfigVar, UserActivatedConnect
 /**
  * What a user level config page may contain.
  *
- * Everything an ordinary page may, except the two reusable kinds. Those are activated
- * once - by the organization or by the customer - so putting one here asks each person
- * for a credential that is not theirs to give.
+ * A connection the integration defines, or references from a component, belongs here:
+ * nobody has supplied its credential in advance, which is the reason this wizard
+ * exists. So does the per-person kind, and any config var that is not a connection.
  *
- * A connection defined by the integration, or referenced from a component, is fine
- * here: nobody has supplied its credential in advance, which is the whole reason a
- * user level page exists. That is the original shape of this wizard and it predates
- * the per-person connection kind.
+ * The two reusable kinds do not. Their credential is supplied once - by the
+ * organization or by the customer - so a page shown to each individual cannot ask
+ * for it.
  *
- * The mirror of `ConfigPageElement`, and stated the same way: the type is the canonical
- * rule and the convert layer enforces it at build time, so a JavaScript author hits it
- * too.
+ * Stated as what it accepts rather than as an `Exclude` of what it does not, which
+ * looks equivalent and is not: the reusable kinds are
+ * `{ dataType: "connection"; stableKey: string }`, and every other connection kind is
+ * assignable to that, so excluding them takes the rest with them.
  */
 export type UserLevelConfigPageElement =
   | string
-  | Exclude<
-      ConfigVar,
-      CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar
-    >;
+  | StandardConfigVar
+  | DataSourceConfigVar
+  | ConnectionConfigVar
+  | UserActivatedConnectionConfigVar;
 
 /** An element on a page of either kind, for code that walks both wizards at once. */
 export type AnyConfigPageElement = ConfigPageElement | UserLevelConfigPageElement;
@@ -110,3 +115,21 @@ export interface UserLevelConfigPage {
   /** Specifies an optional tagline for this Config Page. */
   tagline?: string;
 }
+
+/**
+ * Every kind of config var is either collectable on a user level page or one of the
+ * two reusable kinds that page refuses.
+ *
+ * Listing what the page accepts is the only formulation that works - see the note on
+ * `UserLevelConfigPageElement` - but a list does not follow `ConfigVar` when a kind is
+ * added to it. This fails the build in that case, so the new kind has to be given an
+ * answer rather than silently becoming un-collectable.
+ */
+type UnclassifiedConfigVar = Exclude<
+  ConfigVar,
+  | UserLevelConfigPageElement
+  | CustomerActivatedConnectionConfigVar
+  | OrganizationActivatedConnectionConfigVar
+>;
+type AssertNever<T extends never> = T;
+type _EveryConfigVarIsClassified = AssertNever<UnclassifiedConfigVar>;

--- a/packages/spectral/src/types/ConfigPages.ts
+++ b/packages/spectral/src/types/ConfigPages.ts
@@ -1,4 +1,4 @@
-import type { ConfigVar, ConnectionConfigVar } from "./ConfigVars";
+import type { ConfigVar } from "./ConfigVars";
 import type {
   CustomerActivatedConnectionConfigVar,
   OrganizationActivatedConnectionConfigVar,
@@ -46,18 +46,24 @@ export type ConfigPageElement = string | Exclude<ConfigVar, UserActivatedConnect
 /**
  * What a user level config page may contain.
  *
- * Only the per-person connection kind. Every other kind is activated once by the
- * organization or the customer, so putting one here asks each person for a credential
- * that is not theirs to give. Config vars that are not connections are unaffected.
- * The convert layer enforces this at build time.
+ * Everything an ordinary page may, except the two reusable kinds. Those are activated
+ * once - by the organization or by the customer - so putting one here asks each person
+ * for a credential that is not theirs to give.
+ *
+ * A connection defined by the integration, or referenced from a component, is fine
+ * here: nobody has supplied its credential in advance, which is the whole reason a
+ * user level page exists. That is the original shape of this wizard and it predates
+ * the per-person connection kind.
+ *
+ * The mirror of `ConfigPageElement`, and stated the same way: the type is the canonical
+ * rule and the convert layer enforces it at build time, so a JavaScript author hits it
+ * too.
  */
 export type UserLevelConfigPageElement =
   | string
   | Exclude<
       ConfigVar,
-      | ConnectionConfigVar
-      | CustomerActivatedConnectionConfigVar
-      | OrganizationActivatedConnectionConfigVar
+      CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar
     >;
 
 /** An element on a page of either kind, for code that walks both wizards at once. */


### PR DESCRIPTION
## What broke

The guard added in 10.27 refused every connection kind on a user level page except the per-person one. Two of those had been accepted since the wizard existed:

| on a user level page | 10.26 | 10.27 – 10.30.1 | this PR |
|---|---|---|---|
| user-activated (per person) | ok | ok | ok |
| **integration defines it** | ok | **refused** | ok |
| **referenced from a component** | ok | **refused** | ok |
| org-activated (reusable) | ok | refused | refused |
| customer-activated (reusable) | ok | refused | refused |
| anything that is not a connection | ok | ok | ok |

The two in bold are collected per person on that page - nobody has supplied their credential in advance - which is the reason the wizard exists. The documented ULC example, each of a customer's users connecting their own Dropbox, is one of them.

Only the reusable kinds needed refusing: their credential is supplied once, by the organization or by the customer, so a page shown to each individual cannot ask for it.

## The type has to say this by inclusion

Worth knowing before reviewing, because the obvious form does not work. The first version of this fix excluded only the reusable kinds and still refused the case it meant to allow:

```ts
// looks right, is not
Exclude<ConfigVar, CustomerActivatedConnectionConfigVar | OrganizationActivatedConnectionConfigVar>
```

Both of those are `{ dataType: "connection"; stableKey: string }`, and every other connection kind is assignable to that shape - so excluding them takes the rest along. Stated as what the page accepts instead:

```ts
export type UserLevelConfigPageElement =
  | string
  | StandardConfigVar
  | DataSourceConfigVar
  | ConnectionConfigVar
  | UserActivatedConnectionConfigVar;
```

The existing `tsd` placement tests show the three behaviors apart:

```
Exclude version     OAC refused   CAC refused   ConnectionConfigVar refused  ← the bug
string | ConfigVar  OAC allowed   CAC allowed   ConnectionConfigVar allowed  ← too loose
inclusion version   OAC refused   CAC refused   ConnectionConfigVar allowed  ← this PR
```