### PR TITLE
Add @prismatic-io/spectral-codemod with the headless configuration co…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
           - spectral
           - eslint-config-spectral
           - eslint-plugin-spectral
+          - spectral-codemod
       bump:
         description: "Version bump type"
         required: true

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,22 @@
         "vitest": "^4.1.10",
       },
     },
+    "packages/spectral-codemod": {
+      "name": "@prismatic-io/spectral-codemod",
+      "version": "0.1.0",
+      "bin": {
+        "spectral-codemod": "bin/spectral-codemod.js",
+      },
+      "dependencies": {
+        "ts-morph": "^28.0.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.15",
+        "@types/node": "26.2.0",
+        "typescript": "^6",
+        "vitest": "^4.1.10",
+      },
+    },
     "packages/spectral-test": {
       "name": "spectral-test",
       "version": "1.0.0",
@@ -240,6 +256,8 @@
 
     "@prismatic-io/spectral": ["@prismatic-io/spectral@workspace:packages/spectral"],
 
+    "@prismatic-io/spectral-codemod": ["@prismatic-io/spectral-codemod@workspace:packages/spectral-codemod"],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
@@ -295,6 +313,8 @@
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
     "@tsd/typescript": ["@tsd/typescript@5.9.3", "", {}, "sha512-JSSdNiS0wgd8GHhBwnMAI18Y8XPhLVN+dNelPfZCXFhy9Lb3NbnFyp9JKxxr54jSUkEJPk3cidvCoHducSaRMQ=="],
 
@@ -491,6 +511,8 @@
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -898,6 +920,8 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -1073,6 +1097,8 @@
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 

--- a/mise.toml
+++ b/mise.toml
@@ -30,10 +30,10 @@ description = "Run all CI validation checks"
 depends = ["check", "test", "tsd"]
 
 [tasks.version-bump]
-description = "Bump a package's version (set PACKAGE=spectral|eslint-config-spectral|eslint-plugin-spectral and BUMP_TYPE=patch|minor|major|preview)"
+description = "Bump a package's version (set PACKAGE=spectral|eslint-config-spectral|eslint-plugin-spectral|spectral-codemod and BUMP_TYPE=patch|minor|major|preview)"
 run = """
 if [ -z "$PACKAGE" ]; then
-  echo "ERROR: PACKAGE env var is required (spectral|eslint-config-spectral|eslint-plugin-spectral)."
+  echo "ERROR: PACKAGE env var is required (spectral|eslint-config-spectral|eslint-plugin-spectral|spectral-codemod)."
   exit 1
 fi
 if [ ! -d "packages/$PACKAGE" ]; then
@@ -52,7 +52,7 @@ fi
 description = "Trigger a release workflow on GitHub"
 usage = '''
 arg "<package>" help="Package to release" {
-  choices "spectral" "eslint-config-spectral" "eslint-plugin-spectral"
+  choices "spectral" "eslint-config-spectral" "eslint-plugin-spectral" "spectral-codemod"
 }
 arg "<bump>" help="Version bump type" {
   choices "patch" "minor" "major" "preview"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "bun run --filter @prismatic-io/eslint-plugin-spectral build && bun run --filter @prismatic-io/eslint-config-spectral build && bun run --filter @prismatic-io/spectral build && bun run --filter spectral-test build",
-    "test": "bun run --filter @prismatic-io/spectral test && bun run --filter @prismatic-io/eslint-plugin-spectral test",
+    "build": "bun run --filter @prismatic-io/eslint-plugin-spectral build && bun run --filter @prismatic-io/eslint-config-spectral build && bun run --filter @prismatic-io/spectral build && bun run --filter @prismatic-io/spectral-codemod build && bun run --filter spectral-test build",
+    "test": "bun run --filter @prismatic-io/spectral test && bun run --filter @prismatic-io/eslint-plugin-spectral test && bun run --filter @prismatic-io/spectral-codemod test",
     "tsd": "bun run --filter spectral-test tsd",
-    "check": "bun run --filter @prismatic-io/spectral check && bun run --filter @prismatic-io/eslint-plugin-spectral check",
-    "lint": "bun run --filter @prismatic-io/spectral lint && bun run --filter @prismatic-io/eslint-plugin-spectral lint",
+    "check": "bun run --filter @prismatic-io/spectral check && bun run --filter @prismatic-io/eslint-plugin-spectral check && bun run --filter @prismatic-io/spectral-codemod check",
+    "lint": "bun run --filter @prismatic-io/spectral lint && bun run --filter @prismatic-io/eslint-plugin-spectral lint && bun run --filter @prismatic-io/spectral-codemod lint",
     "all": "bun run check && bun run lint && bun run build && bun run test && bun run tsd"
   }
 }

--- a/packages/spectral-codemod/LICENSE
+++ b/packages/spectral-codemod/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Prismatic Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/spectral-codemod/README.md
+++ b/packages/spectral-codemod/README.md
@@ -1,0 +1,76 @@
+<div align="center">
+  <img src="https://prismatic.io/favicon-48x48.png" />
+  <h1>@prismatic-io/spectral-codemod</h1>
+</div>
+
+Codemods that migrate Prismatic connectors and code-native integrations across
+[`@prismatic-io/spectral`](../spectral) releases. Each codemod is a named rule that
+rewrites your source files in place.
+
+## Usage
+
+Run the latest published codemods without installing anything:
+
+```sh
+npx @prismatic-io/spectral-codemod@latest <codemod> [path]
+```
+
+`path` is a project directory, a `tsconfig.json`, or a single source file. It defaults
+to the current directory. A directory with a `tsconfig.json` contributes the files that
+config includes; any other directory contributes every `.ts` and `.tsx` file beneath it
+except `node_modules` and `dist`.
+
+```sh
+npx @prismatic-io/spectral-codemod@latest --list                          # available codemods
+npx @prismatic-io/spectral-codemod@latest v10.0.0/headless-configuration --dry-run   # report without writing
+```
+
+Commit or stash your work first, then review the diff the codemod leaves behind.
+
+## Codemods
+
+### `v10.0.0/headless-configuration`
+
+Replaces an integration's config wizard with a headless `configuration`. The codemod
+finds the project's single `integration()` call and:
+
+- emits an exported `configurationSchema` zod object with one required field per
+  non-connection config variable across `configPages` and `userLevelConfigPages`,
+- adds `configuration: configuration({ schema, eTag: "INITIAL", init, connections, dataSources })`
+  to the integration, with an empty `init` for you to fill in and no `uiSchema`,
+- moves every connection, including `scopedConfigVars`, into `configuration.connections`,
+- moves every data source config variable into `configuration.dataSources`,
+- removes `configPages`, `userLevelConfigPages`, and `scopedConfigVars` from the call.
+
+Connections and data sources are referenced where they already live, for example
+`configPages.Settings.elements["Field Map"]`, so the original page declarations stay in
+place. Delete them once you have reviewed the result. Install `zod` if the project does
+not already depend on it.
+
+| Config variable | Schema |
+|---|---|
+| `string`, `htmlElement` | `z.string()` |
+| `code` with `codeLanguage: "json"` | `z.json()`, the parsed document |
+| `code` with any other language | `z.string()` |
+| `picklist` with a literal `pickList` | `z.enum([...])`, otherwise `z.string()` |
+| `date` / `timestamp` | `z.iso.date()` / `z.iso.datetime()` |
+| `boolean` / `number` | `z.boolean()` / `z.number()` |
+| `schedule` | `z.object({ value, schedule_type, time_zone })` |
+| `objectSelection` / `objectFieldMap` | zod objects built from a shared `elementSchema` |
+| `jsonForm`, or a component data source reference | `z.unknown()` |
+| `collectionType: "valuelist"` | `z.array(T)` |
+| `collectionType: "keyvaluelist"` | `z.array(z.object({ key: z.string(), value: T }))` |
+
+The schema describes the unpacked value of each variable. The config wizard stored every
+scalar inside a collection as a string, so `init` must parse booleans and numbers in a
+`valuelist` or `keyvaluelist` when it migrates an existing instance.
+
+Page heading strings are skipped. Permission and visibility settings and default values
+are not carried into the schema.
+
+## Writing a codemod
+
+A codemod is a `Codemod` from `src/codemod.ts`: a `name`, a `description`, and a
+`transform(project)` that edits a [ts-morph](https://ts-morph.com) `Project` and returns
+the files it changed. Wrap a file-level transform with `eachFile`. Add the codemod to
+`src/codemods/index.ts` and give it a test built on `applyCodemod` from `src/testing.ts`.

--- a/packages/spectral-codemod/bin/spectral-codemod.js
+++ b/packages/spectral-codemod/bin/spectral-codemod.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const { main } = require("../dist/cli");
+
+main(process.argv.slice(2)).then(
+  (code) => {
+    process.exitCode = code;
+  },
+  (error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  },
+);

--- a/packages/spectral-codemod/package.json
+++ b/packages/spectral-codemod/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@prismatic-io/spectral-codemod",
+  "version": "0.1.0",
+  "description": "Codemods that migrate Prismatic connectors and code-native integrations across @prismatic-io/spectral releases",
+  "keywords": [
+    "prismatic",
+    "codemod",
+    "spectral"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "spectral-codemod": "bin/spectral-codemod.js"
+  },
+  "homepage": "https://prismatic.io",
+  "bugs": {
+    "url": "https://github.com/prismatic-io/spectral"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prismatic-io/spectral.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "license": "MIT",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "bun run format && bun run clean && tsc",
+    "prepack": "bun run build",
+    "lint": "biome lint .",
+    "format": "biome check --write --unsafe .",
+    "check": "biome check .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "dependencies": {
+    "ts-morph": "^28.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.15",
+    "@types/node": "26.2.0",
+    "typescript": "^6",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/spectral-codemod/src/cli.test.ts
+++ b/packages/spectral-codemod/src/cli.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { main, parseArgs } from "./cli";
+
+const capture = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { log: (l: string) => out.push(l), error: (l: string) => err.push(l) }, out, err };
+};
+
+describe("parseArgs", () => {
+  it("reads the codemod, path, and flags", () => {
+    expect(parseArgs(["v10.0.0/headless-configuration", "./src", "--dry-run"])).toEqual({
+      codemod: "v10.0.0/headless-configuration",
+      path: "./src",
+      dryRun: true,
+      list: false,
+      help: false,
+    });
+  });
+
+  it("rejects unknown options and extra positionals", () => {
+    expect(() => parseArgs(["--nope"])).toThrow("Unknown option: --nope");
+    expect(() => parseArgs(["a", "b", "c"])).toThrow("Too many arguments");
+  });
+});
+
+describe("main", () => {
+  it("lists codemods", async () => {
+    const { io, out } = capture();
+    expect(await main(["--list"], io)).toBe(0);
+    expect(out.join("\n")).toContain("v10.0.0/headless-configuration");
+  });
+
+  it("fails with usage when no codemod is named", async () => {
+    const { io, err } = capture();
+    expect(await main([], io)).toBe(1);
+    expect(err[0]).toContain("Usage:");
+  });
+
+  it("fails for an unknown codemod and names the available ones", async () => {
+    const { io, err } = capture();
+    expect(await main(["nope"], io)).toBe(1);
+    expect(err[0]).toContain('Unknown codemod "nope"');
+    expect(err[0]).toContain("v10.0.0/headless-configuration");
+  });
+
+  it("runs a codemod against a path and reports the changed files", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "spectral-codemod-cli-"));
+    try {
+      writeFileSync(
+        join(dir, "index.ts"),
+        `import { configVar, integration } from "@prismatic-io/spectral";
+export default integration({
+  name: "Acme",
+  configPages: { Page: { elements: { name: configVar({ stableKey: "n", dataType: "string" }) } } },
+});
+`,
+      );
+      const { io, out } = capture();
+
+      expect(await main(["v10.0.0/headless-configuration", dir], io)).toBe(0);
+
+      expect(out[0]).toBe("v10.0.0/headless-configuration: scanned 1 files, changed 1");
+      expect(out[1]).toContain("index.ts");
+      expect(readFileSync(join(dir, "index.ts"), "utf8")).toContain("name: z.string(),");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/spectral-codemod/src/cli.ts
+++ b/packages/spectral-codemod/src/cli.ts
@@ -1,0 +1,92 @@
+import { isAbsolute, relative } from "path";
+import { codemods } from "./codemods";
+import { runCodemod } from "./runner";
+
+const USAGE = `Usage: spectral-codemod <codemod> [path] [--dry-run]
+       spectral-codemod --list
+
+Applies a named migration to the project at <path> (default: the current directory).
+
+Options:
+  --dry-run   Report the files that would change without writing them.
+  --list      Print the available codemods.
+  --help      Print this message.`;
+
+interface ParsedArgs {
+  codemod?: string;
+  path?: string;
+  dryRun: boolean;
+  list: boolean;
+  help: boolean;
+}
+
+export const parseArgs = (argv: string[]): ParsedArgs => {
+  const parsed: ParsedArgs = { dryRun: false, list: false, help: false };
+  const positional: string[] = [];
+  for (const arg of argv) {
+    if (arg === "--dry-run") {
+      parsed.dryRun = true;
+    } else if (arg === "--list") {
+      parsed.list = true;
+    } else if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 2) {
+    throw new Error(`Too many arguments.\n\n${USAGE}`);
+  }
+  [parsed.codemod, parsed.path] = positional;
+  return parsed;
+};
+
+export const listCodemods = (): string => {
+  const width = Math.max(...[...codemods.keys()].map((name) => name.length));
+  return [...codemods.values()]
+    .map((mod) => `  ${mod.name.padEnd(width)}  ${mod.description}`)
+    .join("\n");
+};
+
+/** A path inside the working directory prints relative to it; any other prints absolute. */
+const displayPath = (file: string): string => {
+  const rel = relative(process.cwd(), file);
+  return rel.startsWith("..") || isAbsolute(rel) ? file : rel;
+};
+
+/** Runs the command line and resolves to the process exit code. */
+export const main = async (
+  argv: string[],
+  io: { log: (line: string) => void; error: (line: string) => void } = console,
+): Promise<number> => {
+  const args = parseArgs(argv);
+
+  if (args.help) {
+    io.log(USAGE);
+    return 0;
+  }
+  if (args.list) {
+    io.log(listCodemods());
+    return 0;
+  }
+  if (!args.codemod) {
+    io.error(USAGE);
+    return 1;
+  }
+
+  const codemod = codemods.get(args.codemod);
+  if (!codemod) {
+    io.error(`Unknown codemod "${args.codemod}". Available codemods:\n${listCodemods()}`);
+    return 1;
+  }
+
+  const result = await runCodemod(codemod, { path: args.path, dryRun: args.dryRun });
+  const verb = args.dryRun ? "would change" : "changed";
+  io.log(`${codemod.name}: scanned ${result.scanned} files, ${verb} ${result.changed.length}`);
+  for (const file of result.changed) {
+    io.log(`  ${displayPath(file)}`);
+  }
+  return 0;
+};

--- a/packages/spectral-codemod/src/codemod.ts
+++ b/packages/spectral-codemod/src/codemod.ts
@@ -1,0 +1,21 @@
+import type { Project, SourceFile } from "ts-morph";
+
+/**
+ * A named source migration. `transform` edits the project in place through ts-morph
+ * and returns the files it changed; the runner saves only those.
+ */
+export interface Codemod {
+  /** Name given on the command line: `spectral-codemod <name> [path]`. */
+  name: string;
+  /** One line shown by `--list`. */
+  description: string;
+  transform(project: Project): SourceFile[];
+}
+
+export const defineCodemod = (codemod: Codemod): Codemod => codemod;
+
+/** Lifts a file-level transform, which reports whether it changed the file, to a project transform. */
+export const eachFile =
+  (transform: (file: SourceFile) => boolean) =>
+  (project: Project): SourceFile[] =>
+    project.getSourceFiles().filter((file) => transform(file));

--- a/packages/spectral-codemod/src/codemods/index.ts
+++ b/packages/spectral-codemod/src/codemods/index.ts
@@ -1,0 +1,7 @@
+import type { Codemod } from "../codemod";
+import headlessConfiguration from "./v10.0.0/headlessConfiguration";
+
+const all: Codemod[] = [headlessConfiguration];
+
+/** Every shipped codemod, keyed by its command-line name. */
+export const codemods: ReadonlyMap<string, Codemod> = new Map(all.map((mod) => [mod.name, mod]));

--- a/packages/spectral-codemod/src/codemods/v10.0.0/headlessConfiguration.test.ts
+++ b/packages/spectral-codemod/src/codemods/v10.0.0/headlessConfiguration.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { applyCodemod } from "../../testing";
+import headlessConfiguration from "./headlessConfiguration";
+
+const run = (files: Record<string, string>) => applyCodemod(headlessConfiguration, files);
+
+const CONFIG_PAGES = `
+import {
+  configPage,
+  configVar,
+  connectionConfigVar,
+  dataSourceConfigVar,
+  userLevelConfigPage,
+} from "@prismatic-io/spectral";
+
+export const configPages = {
+  Connections: configPage({
+    tagline: "Connect",
+    elements: {
+      "Acme Connection": connectionConfigVar({
+        stableKey: "acme",
+        dataType: "connection",
+        inputs: { token: { label: "Token", type: "password" } },
+      }),
+    },
+  }),
+  Settings: configPage({
+    elements: {
+      heading: "<h1>Settings</h1>",
+      "Object Key": configVar({ stableKey: "object-key", dataType: "string" }),
+      region: configVar({ stableKey: "region", dataType: "picklist", pickList: ["us", "eu"] }),
+      tags: configVar({ stableKey: "tags", dataType: "string", collectionType: "valuelist" }),
+      headers: configVar({ stableKey: "headers", dataType: "string", collectionType: "keyvaluelist" }),
+      enabled: configVar({ stableKey: "enabled", dataType: "boolean" }),
+      limit: configVar({ stableKey: "limit", dataType: "number" }),
+      start: configVar({ stableKey: "start", dataType: "date" }),
+      at: configVar({ stableKey: "at", dataType: "timestamp" }),
+      body: configVar({ stableKey: "body", dataType: "code", codeLanguage: "json" }),
+      markup: configVar({ stableKey: "markup", dataType: "code", codeLanguage: "xml" }),
+      schedule: configVar({ stableKey: "schedule", dataType: "schedule" }),
+      selection: configVar({ stableKey: "selection", dataType: "objectSelection" }),
+      fieldMap: configVar({ stableKey: "field-map", dataType: "objectFieldMap" }),
+      form: configVar({ stableKey: "form", dataType: "jsonForm" }),
+      banner: configVar({ stableKey: "banner", dataType: "htmlElement" }),
+      fields: dataSourceConfigVar({
+        stableKey: "fields",
+        dataSourceType: "picklist",
+        collectionType: "valuelist",
+        perform: async () => ({ result: ["a"] }),
+      }),
+      "Field Map": dataSourceConfigVar({
+        stableKey: "remote-fields",
+        dataSource: { component: "salesforce", key: "listFields" },
+      }),
+    },
+  }),
+};
+
+export const userLevelConfigPages = {
+  Personal: userLevelConfigPage({
+    elements: {
+      nickname: configVar({ stableKey: "nickname", dataType: "string" }),
+    },
+  }),
+};
+`;
+
+const INDEX = `
+import { integration, organizationActivatedConnection } from "@prismatic-io/spectral";
+import { configPages, userLevelConfigPages } from "./configPages";
+import flows from "./flows";
+
+export default integration({
+  name: "Acme",
+  description: "Sync Acme",
+  flows,
+  configPages,
+  userLevelConfigPages,
+  scopedConfigVars: {
+    orgConnection: organizationActivatedConnection({ stableKey: "org" }),
+  },
+});
+`;
+
+describe("v10.0.0/headless-configuration", () => {
+  it("rewrites the integration file and leaves the page declarations alone", () => {
+    const { files, changed } = run({
+      "src/index.ts": INDEX,
+      "src/configPages.ts": CONFIG_PAGES,
+      "src/flows.ts": "export default [];",
+    });
+
+    expect(changed).toEqual(["src/index.ts"]);
+    expect(files["src/configPages.ts"]).toBe(CONFIG_PAGES);
+    expect(files["src/index.ts"]).toMatchInlineSnapshot(`
+      "
+      import { integration, organizationActivatedConnection, configuration } from "@prismatic-io/spectral";
+      import { configPages, userLevelConfigPages } from "./configPages";
+      import flows from "./flows";
+      import { z } from "zod";
+
+      const scopedConfigVars = {
+        orgConnection: organizationActivatedConnection({ stableKey: "org" }),
+      };
+
+      const elementSchema = z.object({ key: z.string(), label: z.string().optional() });
+      export const configurationSchema = z.object({
+        "Object Key": z.string(),
+        region: z.enum(["us", "eu"]),
+        tags: z.array(z.string()),
+        headers: z.array(z.object({ key: z.string(), value: z.string() })),
+        enabled: z.boolean(),
+        limit: z.number(),
+        start: z.iso.date(),
+        at: z.iso.datetime(),
+        body: z.json(),
+        markup: z.string(),
+        schedule: z.object({ value: z.string(), schedule_type: z.string(), time_zone: z.string() }),
+        selection: z.array(z.object({ object: elementSchema, fields: z.array(elementSchema).optional(), defaultSelected: z.boolean().optional() })),
+        fieldMap: z.object({ fields: z.array(z.object({ field: elementSchema, mappedObject: elementSchema.optional(), mappedField: elementSchema.optional(), defaultObject: elementSchema.optional(), defaultField: elementSchema.optional() })), options: z.array(z.object({ object: elementSchema, fields: z.array(elementSchema) })).optional() }),
+        form: z.unknown(),
+        banner: z.string(),
+        nickname: z.string(),
+      });
+
+      export default integration({
+        name: "Acme",
+        description: "Sync Acme",
+        flows,
+        configuration: configuration({
+          schema: configurationSchema,
+          eTag: "INITIAL",
+          init: async () => {
+            // code to handle migrating between different configuration versions
+          },
+          connections: {
+            "Acme Connection": configPages.Connections.elements["Acme Connection"],
+            orgConnection: scopedConfigVars.orgConnection,
+          },
+          dataSources: {
+            fields: configPages.Settings.elements.fields,
+            "Field Map": configPages.Settings.elements["Field Map"],
+          },
+        })
+      });
+      "
+    `);
+  });
+
+  it("hoists inline pages so the configuration can reference them", () => {
+    const { files } = run({
+      "src/index.ts": `
+import { configPage, configVar, connectionConfigVar, integration } from "@prismatic-io/spectral";
+
+export default integration({
+  name: "Inline",
+  configPages: {
+    Page: configPage({
+      elements: {
+        conn: connectionConfigVar({ stableKey: "c", dataType: "connection", inputs: {} }),
+        name: configVar({ stableKey: "n", dataType: "string" }),
+      },
+    }),
+  },
+});
+`,
+    });
+
+    expect(files["src/index.ts"]).toMatchInlineSnapshot(`
+      "
+      import { configPage, configVar, connectionConfigVar, integration, configuration } from "@prismatic-io/spectral";
+      import { z } from "zod";
+
+      const configPages = {
+        Page: configPage({
+          elements: {
+            conn: connectionConfigVar({ stableKey: "c", dataType: "connection", inputs: {} }),
+            name: configVar({ stableKey: "n", dataType: "string" }),
+          },
+        }),
+      };
+
+      export const configurationSchema = z.object({
+        name: z.string(),
+      });
+
+      export default integration({
+        name: "Inline",
+        configuration: configuration({
+          schema: configurationSchema,
+          eTag: "INITIAL",
+          init: async () => {
+            // code to handle migrating between different configuration versions
+          },
+          connections: {
+            conn: configPages.Page.elements.conn,
+          },
+        })
+      });
+      "
+    `);
+  });
+
+  it("follows an aliased pages identifier and an element declared elsewhere", () => {
+    const { files } = run({
+      "src/vars.ts": `
+import { configVar } from "@prismatic-io/spectral";
+export const count = configVar({ stableKey: "count", dataType: "number" });
+`,
+      "src/index.ts": `
+import { configPage, integration } from "@prismatic-io/spectral";
+import { count } from "./vars";
+
+const pages = { Page: configPage({ elements: { count } }) };
+
+export const acme = integration({ name: "Aliased", configPages: pages });
+`,
+    });
+
+    expect(files["src/index.ts"]).toContain("count: z.number(),");
+    expect(files["src/index.ts"]).toContain("configuration: configuration({");
+    expect(files["src/index.ts"]).not.toContain("configPages: pages");
+  });
+
+  it("fails when the project has no integration() call", () => {
+    expect(() => run({ "src/index.ts": "export const x = 1;" })).toThrow(
+      "No integration() call imported from @prismatic-io/spectral was found.",
+    );
+  });
+
+  it("fails when the integration declares no config pages", () => {
+    expect(() =>
+      run({
+        "src/index.ts": `import { integration } from "@prismatic-io/spectral";
+export default integration({ name: "Bare", flows: [] });`,
+      }),
+    ).toThrow("declares no configPages to migrate");
+  });
+});

--- a/packages/spectral-codemod/src/codemods/v10.0.0/headlessConfiguration.ts
+++ b/packages/spectral-codemod/src/codemods/v10.0.0/headlessConfiguration.ts
@@ -1,0 +1,452 @@
+import {
+  type CallExpression,
+  type Expression,
+  Node,
+  type ObjectLiteralExpression,
+  type Project,
+  type SourceFile,
+  SyntaxKind,
+} from "ts-morph";
+import { defineCodemod } from "../../codemod";
+import {
+  type ConfigVarShape,
+  ELEMENT_SCHEMA_SOURCE,
+  usesElementSchema,
+  zodSchemaFor,
+} from "./zodSchema";
+
+const SPECTRAL = "@prismatic-io/spectral";
+const E_TAG = "INITIAL";
+const SCHEMA_NAME = "configurationSchema";
+const PAGE_PROPERTIES = ["configPages", "userLevelConfigPages"] as const;
+const SCOPED_PROPERTY = "scopedConfigVars";
+
+/** Spectral identity helpers whose first argument is the definition they return. */
+const WRAPPERS = new Set([
+  "configPage",
+  "userLevelConfigPage",
+  "configVar",
+  "dataSourceConfigVar",
+  "connectionConfigVar",
+  "customerActivatedConnection",
+  "organizationActivatedConnection",
+  "userActivatedConnection",
+]);
+
+const CONNECTION_WRAPPERS = new Set([
+  "connectionConfigVar",
+  "customerActivatedConnection",
+  "organizationActivatedConnection",
+  "userActivatedConnection",
+]);
+
+interface ClassifiedElement {
+  key: string;
+  /** Source that reaches the element from the integration file, e.g. `configPages.Page.elements.key`. */
+  path: string;
+  kind: "connection" | "dataSource" | "value";
+  shape: ConfigVarShape;
+}
+
+/**
+ * Replaces an integration's config wizard with a headless `configuration`.
+ *
+ * Every non-connection config variable becomes a required field of an exported zod
+ * schema. Connections, including scoped config vars, move to
+ * `configuration.connections`; data source config vars move to
+ * `configuration.dataSources`. Both are referenced where they already live rather
+ * than copied, so the original page declarations stay in place for the author to
+ * remove after review. The codemod does not emit a `uiSchema`.
+ */
+export default defineCodemod({
+  name: "v10.0.0/headless-configuration",
+  description: "Migrate configPages, userLevelConfigPages, and scopedConfigVars to configuration",
+  transform(project) {
+    const call = findIntegrationCall(project);
+    const file = call.getSourceFile();
+    const definition = resolveObjectLiteral(call.getArguments()[0]);
+    if (!definition) {
+      throw new Error(`${file.getFilePath()}: integration() must be given an object literal.`);
+    }
+
+    const elements: ClassifiedElement[] = [];
+    const hoisted: Node[] = [];
+    for (const propertyName of PAGE_PROPERTIES) {
+      const pages = hoistedProperty(definition, propertyName, call);
+      if (pages) {
+        elements.push(...classifyPages(pages.name, pages.literal));
+        if (pages.hoisted) hoisted.push(pages.hoisted);
+      }
+    }
+    const scoped = hoistedProperty(definition, SCOPED_PROPERTY, call);
+    if (scoped) {
+      if (scoped.hoisted) hoisted.push(scoped.hoisted);
+      for (const property of scoped.literal.getProperties()) {
+        const key = propertyKey(property);
+        if (key !== undefined) {
+          elements.push({
+            key,
+            path: `${scoped.name}${accessor(key)}`,
+            kind: "connection",
+            shape: {},
+          });
+        }
+      }
+    }
+    if (
+      elements.length === 0 &&
+      !hasAnyProperty(definition, [...PAGE_PROPERTIES, SCOPED_PROPERTY])
+    ) {
+      throw new Error(`${file.getFilePath()}: integration() declares no configPages to migrate.`);
+    }
+
+    const values = elements.filter((element) => element.kind === "value");
+    const statement = topLevelStatement(call);
+    const schemaStatements = [
+      ...(values.some((element) => usesElementSchema(element.shape))
+        ? [ELEMENT_SCHEMA_SOURCE]
+        : []),
+      `export const ${SCHEMA_NAME} = z.object({\n${values
+        .map((element) => `  ${objectKey(element.key)}: ${zodSchemaFor(element.shape)},`)
+        .join("\n")}\n});\n`,
+    ];
+    file.insertStatements(statement.getChildIndex(), schemaStatements);
+    for (const declaration of hoisted) {
+      declaration.appendWhitespace("\n");
+    }
+
+    for (const name of [...PAGE_PROPERTIES, SCOPED_PROPERTY]) {
+      definition.getProperty(name)?.remove();
+    }
+    definition.addPropertyAssignment({
+      name: "configuration",
+      initializer: configurationSource(elements),
+    });
+
+    ensureNamedImport(file, SPECTRAL, "configuration");
+    ensureNamedImport(file, "zod", "z");
+    file.formatText({ indentSize: 2 });
+    file.replaceWithText(file.getFullText().replace(/\n{3,}/g, "\n\n"));
+    return [file];
+  },
+});
+
+const configurationSource = (elements: ClassifiedElement[]): string => {
+  const group = (kind: ClassifiedElement["kind"], name: string): string[] => {
+    const entries = elements.filter((element) => element.kind === kind);
+    if (entries.length === 0) {
+      return [];
+    }
+    const body = entries
+      .map((element) => `    ${objectKey(element.key)}: ${element.path},`)
+      .join("\n");
+    return [`  ${name}: {\n${body}\n  },`];
+  };
+  return [
+    "configuration({",
+    `  schema: ${SCHEMA_NAME},`,
+    `  eTag: ${JSON.stringify(E_TAG)},`,
+    "  init: async () => {",
+    "    // code to handle migrating between different configuration versions",
+    "  },",
+    ...group("connection", "connections"),
+    ...group("dataSource", "dataSources"),
+    "})",
+  ].join("\n");
+};
+
+/** The single `integration()` call in the project, located through its spectral import. */
+const findIntegrationCall = (project: Project): CallExpression => {
+  const calls = project
+    .getSourceFiles()
+    .flatMap((file) =>
+      file
+        .getDescendantsOfKind(SyntaxKind.CallExpression)
+        .filter((call) => isSpectralImport(call.getExpression(), "integration")),
+    );
+  if (calls.length !== 1) {
+    throw new Error(
+      calls.length === 0
+        ? `No integration() call imported from ${SPECTRAL} was found.`
+        : `Found ${calls.length} integration() calls; run the codemod against one integration at a time.`,
+    );
+  }
+  return calls[0];
+};
+
+/** True when `expression` is an identifier bound by a named import of `exportName` from `SPECTRAL`. */
+const isSpectralImport = (expression: Expression, exportName: string): boolean => {
+  if (!Node.isIdentifier(expression)) {
+    return false;
+  }
+  return expression
+    .getDefinitionNodes()
+    .some(
+      (definition) =>
+        Node.isImportSpecifier(definition) &&
+        definition.getName() === exportName &&
+        definition.getImportDeclaration().getModuleSpecifierValue() === SPECTRAL,
+    );
+};
+
+/**
+ * The object literal behind an expression: unwrapped from `as`, `satisfies`, and
+ * parentheses; taken from the first argument of a spectral identity helper; or
+ * followed from an identifier to its declaration, in this file or an imported one.
+ */
+const resolveObjectLiteral = (
+  expression: Node | undefined,
+): ObjectLiteralExpression | undefined => {
+  if (!expression) {
+    return undefined;
+  }
+  if (Node.isObjectLiteralExpression(expression)) {
+    return expression;
+  }
+  if (
+    Node.isAsExpression(expression) ||
+    Node.isSatisfiesExpression(expression) ||
+    Node.isParenthesizedExpression(expression)
+  ) {
+    return resolveObjectLiteral(expression.getExpression());
+  }
+  if (Node.isCallExpression(expression) && wrapperName(expression) !== undefined) {
+    return resolveObjectLiteral(expression.getArguments()[0]);
+  }
+  if (Node.isIdentifier(expression)) {
+    for (const declaration of declarationsOf(expression)) {
+      const resolved = Node.isVariableDeclaration(declaration)
+        ? resolveObjectLiteral(declaration.getInitializer())
+        : undefined;
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The declarations an identifier refers to, followed through named imports into the
+ * exporting module. A shorthand property's name is bound to the property, so its
+ * value symbol is used instead.
+ */
+const declarationsOf = (identifier: Node): Node[] => {
+  const parent = identifier.getParent();
+  const symbol = Node.isShorthandPropertyAssignment(parent)
+    ? parent.getValueSymbol()
+    : identifier.getSymbol();
+  return (
+    symbol?.getDeclarations().flatMap((declaration) => {
+      if (!Node.isImportSpecifier(declaration)) {
+        return [declaration];
+      }
+      const exported = declaration
+        .getImportDeclaration()
+        .getModuleSpecifierSourceFile()
+        ?.getExportedDeclarations()
+        .get(declaration.getName());
+      return exported ?? [];
+    }) ?? []
+  );
+};
+
+const wrapperName = (call: CallExpression): string | undefined => {
+  const callee = call.getExpression();
+  return Node.isIdentifier(callee) && WRAPPERS.has(callee.getText()) ? callee.getText() : undefined;
+};
+
+/**
+ * A page-holding property of the integration definition, as an identifier the new
+ * `configuration` can reach it by. An inline object literal is hoisted into a
+ * `const` before the integration so it can be referenced too.
+ */
+const hoistedProperty = (
+  definition: ObjectLiteralExpression,
+  propertyName: string,
+  call: CallExpression,
+): { name: string; literal: ObjectLiteralExpression; hoisted?: Node } | undefined => {
+  const property = definition.getProperty(propertyName);
+  if (!property) {
+    return undefined;
+  }
+  const initializer = Node.isShorthandPropertyAssignment(property)
+    ? property.getNameNode()
+    : Node.isPropertyAssignment(property)
+      ? property.getInitializerOrThrow()
+      : undefined;
+  if (!initializer) {
+    throw new Error(`${propertyName} must be a property assignment.`);
+  }
+
+  if (Node.isIdentifier(initializer)) {
+    const literal = resolveObjectLiteral(initializer);
+    if (!literal) {
+      throw new Error(
+        `Could not resolve ${propertyName} (${initializer.getText()}) to an object literal.`,
+      );
+    }
+    return { name: initializer.getText(), literal };
+  }
+
+  const file = call.getSourceFile();
+  const statement = topLevelStatement(call);
+  const name = file.getVariableDeclaration(propertyName)
+    ? `integration${capitalize(propertyName)}`
+    : propertyName;
+  const [hoisted] = file.insertStatements(statement.getChildIndex(), [
+    `const ${name} = ${initializer.getText()};`,
+  ]);
+  const literal = resolveObjectLiteral(
+    hoisted.asKindOrThrow(SyntaxKind.VariableStatement).getDeclarations()[0].getInitializer(),
+  );
+  if (!literal) {
+    throw new Error(`Could not resolve ${propertyName} to an object literal.`);
+  }
+  return { name, literal, hoisted };
+};
+
+const classifyPages = (pagesName: string, pages: ObjectLiteralExpression): ClassifiedElement[] => {
+  const elements: ClassifiedElement[] = [];
+  for (const pageProperty of pages.getProperties()) {
+    const pageKey = propertyKey(pageProperty);
+    const page = resolveObjectLiteral(propertyValue(pageProperty));
+    if (pageKey === undefined || !page) {
+      continue;
+    }
+    const pageElements = resolveObjectLiteral(propertyValue(page.getProperty("elements")));
+    if (!pageElements) {
+      continue;
+    }
+    for (const elementProperty of pageElements.getProperties()) {
+      const key = propertyKey(elementProperty);
+      const value = propertyValue(elementProperty);
+      if (
+        key === undefined ||
+        !value ||
+        Node.isStringLiteral(value) ||
+        Node.isNoSubstitutionTemplateLiteral(value)
+      ) {
+        continue;
+      }
+      const classified = classifyElement(value);
+      if (classified) {
+        elements.push({
+          key,
+          path: `${pagesName}${accessor(pageKey)}.elements${accessor(key)}`,
+          ...classified,
+        });
+      }
+    }
+  }
+  return elements;
+};
+
+const classifyElement = (
+  value: Expression,
+): Pick<ClassifiedElement, "kind" | "shape"> | undefined => {
+  const wrapper = Node.isCallExpression(value) ? wrapperName(value) : undefined;
+  const literal = resolveObjectLiteral(value);
+  if (!literal) {
+    return undefined;
+  }
+  const dataType = literalString(literal, "dataType");
+  if (
+    (wrapper && CONNECTION_WRAPPERS.has(wrapper)) ||
+    dataType === "connection" ||
+    dataType === "userScopedConnection" ||
+    literal.getProperty("connection")
+  ) {
+    return { kind: "connection", shape: {} };
+  }
+  const collectionType = literalString(
+    literal,
+    "collectionType",
+  ) as ConfigVarShape["collectionType"];
+  if (
+    wrapper === "dataSourceConfigVar" ||
+    literal.getProperty("dataSource") ||
+    literal.getProperty("dataSourceType")
+  ) {
+    return {
+      kind: "dataSource",
+      shape: { valueType: literalString(literal, "dataSourceType"), collectionType },
+    };
+  }
+  return {
+    kind: "value",
+    shape: {
+      valueType: dataType,
+      collectionType,
+      pickList: literalStrings(literal, "pickList"),
+      codeLanguage: literalString(literal, "codeLanguage"),
+    },
+  };
+};
+
+const propertyKey = (property: Node): string | undefined => {
+  if (!Node.isPropertyAssignment(property) && !Node.isShorthandPropertyAssignment(property)) {
+    return undefined;
+  }
+  const nameNode = property.getNameNode();
+  return Node.isStringLiteral(nameNode) ? nameNode.getLiteralText() : nameNode.getText();
+};
+
+const propertyValue = (property: Node | undefined): Expression | undefined => {
+  if (Node.isPropertyAssignment(property)) {
+    return property.getInitializer();
+  }
+  if (Node.isShorthandPropertyAssignment(property)) {
+    return property.getNameNode();
+  }
+  return undefined;
+};
+
+const literalString = (literal: ObjectLiteralExpression, name: string): string | undefined => {
+  const value = propertyValue(literal.getProperty(name));
+  return value && (Node.isStringLiteral(value) || Node.isNoSubstitutionTemplateLiteral(value))
+    ? value.getLiteralText()
+    : undefined;
+};
+
+const literalStrings = (literal: ObjectLiteralExpression, name: string): string[] | undefined => {
+  const value = propertyValue(literal.getProperty(name));
+  if (!Node.isArrayLiteralExpression(value)) {
+    return undefined;
+  }
+  const items = value.getElements();
+  return items.every((item) => Node.isStringLiteral(item))
+    ? items.map((item) => item.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralText())
+    : undefined;
+};
+
+const hasAnyProperty = (literal: ObjectLiteralExpression, names: readonly string[]): boolean =>
+  names.some((name) => literal.getProperty(name) !== undefined);
+
+const ensureNamedImport = (file: SourceFile, moduleSpecifier: string, name: string): void => {
+  const existing = file.getImportDeclaration(
+    (declaration) => declaration.getModuleSpecifierValue() === moduleSpecifier,
+  );
+  if (!existing) {
+    file.addImportDeclaration({ moduleSpecifier, namedImports: [name] });
+    return;
+  }
+  if (!existing.getNamedImports().some((specifier) => specifier.getName() === name)) {
+    existing.addNamedImport(name);
+  }
+};
+
+/** The source file statement that contains `node`. */
+const topLevelStatement = (node: Node): Node => {
+  const statement = node.getAncestors().find((ancestor) => Node.isSourceFile(ancestor.getParent()));
+  if (!statement) {
+    throw new Error("integration() must be called at the top level of a module.");
+  }
+  return statement;
+};
+
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+const objectKey = (key: string): string => (IDENTIFIER.test(key) ? key : JSON.stringify(key));
+const accessor = (key: string): string =>
+  IDENTIFIER.test(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
+const capitalize = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1);

--- a/packages/spectral-codemod/src/codemods/v10.0.0/zodSchema.test.ts
+++ b/packages/spectral-codemod/src/codemods/v10.0.0/zodSchema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { zodSchemaFor } from "./zodSchema";
+
+describe("zodSchemaFor", () => {
+  it.each([
+    ["string", "z.string()"],
+    ["code", "z.string()"],
+    ["htmlElement", "z.string()"],
+    ["date", "z.iso.date()"],
+    ["timestamp", "z.iso.datetime()"],
+    ["boolean", "z.boolean()"],
+    ["number", "z.number()"],
+    ["jsonForm", "z.unknown()"],
+    ["picklist", "z.string()"],
+  ])("maps %s", (valueType, expected) => {
+    expect(zodSchemaFor({ valueType })).toBe(expected);
+  });
+
+  it("describes JSON code as the parsed document and other code as text", () => {
+    expect(zodSchemaFor({ valueType: "code", codeLanguage: "json" })).toBe("z.json()");
+    expect(zodSchemaFor({ valueType: "code", codeLanguage: "xml" })).toBe("z.string()");
+    expect(
+      zodSchemaFor({ valueType: "code", codeLanguage: "json", collectionType: "valuelist" }),
+    ).toBe("z.array(z.json())");
+  });
+
+  it("uses the literal choices of a picklist", () => {
+    expect(zodSchemaFor({ valueType: "picklist", pickList: ["a", "b"] })).toBe(
+      'z.enum(["a", "b"])',
+    );
+  });
+
+  it("wraps collections", () => {
+    expect(zodSchemaFor({ valueType: "number", collectionType: "valuelist" })).toBe(
+      "z.array(z.number())",
+    );
+    expect(zodSchemaFor({ valueType: "boolean", collectionType: "keyvaluelist" })).toBe(
+      "z.array(z.object({ key: z.string(), value: z.boolean() }))",
+    );
+  });
+
+  it("falls back to unknown for a value type it cannot see", () => {
+    expect(zodSchemaFor({})).toBe("z.unknown()");
+    expect(zodSchemaFor({ collectionType: "valuelist" })).toBe("z.array(z.unknown())");
+  });
+});

--- a/packages/spectral-codemod/src/codemods/v10.0.0/zodSchema.ts
+++ b/packages/spectral-codemod/src/codemods/v10.0.0/zodSchema.ts
@@ -1,0 +1,68 @@
+/**
+ * Maps a config variable's value type onto zod source text.
+ *
+ * The value type is what a flow reads at runtime, which is the same for a standard
+ * config var and for a data source config var of the same type.
+ */
+
+export interface ConfigVarShape {
+  /** `dataType` of a standard config var, or `dataSourceType` of a data source config var. */
+  valueType?: string;
+  collectionType?: "valuelist" | "keyvaluelist";
+  /** Literal choices of a `picklist` standard config var, when statically known. */
+  pickList?: string[];
+  /** `codeLanguage` of a `code` standard config var. */
+  codeLanguage?: string;
+}
+
+/** Zod source for `Element`, shared by object selection and object field map values. */
+export const ELEMENT_SCHEMA_NAME = "elementSchema";
+export const ELEMENT_SCHEMA_SOURCE = `const ${ELEMENT_SCHEMA_NAME} = z.object({ key: z.string(), label: z.string().optional() });`;
+
+const SCALAR: Record<string, string> = {
+  string: "z.string()",
+  picklist: "z.string()",
+  code: "z.string()",
+  htmlElement: "z.string()",
+  date: "z.iso.date()",
+  timestamp: "z.iso.datetime()",
+  boolean: "z.boolean()",
+  number: "z.number()",
+  schedule: "z.object({ value: z.string(), schedule_type: z.string(), time_zone: z.string() })",
+  objectSelection: `z.array(z.object({ object: ${ELEMENT_SCHEMA_NAME}, fields: z.array(${ELEMENT_SCHEMA_NAME}).optional(), defaultSelected: z.boolean().optional() }))`,
+  objectFieldMap: `z.object({ fields: z.array(z.object({ field: ${ELEMENT_SCHEMA_NAME}, mappedObject: ${ELEMENT_SCHEMA_NAME}.optional(), mappedField: ${ELEMENT_SCHEMA_NAME}.optional(), defaultObject: ${ELEMENT_SCHEMA_NAME}.optional(), defaultField: ${ELEMENT_SCHEMA_NAME}.optional() })), options: z.array(z.object({ object: ${ELEMENT_SCHEMA_NAME}, fields: z.array(${ELEMENT_SCHEMA_NAME}) })).optional() })`,
+  jsonForm: "z.unknown()",
+};
+
+const scalarSchemaFor = (shape: ConfigVarShape): string => {
+  if (shape.valueType === "picklist" && shape.pickList?.length) {
+    return `z.enum([${shape.pickList.map((choice) => JSON.stringify(choice)).join(", ")}])`;
+  }
+  if (shape.valueType === "code" && shape.codeLanguage === "json") {
+    return "z.json()";
+  }
+  return (shape.valueType && SCALAR[shape.valueType]) ?? "z.unknown()";
+};
+
+/** True when the shape's zod source refers to `elementSchema`. */
+export const usesElementSchema = (shape: ConfigVarShape): boolean =>
+  shape.valueType === "objectSelection" || shape.valueType === "objectFieldMap";
+
+/**
+ * Zod source for one config variable. The schema describes the unpacked value: a JSON
+ * code variable is the parsed document, and collection scalars are typed even though
+ * the wizard stored them as strings. An unknown value type, such as a component data
+ * source reference whose type lives in the component registry, becomes `z.unknown()`.
+ */
+export const zodSchemaFor = (shape: ConfigVarShape): string => {
+  const scalar = scalarSchemaFor(shape);
+
+  switch (shape.collectionType) {
+    case "valuelist":
+      return `z.array(${scalar})`;
+    case "keyvaluelist":
+      return `z.array(z.object({ key: z.string(), value: ${scalar} }))`;
+    default:
+      return scalar;
+  }
+};

--- a/packages/spectral-codemod/src/index.ts
+++ b/packages/spectral-codemod/src/index.ts
@@ -1,0 +1,3 @@
+export { type Codemod, defineCodemod } from "./codemod";
+export { codemods } from "./codemods";
+export { type RunOptions, type RunResult, runCodemod } from "./runner";

--- a/packages/spectral-codemod/src/runner.test.ts
+++ b/packages/spectral-codemod/src/runner.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { defineCodemod, eachFile } from "./codemod";
+import { runCodemod } from "./runner";
+
+const shout = defineCodemod({
+  name: "shout",
+  description: "Upper-cases the string literal `hello`",
+  transform: eachFile((file) => {
+    let changed = false;
+    file.forEachDescendant((node) => {
+      if (node.getText() === '"hello"') {
+        node.replaceWithText('"HELLO"');
+        changed = true;
+      }
+    });
+    return changed;
+  }),
+});
+
+const dirs: string[] = [];
+const scratch = () => {
+  const dir = mkdtempSync(join(tmpdir(), "spectral-codemod-"));
+  dirs.push(dir);
+  return dir;
+};
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const write = (dir: string, name: string, text: string) => {
+  mkdirSync(join(dir, name, ".."), { recursive: true });
+  writeFileSync(join(dir, name), text);
+};
+
+describe("runCodemod", () => {
+  it("uses tsconfig.json to pick files and writes the changed ones", async () => {
+    const dir = scratch();
+    write(dir, "tsconfig.json", JSON.stringify({ include: ["src"] }));
+    write(dir, "src/a.ts", 'export const a = "hello";\n');
+    write(dir, "src/b.ts", 'export const b = "other";\n');
+    write(dir, "scripts/c.ts", 'export const c = "hello";\n');
+
+    const result = await runCodemod(shout, { path: dir });
+
+    expect(result.scanned).toBe(2);
+    expect(result.changed).toEqual([join(dir, "src/a.ts")]);
+    expect(readFileSync(join(dir, "src/a.ts"), "utf8")).toBe('export const a = "HELLO";\n');
+    expect(readFileSync(join(dir, "scripts/c.ts"), "utf8")).toBe('export const c = "hello";\n');
+  });
+
+  it("scans every TypeScript file except node_modules and dist without a tsconfig", async () => {
+    const dir = scratch();
+    write(dir, "src/a.ts", 'export const a = "hello";\n');
+    write(dir, "node_modules/dep/index.ts", 'export const d = "hello";\n');
+    write(dir, "dist/a.ts", 'export const a = "hello";\n');
+
+    const result = await runCodemod(shout, { path: dir });
+
+    expect(result.scanned).toBe(1);
+    expect(result.changed).toHaveLength(1);
+    expect(readFileSync(join(dir, "node_modules/dep/index.ts"), "utf8")).toContain('"hello"');
+  });
+
+  it("targets a single file", async () => {
+    const dir = scratch();
+    write(dir, "a.ts", 'export const a = "hello";\n');
+    write(dir, "b.ts", 'export const b = "hello";\n');
+
+    const result = await runCodemod(shout, { path: join(dir, "a.ts") });
+
+    expect(result.scanned).toBe(1);
+    expect(readFileSync(join(dir, "b.ts"), "utf8")).toContain('"hello"');
+  });
+
+  it("does not write in dry-run mode", async () => {
+    const dir = scratch();
+    write(dir, "a.ts", 'export const a = "hello";\n');
+
+    const result = await runCodemod(shout, { path: dir, dryRun: true });
+
+    expect(result.changed).toHaveLength(1);
+    expect(readFileSync(join(dir, "a.ts"), "utf8")).toBe('export const a = "hello";\n');
+  });
+
+  it("rejects a missing path", async () => {
+    await expect(runCodemod(shout, { path: join(scratch(), "nope") })).rejects.toThrow(
+      "Path not found",
+    );
+  });
+});

--- a/packages/spectral-codemod/src/runner.ts
+++ b/packages/spectral-codemod/src/runner.ts
@@ -1,0 +1,70 @@
+import { existsSync, statSync } from "fs";
+import { join, resolve } from "path";
+import { Project } from "ts-morph";
+import type { Codemod } from "./codemod";
+
+export interface RunOptions {
+  /** A project directory, a tsconfig.json, or a single source file. Defaults to the working directory. */
+  path?: string;
+  /** Report the files a codemod would change without writing them. */
+  dryRun?: boolean;
+}
+
+export interface RunResult {
+  /** Absolute path of every file the codemod changed. */
+  changed: string[];
+  /** Number of source files the codemod inspected. */
+  scanned: number;
+}
+
+const SOURCE_GLOBS = ["**/*.ts", "**/*.tsx", "!**/node_modules/**", "!**/dist/**"];
+
+/**
+ * Applies one codemod to a project.
+ *
+ * A directory holding a `tsconfig.json` contributes the files that config includes.
+ * Any other directory contributes every TypeScript file beneath it except
+ * `node_modules` and `dist`. A file path contributes that file alone.
+ */
+export const runCodemod = async (
+  codemod: Codemod,
+  options: RunOptions = {},
+): Promise<RunResult> => {
+  const target = resolve(options.path ?? ".");
+  if (!existsSync(target)) {
+    throw new Error(`Path not found: ${target}`);
+  }
+
+  const project = createProject(target);
+  const changed = codemod.transform(project).map((file) => file.getFilePath());
+
+  if (!options.dryRun) {
+    await project.save();
+  }
+
+  return { changed, scanned: project.getSourceFiles().length };
+};
+
+const createProject = (target: string): Project => {
+  if (statSync(target).isFile()) {
+    if (target.endsWith("tsconfig.json")) {
+      return new Project({ tsConfigFilePath: target });
+    }
+    const project = new Project();
+    project.addSourceFileAtPath(target);
+    return project;
+  }
+
+  const tsConfigFilePath = join(target, "tsconfig.json");
+  if (existsSync(tsConfigFilePath)) {
+    return new Project({ tsConfigFilePath });
+  }
+
+  const project = new Project();
+  project.addSourceFilesAtPaths(
+    SOURCE_GLOBS.map((glob) =>
+      glob.startsWith("!") ? `!${join(target, glob.slice(1))}` : join(target, glob),
+    ),
+  );
+  return project;
+};

--- a/packages/spectral-codemod/src/testing.ts
+++ b/packages/spectral-codemod/src/testing.ts
@@ -1,0 +1,35 @@
+import { Project } from "ts-morph";
+import type { Codemod } from "./codemod";
+
+export interface AppliedCodemod {
+  /** Every file in the project after the codemod ran, keyed by path. */
+  files: Record<string, string>;
+  /** Paths of the files the codemod reported as changed. */
+  changed: string[];
+}
+
+/** Applies a codemod to an in-memory project built from `files`, keyed by path. */
+export const applyCodemod = (codemod: Codemod, files: Record<string, string>): AppliedCodemod => {
+  const project = new Project({ useInMemoryFileSystem: true });
+  for (const [path, text] of Object.entries(files)) {
+    project.createSourceFile(path, text);
+  }
+  const changed = codemod.transform(project).map((file) => file.getFilePath().replace(/^\//, ""));
+  return {
+    files: Object.fromEntries(
+      project
+        .getSourceFiles()
+        .map((file) => [file.getFilePath().replace(/^\//, ""), file.getFullText()]),
+    ),
+    changed,
+  };
+};
+
+/** Applies a codemod to a single in-memory file and returns its resulting text. */
+export const applyCodemodToSource = (
+  codemod: Codemod,
+  source: string,
+): { code: string; changed: boolean } => {
+  const { files, changed } = applyCodemod(codemod, { "index.ts": source });
+  return { code: files["index.ts"], changed: changed.length > 0 };
+};

--- a/packages/spectral-codemod/tsconfig.json
+++ b/packages/spectral-codemod/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["esnext"],
+    "module": "commonjs",
+    "strict": true,
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/testing.ts"]
+}

--- a/packages/spectral-codemod/vitest.config.ts
+++ b/packages/spectral-codemod/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});


### PR DESCRIPTION
…demod

A new workspace package holds the codemod runner and named migrations for projects that consume spectral. It runs as
`npx @prismatic-io/spectral-codemod@latest <codemod> [path]`.

The first codemod, v10.0.0/headless-configuration, replaces an integration's configPages, userLevelConfigPages, and scopedConfigVars with a headless configuration: an exported zod schema describing the unpacked value of every non-connection config variable, connections and data sources referenced where they already live, an eTag of INITIAL, and an empty init for the author to fill in.